### PR TITLE
🐛 Fix hero banner cache response handling

### DIFF
--- a/packages/client/src/apis/server-cache.api.spec.ts
+++ b/packages/client/src/apis/server-cache.api.spec.ts
@@ -1,0 +1,55 @@
+import { getServerCache, setServerCache } from '~/apis/server-cache.api';
+import { graphQuery } from '~/modules/graph-query';
+
+vi.mock('~/modules/graph-query', () => ({ graphQuery: vi.fn() }));
+
+describe('server-cache.api', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns a GraphQL error response when setCache payload is missing', async () => {
+        vi.mocked(graphQuery).mockResolvedValue({ type: 'success' } as never);
+
+        const response = await setServerCache('heroBanner', 'https://example.com/hero.jpg');
+
+        expect(response).toEqual({
+            type: 'error',
+            category: 'graphql',
+            errors: [{
+                code: 'INVALID_RESPONSE_SHAPE',
+                message: 'GraphQL response field "setCache" is missing or invalid',
+                details: { type: 'success' }
+            }]
+        });
+    });
+
+    it('encodes values before sending the mutation and returns the validated payload', async () => {
+        const encodedValue = encodeURIComponent('https://example.com/hero.jpg');
+
+        vi.mocked(graphQuery).mockResolvedValue({
+            type: 'success',
+            setCache: { value: encodedValue }
+        } as never);
+
+        const response = await setServerCache('heroBanner', 'https://example.com/hero.jpg');
+
+        expect(graphQuery).toHaveBeenCalledWith(
+            expect.stringContaining('mutation SetServerCache'),
+            {
+                key: 'heroBanner',
+                value: encodedValue
+            }
+        );
+        expect(response).toEqual({
+            type: 'success',
+            setCache: { value: encodedValue }
+        });
+    });
+
+    it('falls back to an empty string when cache query payload is invalid', async () => {
+        vi.mocked(graphQuery).mockResolvedValue({ type: 'success' } as never);
+
+        await expect(getServerCache('heroBanner')).resolves.toBe('');
+    });
+});

--- a/packages/client/src/apis/server-cache.api.ts
+++ b/packages/client/src/apis/server-cache.api.ts
@@ -1,4 +1,7 @@
-import { graphQuery } from '~/modules/graph-query';
+import {
+    graphQuery,
+    type GraphQueryErrorResponse
+} from '~/modules/graph-query';
 
 type CacheName = 'heroBanner';
 
@@ -6,26 +9,55 @@ interface CacheItem {
     value: string;
 }
 
+const isCacheItem = (value: unknown): value is CacheItem => {
+    return typeof value === 'object'
+        && value !== null
+        && 'value' in value
+        && typeof value.value === 'string';
+};
+
+const invalidResponseShape = (
+    field: string,
+    details: unknown
+): GraphQueryErrorResponse => ({
+    type: 'error',
+    category: 'graphql',
+    errors: [{
+        code: 'INVALID_RESPONSE_SHAPE',
+        message: `GraphQL response field "${field}" is missing or invalid`,
+        details
+    }]
+});
+
 export const getServerCache = async (key: CacheName) => {
     try {
-        const response = await graphQuery<{ cache: CacheItem }, { key: CacheName }>(`
+        const response = await graphQuery<{ cache?: CacheItem }, { key: CacheName }>(`
         query GetServerCache($key: String!) {
             cache(key: $key) {
                 value
             }
         }
     `, { key });
+
         if (response.type === 'error') {
             throw response;
         }
+
+        if (!isCacheItem(response.cache)) {
+            throw invalidResponseShape('cache', response);
+        }
+
         return response.cache.value;
     } catch {
         return '';
     }
 };
 
-export const setServerCache = async (key: CacheName, value: string) => {
-    return graphQuery<{ cache: CacheItem }, { key: CacheName; value: string }>(`
+export const setServerCache = async (
+    key: CacheName,
+    value: string
+) => {
+    const response = await graphQuery<{ setCache?: CacheItem }, { key: CacheName; value: string }>(`
         mutation SetServerCache($key: String!, $value: String!) {
             setCache(key: $key, value: $value) {
                 value
@@ -35,6 +67,19 @@ export const setServerCache = async (key: CacheName, value: string) => {
         key,
         value: encodeURIComponent(value)
     });
+
+    if (response.type === 'error') {
+        return response;
+    }
+
+    if (!isCacheItem(response.setCache)) {
+        return invalidResponseShape('setCache', response);
+    }
+
+    return {
+        ...response,
+        setCache: response.setCache
+    };
 };
 
 export const deleteServerCache = async (key: CacheName) => {

--- a/packages/client/src/components/layout/SiteLayout/SidebarHeroBanner.spec.tsx
+++ b/packages/client/src/components/layout/SiteLayout/SidebarHeroBanner.spec.tsx
@@ -7,6 +7,7 @@ import { createQueryClientWrapper, createTestQueryClient } from '~/test/test-uti
 import SidebarHeroBanner from './SidebarHeroBanner';
 
 const mockConfirm = vi.fn();
+const mockToast = vi.fn();
 type ThemeState = {
     theme: string;
 };
@@ -21,7 +22,8 @@ vi.mock('~/components/ui', async () => {
 
     return {
         ...actual,
-        useConfirm: () => mockConfirm
+        useConfirm: () => mockConfirm,
+        useToast: () => mockToast
     };
 });
 
@@ -30,7 +32,10 @@ vi.mock('~/store/theme', () => ({ useTheme: (selector: (state: ThemeState) => un
 describe('<SidebarHeroBanner />', () => {
     it('renders the hero image and removes it through the confirm flow', async () => {
         vi.mocked(getServerCache).mockResolvedValue('https://example.com/hero.jpg');
-        vi.mocked(setServerCache).mockResolvedValue('' as never);
+        vi.mocked(setServerCache).mockResolvedValue({
+            type: 'success',
+            setCache: { value: '' }
+        });
         mockConfirm.mockResolvedValue(true);
 
         const queryClient = createTestQueryClient();

--- a/packages/client/src/components/layout/SiteLayout/SidebarHeroBanner.tsx
+++ b/packages/client/src/components/layout/SiteLayout/SidebarHeroBanner.tsx
@@ -1,11 +1,12 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { getServerCache, setServerCache } from '~/apis/server-cache.api';
-import { Text, useConfirm } from '~/components/ui';
+import { Text, useConfirm, useToast } from '~/components/ui';
 import { queryKeys } from '~/modules/query-key-factory';
 
 const SidebarHeroBanner = () => {
     const confirm = useConfirm();
+    const toast = useToast();
     const queryClient = useQueryClient();
 
     const { data: heroBanner } = useQuery({
@@ -27,7 +28,12 @@ const SidebarHeroBanner = () => {
                 className="surface-base focus-ring-soft group relative block w-full overflow-hidden text-left outline-none"
                 onClick={async () => {
                     if (await confirm('Remove this hero banner from the sidebar?')) {
-                        await setServerCache('heroBanner', '');
+                        const response = await setServerCache('heroBanner', '');
+                        if (response.type === 'error') {
+                            toast(response.errors[0]?.message ?? 'Failed to remove hero banner');
+                            return;
+                        }
+
                         await queryClient.invalidateQueries({
                             queryKey: queryKeys.ui.heroBanner(),
                             exact: true

--- a/packages/client/src/pages/setting/manage-image-detail.spec.tsx
+++ b/packages/client/src/pages/setting/manage-image-detail.spec.tsx
@@ -1,0 +1,149 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClientProvider } from '@tanstack/react-query';
+import {
+    Outlet,
+    RouterProvider,
+    createRootRoute,
+    createRoute,
+    createRouter
+} from '@tanstack/react-router';
+
+import { deleteImage, fetchImage } from '~/apis/image.api';
+import { fetchImageNotes } from '~/apis/note.api';
+import { setServerCache } from '~/apis/server-cache.api';
+import { queryKeys } from '~/modules/query-key-factory';
+import { createTestQueryClient } from '~/test/test-utils';
+import {
+    SETTINGS_MANAGE_IMAGE_DETAIL_ROUTE,
+    SETTINGS_MANAGE_IMAGE_ROUTE
+} from '~/modules/url';
+
+import ManageImageDetail from './manage-image-detail';
+
+const mockConfirm = vi.fn();
+const mockToast = vi.fn();
+
+vi.mock('~/apis/image.api', () => ({
+    deleteImage: vi.fn(),
+    fetchImage: vi.fn()
+}));
+
+vi.mock('~/apis/note.api', () => ({ fetchImageNotes: vi.fn() }));
+
+vi.mock('~/apis/server-cache.api', () => ({ setServerCache: vi.fn() }));
+
+vi.mock('~/components/ui', async () => {
+    const actual = await vi.importActual<object>('~/components/ui');
+
+    return {
+        ...actual,
+        useConfirm: () => mockConfirm,
+        useToast: () => mockToast
+    };
+});
+
+vi.mock('~/components/shared', async () => {
+    const actual = await vi.importActual<object>('~/components/shared');
+
+    return {
+        ...actual,
+        Image: ({
+            src,
+            alt,
+            className
+        }: {
+            src: string;
+            alt?: string;
+            className?: string;
+        }) => (
+            <img src={src} alt={alt} className={className} />
+        )
+    };
+});
+
+const renderPage = async () => {
+    window.history.pushState({}, '', '/setting/manage-image/image-1');
+
+    const queryClient = createTestQueryClient();
+    const invalidateSpy = vi
+        .spyOn(queryClient, 'invalidateQueries')
+        .mockResolvedValue(undefined);
+
+    const rootRoute = createRootRoute({ component: () => <Outlet /> });
+    const manageImageRoute = createRoute({
+        getParentRoute: () => rootRoute,
+        path: SETTINGS_MANAGE_IMAGE_ROUTE,
+        component: () => null
+    });
+    const manageImageDetailRoute = createRoute({
+        getParentRoute: () => rootRoute,
+        path: SETTINGS_MANAGE_IMAGE_DETAIL_ROUTE,
+        component: ManageImageDetail
+    });
+    const router = createRouter({
+        routeTree: rootRoute.addChildren([
+            manageImageRoute,
+            manageImageDetailRoute
+        ])
+    });
+
+    render(
+        <QueryClientProvider client={queryClient}>
+            <RouterProvider router={router} />
+        </QueryClientProvider>
+    );
+
+    await act(async () => {
+        await router.load();
+    });
+
+    return { invalidateSpy };
+};
+
+describe('<ManageImageDetail />', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+
+        vi.mocked(deleteImage).mockResolvedValue({
+            type: 'success',
+            deleteImage: true
+        });
+        vi.mocked(fetchImage).mockResolvedValue({
+            type: 'success',
+            image: {
+                id: 'image-1',
+                url: 'https://example.com/hero.jpg'
+            }
+        });
+        vi.mocked(fetchImageNotes).mockResolvedValue({
+            type: 'success',
+            imageNotes: []
+        });
+    });
+
+    it('updates the hero banner and invalidates the sidebar cache query', async () => {
+        vi.mocked(setServerCache).mockResolvedValue({
+            type: 'success',
+            setCache: { value: encodeURIComponent('https://example.com/hero.jpg') }
+        });
+
+        const { invalidateSpy } = await renderPage();
+
+        await userEvent.click(
+            await screen.findByRole('button', { name: 'Set hero banner' })
+        );
+
+        await waitFor(() => {
+            expect(setServerCache).toHaveBeenCalledWith(
+                'heroBanner',
+                'https://example.com/hero.jpg'
+            );
+            expect(invalidateSpy).toHaveBeenCalledWith({
+                queryKey: queryKeys.ui.heroBanner(),
+                exact: true
+            });
+            expect(mockToast).toHaveBeenCalledWith('Hero banner updated');
+        });
+    });
+});

--- a/packages/client/src/pages/setting/manage-image-detail.tsx
+++ b/packages/client/src/pages/setting/manage-image-detail.tsx
@@ -171,7 +171,6 @@ const ManageImageDetailContent = ({ id }: ManageImageDetailContentProps) => {
             if (response.type === 'error') {
                 throw response;
             }
-            return response.cache.value;
         },
         onSuccess: async () => {
             await queryClient.invalidateQueries({

--- a/packages/client/src/router.tsx
+++ b/packages/client/src/router.tsx
@@ -232,7 +232,6 @@ const routeTree = rootRoute.addChildren([
 
 export const router = createRouter({
     routeTree,
-    defaultPreload: 'intent',
     defaultPendingComponent: () => (
         <RoutePendingView
             title="Loading page"


### PR DESCRIPTION
## :dart: Goal
- Stop the hero banner update flow from failing with `response.cache is undefined` and the follow-on router crash after setting a banner.
- Add regression coverage so server cache response-shape mismatches fail predictably instead of surfacing as runtime UI errors.

## :hammer_and_wrench: Core Changes
- Removed the global TanStack Router `defaultPreload: 'intent'` setting to avoid the `_nonReactive` preload crash path hit after setting a hero banner.
- Corrected `setServerCache` to read the GraphQL `setCache` payload, added runtime response-shape validation, and made sidebar/banner mutations handle API errors explicitly.
- Added regression tests for the server cache API contract and for the image detail `Set hero banner` click flow.

## :brain: Key Decisions
- Kept the response-shape guard at the API boundary because the root issue was a handwritten GraphQL response contract drifting from the actual schema.
- Treated the router preload crash as a hotfix-first problem and disabled the global preload option instead of waiting on a router upgrade.
- Left the hero banner success path keyed on mutation success plus query invalidation instead of depending on the returned cache value in the page component.

## :test_tube: Verification Guide
### How to verify
1. Run `pnpm lint`.
2. Run `pnpm type-check`.
3. Run `pnpm test:ci`.
4. Run `pnpm build`.
5. In the app, open `/setting/manage-image/:id` and click `Set hero banner`.

### Expected result
- All commands complete successfully. `pnpm lint` still prints one existing unrelated server warning for `packages/server/src/schema/image/index.ts`.
- Clicking `Set hero banner` shows the success toast, updates the sidebar hero banner query, and does not throw `response.cache is undefined` or the router `_nonReactive` runtime error.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [ ] Documentation updated (if needed)
