### PR TITLE
🐛 Prevent duplicate tag creation

### DIFF
--- a/packages/client/src/components/schema/TagView/TagView.spec.ts
+++ b/packages/client/src/components/schema/TagView/TagView.spec.ts
@@ -1,0 +1,17 @@
+import { hasExactTagMatch } from './tag-match';
+
+describe('hasExactTagMatch', () => {
+    it('returns true when the fetched tags already contain the exact tag name', () => {
+        expect(hasExactTagMatch('project', [
+            { name: '@project' },
+            { name: '@project-archive' }
+        ])).toBe(true);
+    });
+
+    it('returns false when the fetched tags only contain partial matches', () => {
+        expect(hasExactTagMatch('project', [
+            { name: '@project-archive' },
+            { name: '@project-next' }
+        ])).toBe(false);
+    });
+});

--- a/packages/client/src/components/schema/TagView/TagView.tsx
+++ b/packages/client/src/components/schema/TagView/TagView.tsx
@@ -1,5 +1,6 @@
 import { SuggestionMenuController } from '@blocknote/react';
 import { createTag, fetchTags } from '~/apis/tag.api';
+import { hasExactTagMatch } from './tag-match';
 
 interface TagViewProps {
     onClick: (content: {
@@ -27,7 +28,7 @@ const TagView = ({ onClick }: TagViewProps) => {
 
                 const { tags } = response.allTags;
 
-                const noMatchedTag = tags.some(tag => tag.name !== `@${query}`);
+                const hasMatchingTag = hasExactTagMatch(query, tags);
 
                 const itemAddNewTag = [{
                     title: 'Add a new tag',
@@ -60,7 +61,7 @@ const TagView = ({ onClick }: TagViewProps) => {
                             tag: tag.name
                         }
                     })
-                })).concat((query && noMatchedTag) ? itemAddNewTag : []);
+                })).concat((query && !hasMatchingTag) ? itemAddNewTag : []);
             }}
         />
     );

--- a/packages/client/src/components/schema/TagView/index.ts
+++ b/packages/client/src/components/schema/TagView/index.ts
@@ -1,1 +1,2 @@
 export { default } from './TagView';
+export { hasExactTagMatch } from './tag-match';

--- a/packages/client/src/components/schema/TagView/tag-match.ts
+++ b/packages/client/src/components/schema/TagView/tag-match.ts
@@ -1,0 +1,6 @@
+export const hasExactTagMatch = (
+    query: string,
+    tags: Array<{ name: string }>
+) => {
+    return tags.some((tag) => tag.name === `@${query}`);
+};

--- a/packages/server/prisma/migrations/20260413143000_0014_tag_name_unique/migration.sql
+++ b/packages/server/prisma/migrations/20260413143000_0014_tag_name_unique/migration.sql
@@ -1,0 +1,32 @@
+CREATE TEMP TABLE "_TagDuplicateMap" AS
+SELECT
+    duplicate."id" AS "duplicateId",
+    grouped."canonicalId" AS "canonicalId"
+FROM "Tag" AS duplicate
+JOIN (
+    SELECT
+        "name",
+        MIN("id") AS "canonicalId"
+    FROM "Tag"
+    GROUP BY "name"
+) AS grouped
+    ON grouped."name" = duplicate."name"
+WHERE duplicate."id" <> grouped."canonicalId";
+
+INSERT OR IGNORE INTO "_NoteToTag" ("A", "B")
+SELECT
+    relation."A",
+    duplicateMap."canonicalId"
+FROM "_NoteToTag" AS relation
+JOIN "_TagDuplicateMap" AS duplicateMap
+    ON duplicateMap."duplicateId" = relation."B";
+
+DELETE FROM "Tag"
+WHERE "id" IN (
+    SELECT "duplicateId"
+    FROM "_TagDuplicateMap"
+);
+
+CREATE UNIQUE INDEX "Tag_name_key" ON "Tag"("name");
+
+DROP TABLE "_TagDuplicateMap";

--- a/packages/server/prisma/schema.prisma
+++ b/packages/server/prisma/schema.prisma
@@ -103,7 +103,7 @@ model Image {
 
 model Tag {
     id        Int      @id @default(autoincrement())
-    name      String
+    name      String   @unique
     createdAt DateTime @default(now())
     updatedAt DateTime @updatedAt
     notes     Note[]   @relation("NoteToTag")

--- a/packages/server/src/modules/tag-organization.ts
+++ b/packages/server/src/modules/tag-organization.ts
@@ -9,7 +9,7 @@ interface TagRecord {
 
 interface TagOrganizationDeps {
     createTag: (name: string) => Promise<TagRecord>;
-    findTagsByName: (name: string) => Promise<TagRecord[]>;
+    findTagByName: (name: string) => Promise<TagRecord | null>;
 }
 
 export interface TagOrganizationResult {
@@ -55,21 +55,63 @@ const serializeTag = (tag: TagRecord) => ({
     updatedAt: tag.updatedAt.toISOString()
 });
 
+const isTagNameUniqueConflict = (error: unknown) => {
+    if (typeof error !== 'object' || error === null || !('code' in error)) {
+        return false;
+    }
+
+    if (error.code !== 'P2002') {
+        return false;
+    }
+
+    if (!('meta' in error) || typeof error.meta !== 'object' || error.meta === null) {
+        return true;
+    }
+
+    const rawTarget = 'target' in error.meta ? error.meta.target : null;
+    const targets = Array.isArray(rawTarget)
+        ? rawTarget.filter((value): value is string => typeof value === 'string')
+        : (typeof rawTarget === 'string' ? [rawTarget] : []);
+
+    return targets.length === 0 || targets.includes('name');
+};
+
 export const createTagOrganizationService = (deps: TagOrganizationDeps) => {
     return {
         ensureTag: async (name: string): Promise<TagOrganizationResult> => {
             const normalizedName = normalizeTagName(name);
-            const existingTags = await deps.findTagsByName(normalizedName);
+            const existingTag = await deps.findTagByName(normalizedName);
 
-            if (existingTags.length > 0) {
+            if (existingTag) {
                 return {
                     created: false,
                     normalizedName,
-                    tag: serializeTag(existingTags[0])
+                    tag: serializeTag(existingTag)
                 };
             }
 
-            const createdTag = await deps.createTag(normalizedName);
+            let createdTag: TagRecord;
+
+            try {
+                createdTag = await deps.createTag(normalizedName);
+            } catch (error) {
+                if (!isTagNameUniqueConflict(error)) {
+                    throw error;
+                }
+
+                const conflictedTag = await deps.findTagByName(normalizedName);
+
+                if (!conflictedTag) {
+                    throw error;
+                }
+
+                return {
+                    created: false,
+                    normalizedName,
+                    tag: serializeTag(conflictedTag)
+                };
+            }
+
             return {
                 created: true,
                 normalizedName,
@@ -83,8 +125,8 @@ const defaultTagOrganizationService = createTagOrganizationService({
     createTag: async (name) => {
         return models.tag.create({ data: { name } });
     },
-    findTagsByName: async (name) => {
-        return models.tag.findMany({
+    findTagByName: async (name) => {
+        return models.tag.findFirst({
             where: { name },
             orderBy: { createdAt: 'asc' }
         });

--- a/packages/server/src/schema/tag/index.ts
+++ b/packages/server/src/schema/tag/index.ts
@@ -2,6 +2,7 @@ import type { IResolvers } from '@graphql-tools/utils';
 
 import models, { type Tag, type Prisma } from '~/models.js';
 import { gql } from '~/modules/graphql.js';
+import { ensureTagByName } from '~/modules/tag-organization.js';
 import type { Pagination, SearchFilter } from '~/types/index.js';
 
 export const tagType = gql`
@@ -46,6 +47,20 @@ export const tagTypeDefs = `
     ${tagMutation}
 `;
 
+export const createTagMutationResolver = (
+    ensureTag = ensureTagByName
+) => {
+    return async (_: unknown, { name }: { name: string }) => {
+        const result = await ensureTag(name);
+
+        return result.tag;
+    };
+};
+
+type TagReferenceCountSource = Pick<Tag, 'id'> | {
+    id: string;
+};
+
 export const tagResolvers: IResolvers = {
     Query: {
         allTags: async (_, {
@@ -72,14 +87,10 @@ export const tagResolvers: IResolvers = {
             };
         }
     },
-    Mutation: {
-        createTag: async (_, { name }: Tag) => {
-            return models.tag.create({ data: { name } });
-        }
-    },
+    Mutation: { createTag: createTagMutationResolver() },
     Tag: {
-        referenceCount: async (tag: Tag) => {
-            return models.note.count({ where: { tags: { some: { id: tag.id } } } });
+        referenceCount: async (tag: TagReferenceCountSource) => {
+            return models.note.count({ where: { tags: { some: { id: Number(tag.id) } } } });
         }
     }
 };

--- a/packages/server/test/tag-organization.test.ts
+++ b/packages/server/test/tag-organization.test.ts
@@ -24,12 +24,12 @@ test('tag organization service returns an existing tag without creating a duplic
             createCalls += 1;
             throw new Error('should not create');
         },
-        findTagsByName: async () => [{
+        findTagByName: async () => ({
             id: 3,
             name: '@project',
             createdAt: new Date('2026-03-30T00:00:00.000Z'),
             updatedAt: new Date('2026-03-30T00:00:00.000Z')
-        }]
+        })
     });
 
     const result = await service.ensureTag('project');
@@ -55,7 +55,7 @@ test('tag organization service creates a tag when the normalized name is missing
             createdAt: new Date('2026-03-31T00:00:00.000Z'),
             updatedAt: new Date('2026-03-31T00:00:00.000Z')
         }),
-        findTagsByName: async () => []
+        findTagByName: async () => null
     });
 
     const result = await service.ensureTag('@inbox');
@@ -68,6 +68,48 @@ test('tag organization service creates a tag when the normalized name is missing
             name: '@inbox',
             createdAt: '2026-03-31T00:00:00.000Z',
             updatedAt: '2026-03-31T00:00:00.000Z'
+        }
+    });
+});
+
+test('tag organization service returns the canonical tag after a unique conflict race', async () => {
+    let findCalls = 0;
+    const service = createTagOrganizationService({
+        createTag: async () => {
+            throw {
+                code: 'P2002',
+                meta: {
+                    target: ['name']
+                }
+            };
+        },
+        findTagByName: async () => {
+            findCalls += 1;
+
+            if (findCalls === 1) {
+                return null;
+            }
+
+            return {
+                id: 7,
+                name: '@project',
+                createdAt: new Date('2026-04-13T00:00:00.000Z'),
+                updatedAt: new Date('2026-04-13T00:00:00.000Z')
+            };
+        }
+    });
+
+    const result = await service.ensureTag('project');
+
+    assert.equal(findCalls, 2);
+    assert.deepEqual(result, {
+        created: false,
+        normalizedName: '@project',
+        tag: {
+            id: '7',
+            name: '@project',
+            createdAt: '2026-04-13T00:00:00.000Z',
+            updatedAt: '2026-04-13T00:00:00.000Z'
         }
     });
 });

--- a/packages/server/test/tag-resolver.test.ts
+++ b/packages/server/test/tag-resolver.test.ts
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createTagMutationResolver } from '../src/schema/tag/index.js';
+
+test('createTag mutation returns the canonical tag from the tag organization service', async () => {
+    const resolver = createTagMutationResolver(async () => ({
+        created: false,
+        normalizedName: '@project',
+        tag: {
+            id: '12',
+            name: '@project',
+            createdAt: '2026-04-13T00:00:00.000Z',
+            updatedAt: '2026-04-13T00:00:00.000Z'
+        }
+    }));
+
+    const result = await resolver(null, { name: ' project ' });
+
+    assert.deepEqual(result, {
+        id: '12',
+        name: '@project',
+        createdAt: '2026-04-13T00:00:00.000Z',
+        updatedAt: '2026-04-13T00:00:00.000Z'
+    });
+});


### PR DESCRIPTION
## :dart: Goal
- Prevent duplicate Ocean Brain tags from being created across GraphQL, MCP tag creation, and markdown-import note authoring paths.
- Migrate existing duplicate tag rows safely so patched users keep a single canonical tag with preserved note relations.

## :hammer_and_wrench: Core Changes
- Added a unique constraint for `Tag.name` and a migration that merges duplicate tags into the canonical row before enabling the constraint.
- Routed GraphQL tag creation through the shared tag organization service so duplicate creation races return the existing tag instead of creating another row.
- Fixed the client tag suggestion menu to treat exact matches correctly before showing "Add a new tag".
- Added focused tests for the unique-conflict race, GraphQL tag resolver behavior, and client exact-match detection.

## :brain: Key Decisions
- Used a DB-level unique constraint plus race-aware service fallback instead of relying on a read-before-write check alone, because concurrent requests can still create duplicates without the DB guard.
- Kept explicit tag creation support because the current editor flow still needs a concrete tag id before inserting tag inline content.
- Verified the migration with a temp SQLite upgrade smoke from pre-0014 state containing duplicate tags, plus a fresh-install smoke that confirms duplicate inserts are rejected.

## :test_tube: Verification Guide
### How to verify
1. `pnpm --filter @ocean-brain/server test -- tag-organization.test.ts tag-resolver.test.ts`
2. `pnpm --filter @ocean-brain/client test -- TagView.spec.ts`
3. `pnpm type-check`
4. `pnpm lint`

### Expected result
- All commands pass.
- Duplicate tag creation converges to one canonical tag row.
- Existing upgraded databases keep note-tag relations after migration.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [ ] Documentation updated (if needed)
