### PR TITLE
⚡ Persist note search projections

### DIFF
--- a/packages/client/src/components/schema/custom-types.ts
+++ b/packages/client/src/components/schema/custom-types.ts
@@ -1,0 +1,14 @@
+export const OCEAN_BRAIN_CUSTOM_INLINE_CONTENT_TYPES = [
+    'tag',
+    'reference'
+] as const;
+
+export type OceanBrainCustomInlineContentType =
+    (typeof OCEAN_BRAIN_CUSTOM_INLINE_CONTENT_TYPES)[number];
+
+export const OCEAN_BRAIN_CUSTOM_BLOCK_TYPES = [
+    'tableOfContents'
+] as const;
+
+export type OceanBrainCustomBlockType =
+    (typeof OCEAN_BRAIN_CUSTOM_BLOCK_TYPES)[number];

--- a/packages/client/src/components/schema/schema.tsx
+++ b/packages/client/src/components/schema/schema.tsx
@@ -3,16 +3,34 @@ import { BlockNoteSchema, defaultBlockSpecs, defaultInlineContentSpecs } from '@
 import Reference from './Reference';
 import Tag from './Tag';
 import TableOfContents from './TableOfContents';
+import type {
+    OceanBrainCustomBlockType,
+    OceanBrainCustomInlineContentType
+} from './custom-types';
+
+const defineOceanBrainInlineContentSpecs = <T extends Record<OceanBrainCustomInlineContentType, unknown>>(
+    specs: T & Record<Exclude<keyof T, OceanBrainCustomInlineContentType>, never>
+) => specs;
+
+const defineOceanBrainBlockSpecs = <T extends Record<OceanBrainCustomBlockType, unknown>>(
+    specs: T & Record<Exclude<keyof T, OceanBrainCustomBlockType>, never>
+) => specs;
+
+const oceanBrainInlineContentSpecs = defineOceanBrainInlineContentSpecs({
+    tag: Tag,
+    reference: Reference
+});
+
+const oceanBrainBlockSpecs = defineOceanBrainBlockSpecs({ tableOfContents: TableOfContents });
 
 const schema = BlockNoteSchema.create({
     inlineContentSpecs: {
         ...defaultInlineContentSpecs,
-        tag: Tag,
-        reference: Reference
+        ...oceanBrainInlineContentSpecs
     },
     blockSpecs: {
         ...defaultBlockSpecs,
-        tableOfContents: TableOfContents
+        ...oceanBrainBlockSpecs
     }
 });
 

--- a/packages/server/prisma/migrations/20260414143000_0015_note_searchable_text/migration.sql
+++ b/packages/server/prisma/migrations/20260414143000_0015_note_searchable_text/migration.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "Note"
+ADD COLUMN "searchableText" TEXT NOT NULL DEFAULT '';
+
+ALTER TABLE "Note"
+ADD COLUMN "searchableTextVersion" INTEGER NOT NULL DEFAULT 0;

--- a/packages/server/prisma/schema.prisma
+++ b/packages/server/prisma/schema.prisma
@@ -26,17 +26,19 @@ model McpToken {
 }
 
 model Note {
-    id        Int        @id @default(autoincrement())
-    title     String
-    content   String
-    createdAt DateTime   @default(now())
-    updatedAt DateTime   @updatedAt
-    pinned    Boolean    @default(false)
-    order     Int        @default(0)
-    layout    NoteLayout @default(wide)
-    tags      Tag[]      @relation("NoteToTag")
-    reminders Reminder[] @relation("NoteToReminder")
-    snapshots NoteSnapshot[]
+    id                   Int        @id @default(autoincrement())
+    title                String
+    content              String
+    searchableText       String     @default("")
+    searchableTextVersion Int       @default(0)
+    createdAt            DateTime   @default(now())
+    updatedAt            DateTime   @updatedAt
+    pinned               Boolean    @default(false)
+    order                Int        @default(0)
+    layout               NoteLayout @default(wide)
+    tags                 Tag[]      @relation("NoteToTag")
+    reminders            Reminder[] @relation("NoteToReminder")
+    snapshots            NoteSnapshot[]
 }
 
 model NoteSnapshot {

--- a/packages/server/src/main.ts
+++ b/packages/server/src/main.ts
@@ -1,5 +1,6 @@
 import { createApp } from './app.js';
 import { logAuthConfig, resolveAuthConfig } from './modules/auth-mode.js';
+import { startDataMaintenanceScheduler } from './modules/data-maintenance.js';
 
 const PORT = Number(process.env.PORT || 6683);
 const HOST = process.env.HOST || '0.0.0.0';
@@ -13,6 +14,18 @@ try {
 
     app.listen(PORT, HOST, () => {
         process.stdout.write(`http server listen on ${HOST}:${PORT} (auth: ${authConfig.mode})\n`);
+
+        startDataMaintenanceScheduler({
+            onResults: (results) => {
+                for (const result of results) {
+                    process.stdout.write(`[maintenance] Reconciled ${result.processedCount} rows for ${result.key}\n`);
+                }
+            },
+            onError: (error) => {
+                const message = error instanceof Error ? error.message : 'Unknown data maintenance error';
+                process.stderr.write(`[maintenance] Background run failed: ${message}\n`);
+            }
+        });
     });
 } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown auth configuration error';

--- a/packages/server/src/modules/data-maintenance.ts
+++ b/packages/server/src/modules/data-maintenance.ts
@@ -1,0 +1,118 @@
+import { backfillStaleNoteSearchText } from './note-search-backfill.js';
+
+export interface DataMaintenanceJobResult {
+    key: string;
+    processedCount: number;
+}
+
+interface DataMaintenanceSchedulerOptions {
+    intervalMs?: number;
+    onError?: (error: unknown) => void;
+    onResults?: (results: DataMaintenanceJobResult[]) => void;
+    runInBackground?: (limit?: number) => Promise<DataMaintenanceJobResult[]>;
+}
+
+interface DataMaintenanceJob {
+    key: string;
+    run: (limit?: number) => Promise<number>;
+}
+
+interface DataMaintenanceService {
+    runNow: (limit?: number) => Promise<DataMaintenanceJobResult[]>;
+    runInBackground: (limit?: number) => Promise<DataMaintenanceJobResult[]>;
+}
+
+let activeDataMaintenanceTimer: ReturnType<typeof setInterval> | null = null;
+const DEFAULT_DATA_MAINTENANCE_INTERVAL_MS = 15 * 60 * 1000;
+
+export const createDataMaintenanceService = (
+    jobs: DataMaintenanceJob[]
+): DataMaintenanceService => {
+    let activeDataMaintenancePromise: Promise<DataMaintenanceJobResult[]> | null = null;
+
+    const runNow = async (limit?: number) => {
+        const results: DataMaintenanceJobResult[] = [];
+
+        for (const job of jobs) {
+            const processedCount = await job.run(limit);
+
+            if (processedCount > 0) {
+                results.push({
+                    key: job.key,
+                    processedCount
+                });
+            }
+        }
+
+        return results;
+    };
+
+    const runInBackground = (limit?: number) => {
+        if (activeDataMaintenancePromise) {
+            return activeDataMaintenancePromise;
+        }
+
+        activeDataMaintenancePromise = runNow(limit)
+            .finally(() => {
+                activeDataMaintenancePromise = null;
+            });
+
+        return activeDataMaintenancePromise;
+    };
+
+    return {
+        runNow,
+        runInBackground
+    };
+};
+
+const defaultDataMaintenanceService = createDataMaintenanceService([
+    {
+        key: 'note-search-projection',
+        run: backfillStaleNoteSearchText
+    }
+]);
+
+export const runDataMaintenance = async (limit?: number) => {
+    return defaultDataMaintenanceService.runNow(limit);
+};
+
+export const runDataMaintenanceInBackground = (limit?: number) => {
+    return defaultDataMaintenanceService.runInBackground(limit);
+};
+
+export const startDataMaintenanceScheduler = (
+    options: DataMaintenanceSchedulerOptions = {}
+) => {
+    if (activeDataMaintenanceTimer) {
+        return () => {};
+    }
+
+    const intervalMs = options.intervalMs ?? DEFAULT_DATA_MAINTENANCE_INTERVAL_MS;
+
+    const tick = () => {
+        const runInBackground = options.runInBackground ?? runDataMaintenanceInBackground;
+
+        void runInBackground()
+            .then((results) => {
+                options.onResults?.(results);
+            })
+            .catch((error) => {
+                options.onError?.(error);
+            });
+    };
+
+    tick();
+
+    activeDataMaintenanceTimer = setInterval(tick, intervalMs);
+    activeDataMaintenanceTimer.unref?.();
+
+    return () => {
+        if (!activeDataMaintenanceTimer) {
+            return;
+        }
+
+        clearInterval(activeDataMaintenanceTimer);
+        activeDataMaintenanceTimer = null;
+    };
+};

--- a/packages/server/src/modules/note-authoring.ts
+++ b/packages/server/src/modules/note-authoring.ts
@@ -3,6 +3,7 @@ import {
     extractTagIdsFromContentJson,
     markdownToBlocksJson
 } from './blocknote.js';
+import { buildNoteSearchProjection } from './note-search.js';
 import { captureNoteBaseline } from './note-snapshot.js';
 
 interface PlaceholderRecord {
@@ -198,6 +199,10 @@ const defaultNoteAuthoringService = createNoteAuthoringService({
             data: {
                 title: input.title,
                 content: input.content,
+                ...buildNoteSearchProjection({
+                    title: input.title,
+                    content: input.content
+                }),
                 ...(input.layout ? { layout: input.layout } : {}),
                 ...(input.tagIds
                     ? { tags: { connect: input.tagIds.map((id) => ({ id: Number(id) })) } }
@@ -225,12 +230,31 @@ const defaultNoteAuthoringService = createNoteAuthoringService({
     extractTagIds: extractTagIdsFromContentJson,
     captureBaseline: captureNoteBaseline,
     updateNote: async (id, input) => {
+        const existingNote = await models.note.findUnique({
+            where: { id },
+            select: {
+                title: true,
+                content: true
+            }
+        });
+
+        if (!existingNote) {
+            throw new Error('NOTE_NOT_FOUND');
+        }
+
+        const nextTitle = input.title ?? existingNote.title;
+        const nextContent = input.content ?? existingNote.content;
+
         return models.note.update({
             where: { id },
             data: {
                 title: input.title,
                 content: input.content,
                 layout: input.layout,
+                ...buildNoteSearchProjection({
+                    title: nextTitle,
+                    content: nextContent
+                }),
                 ...(input.tagIds
                     ? { tags: { set: input.tagIds.map((tagId) => ({ id: Number(tagId) })) } }
                     : {})

--- a/packages/server/src/modules/note-search-backfill.ts
+++ b/packages/server/src/modules/note-search-backfill.ts
@@ -1,0 +1,111 @@
+import models from '~/models.js';
+import {
+    buildNoteSearchProjection,
+    NOTE_SEARCH_TEXT_SCHEMA_VERSION,
+    type NoteSearchProjection
+} from './note-search.js';
+
+interface BackfillCandidate {
+    id: number;
+    title: string;
+    content: string;
+}
+
+interface NoteSearchBackfillDeps {
+    listStaleNotes: (limit: number) => Promise<BackfillCandidate[]>;
+    updateNotes: (updates: Array<{ id: number; projection: NoteSearchProjection }>) => Promise<void>;
+}
+
+const DEFAULT_BACKFILL_BATCH_SIZE = 100;
+let activeNoteSearchBackfillPromise: Promise<number> | null = null;
+
+const yieldToEventLoop = async () => {
+    await new Promise<void>((resolve) => {
+        setTimeout(resolve, 0);
+    });
+};
+
+export const createNoteSearchBackfillService = (deps: NoteSearchBackfillDeps) => {
+    const backfillBatch = async (limit = DEFAULT_BACKFILL_BATCH_SIZE) => {
+        const staleNotes = await deps.listStaleNotes(limit);
+
+        if (staleNotes.length === 0) {
+            return 0;
+        }
+
+        await deps.updateNotes(
+            staleNotes.map((note) => ({
+                id: note.id,
+                projection: buildNoteSearchProjection(note)
+            }))
+        );
+
+        return staleNotes.length;
+    };
+
+    const backfillAll = async (limit = DEFAULT_BACKFILL_BATCH_SIZE) => {
+        let total = 0;
+
+        while (true) {
+            const count = await backfillBatch(limit);
+
+            if (!count) {
+                return total;
+            }
+
+            total += count;
+
+            if (count < limit) {
+                return total;
+            }
+
+            await yieldToEventLoop();
+        }
+    };
+
+    return {
+        backfillBatch,
+        backfillAll
+    };
+};
+
+const defaultNoteSearchBackfillService = createNoteSearchBackfillService({
+    listStaleNotes: async (limit) => {
+        return models.note.findMany({
+            where: { searchableTextVersion: { not: NOTE_SEARCH_TEXT_SCHEMA_VERSION } },
+            orderBy: { id: 'asc' },
+            take: limit,
+            select: {
+                id: true,
+                title: true,
+                content: true
+            }
+        });
+    },
+    updateNotes: async (updates) => {
+        await models.$transaction(
+            updates.map(({ id, projection }) => models.note.update({
+                where: { id },
+                data: projection
+            }))
+        );
+    }
+});
+
+export const backfillStaleNoteSearchText = async (limit?: number) => {
+    return defaultNoteSearchBackfillService.backfillAll(limit);
+};
+
+export const runNoteSearchBackfillInBackground = (limit?: number) => {
+    if (activeNoteSearchBackfillPromise) {
+        return activeNoteSearchBackfillPromise;
+    }
+
+    activeNoteSearchBackfillPromise = defaultNoteSearchBackfillService
+        .backfillAll(limit)
+        .finally(() => {
+            activeNoteSearchBackfillPromise = null;
+        });
+
+    return activeNoteSearchBackfillPromise;
+};

--- a/packages/server/src/modules/note-search.ts
+++ b/packages/server/src/modules/note-search.ts
@@ -1,0 +1,274 @@
+export interface NoteSearchQuery {
+    included: string[];
+    excluded: string[];
+    hasFilters: boolean;
+}
+
+interface SearchableNoteLike {
+    title: string;
+    content: string;
+    searchableText?: string;
+    searchableTextVersion?: number;
+}
+
+export interface NoteSearchProjection {
+    searchableText: string;
+    searchableTextVersion: number;
+}
+
+interface SearchProjectionContext {
+    segments: string[];
+}
+
+type SearchableJsonNode = Record<string, unknown>;
+type SearchNodeExtractor = (node: SearchableJsonNode, context: SearchProjectionContext) => void;
+type SearchExtractorNodeType = (typeof NOTE_SEARCH_EXTRACTOR_NODE_TYPES)[number];
+
+// If we later materialize searchable text into a DB column, bump this when the
+// extraction meaning changes so stored projections can be rebuilt safely.
+export const NOTE_SEARCH_TEXT_SCHEMA_VERSION = 1;
+
+const FILE_BLOCK_VISIBLE_PROP_KEYS = ['name', 'caption'] as const;
+
+export const NOTE_SEARCH_EXTRACTOR_NODE_TYPES = [
+    'text',
+    'tag',
+    'reference',
+    'image',
+    'video',
+    'audio',
+    'file'
+] as const;
+
+export const NOTE_SEARCH_PASS_THROUGH_NODE_TYPES = [
+    'link',
+    'paragraph',
+    'heading',
+    'bulletListItem',
+    'numberedListItem',
+    'checkListItem',
+    'toggleListItem',
+    'quote',
+    'codeBlock',
+    'divider',
+    'table',
+    'tableContent',
+    'tableCell'
+] as const;
+
+export const NOTE_SEARCH_IGNORED_NODE_TYPES = [
+    'tableOfContents'
+] as const;
+
+const KNOWN_NOTE_SEARCH_NODE_TYPES = new Set<string>([
+    ...NOTE_SEARCH_EXTRACTOR_NODE_TYPES,
+    ...NOTE_SEARCH_PASS_THROUGH_NODE_TYPES,
+    ...NOTE_SEARCH_IGNORED_NODE_TYPES
+]);
+const SEARCH_NODE_EXTRACTOR_TYPE_SET = new Set<string>(NOTE_SEARCH_EXTRACTOR_NODE_TYPES);
+
+const unknownNoteSearchNodeTypeCounts = new Map<string, number>();
+
+const SEARCH_NODE_EXTRACTORS: Record<SearchExtractorNodeType, SearchNodeExtractor> = {
+    text: (node, context) => {
+        pushVisibleSegment(context, node.text);
+    },
+    tag: (node, context) => {
+        pushVisibleProps(context, node.props, ['tag']);
+    },
+    reference: (node, context) => {
+        pushVisibleProps(context, node.props, ['title']);
+    },
+    image: (node, context) => {
+        pushVisibleProps(context, node.props, FILE_BLOCK_VISIBLE_PROP_KEYS);
+    },
+    video: (node, context) => {
+        pushVisibleProps(context, node.props, FILE_BLOCK_VISIBLE_PROP_KEYS);
+    },
+    audio: (node, context) => {
+        pushVisibleProps(context, node.props, FILE_BLOCK_VISIBLE_PROP_KEYS);
+    },
+    file: (node, context) => {
+        pushVisibleProps(context, node.props, FILE_BLOCK_VISIBLE_PROP_KEYS);
+    }
+};
+
+const recordUnknownNoteSearchNodeType = (type: string) => {
+    if (KNOWN_NOTE_SEARCH_NODE_TYPES.has(type)) {
+        return;
+    }
+
+    const nextCount = (unknownNoteSearchNodeTypeCounts.get(type) ?? 0) + 1;
+    unknownNoteSearchNodeTypeCounts.set(type, nextCount);
+
+    if (nextCount === 1) {
+        process.emitWarning(
+            `note-search encountered unsupported BlockNote node type "${type}". Only nested text will be indexed until explicit support is added.`,
+            { code: 'OCEAN_BRAIN_NOTE_SEARCH_UNKNOWN_NODE' }
+        );
+    }
+};
+
+const isSearchExtractorNodeType = (type: string): type is SearchExtractorNodeType => {
+    return SEARCH_NODE_EXTRACTOR_TYPE_SET.has(type);
+};
+
+const normalizeSearchText = (value: string) => value.replace(/\s+/g, ' ').trim();
+
+const normalizeSearchToken = (value: string) => normalizeSearchText(value).toLowerCase();
+
+const isRecord = (value: unknown): value is SearchableJsonNode => {
+    return typeof value === 'object' && value !== null;
+};
+
+const pushVisibleSegment = (context: SearchProjectionContext, value: unknown) => {
+    if (typeof value !== 'string') {
+        return;
+    }
+
+    const normalizedValue = normalizeSearchText(value);
+
+    if (!normalizedValue) {
+        return;
+    }
+
+    context.segments.push(normalizedValue);
+};
+
+const pushVisibleProps = (
+    context: SearchProjectionContext,
+    props: unknown,
+    keys: readonly string[]
+) => {
+    if (!isRecord(props)) {
+        return;
+    }
+
+    for (const key of keys) {
+        pushVisibleSegment(context, props[key]);
+    }
+};
+
+const collectVisibleSearchSegments = (node: unknown, context: SearchProjectionContext) => {
+    if (Array.isArray(node)) {
+        node.forEach((item) => collectVisibleSearchSegments(item, context));
+        return;
+    }
+
+    if (!isRecord(node)) {
+        return;
+    }
+
+    const type = typeof node.type === 'string' ? node.type : undefined;
+
+    if (type) {
+        if (isSearchExtractorNodeType(type)) {
+            SEARCH_NODE_EXTRACTORS[type](node, context);
+        }
+
+        recordUnknownNoteSearchNodeType(type);
+    }
+
+    if ('content' in node) {
+        collectVisibleSearchSegments(node.content, context);
+    }
+
+    if ('children' in node) {
+        collectVisibleSearchSegments(node.children, context);
+    }
+
+    if ('rows' in node) {
+        collectVisibleSearchSegments(node.rows, context);
+    }
+
+    if ('cells' in node) {
+        collectVisibleSearchSegments(node.cells, context);
+    }
+};
+
+export const buildNoteSearchText = (note: Pick<SearchableNoteLike, 'title' | 'content'>) => {
+    const normalizedTitle = normalizeSearchText(note.title);
+    const normalizedContent = extractVisibleSearchTextFromContent(note.content);
+
+    return normalizeSearchToken(`${normalizedTitle} ${normalizedContent}`);
+};
+
+export const buildNoteSearchProjection = (note: Pick<SearchableNoteLike, 'title' | 'content'>): NoteSearchProjection => {
+    return {
+        searchableText: buildNoteSearchText(note),
+        searchableTextVersion: NOTE_SEARCH_TEXT_SCHEMA_VERSION
+    };
+};
+
+export const parseNoteSearchQuery = (query: string): NoteSearchQuery => {
+    const included: string[] = [];
+    const excluded: string[] = [];
+
+    for (const item of query.split(/\s+/).map((value) => value.trim()).filter(Boolean)) {
+        if (item.startsWith('-') && item.length > 1) {
+            excluded.push(normalizeSearchToken(item.slice(1)));
+            continue;
+        }
+
+        included.push(normalizeSearchToken(item));
+    }
+
+    return {
+        included,
+        excluded,
+        hasFilters: included.length > 0 || excluded.length > 0
+    };
+};
+
+export const extractVisibleSearchTextFromContent = (content: string) => {
+    try {
+        const parsed = JSON.parse(content) as unknown;
+        const context: SearchProjectionContext = { segments: [] };
+
+        collectVisibleSearchSegments(parsed, context);
+
+        return normalizeSearchText(context.segments.join(' '));
+    } catch {
+        return '';
+    }
+};
+
+export const matchesNoteSearchQuery = (
+    note: SearchableNoteLike,
+    query: string | NoteSearchQuery
+) => {
+    const parsedQuery = typeof query === 'string' ? parseNoteSearchQuery(query) : query;
+
+    if (!parsedQuery.hasFilters) {
+        return true;
+    }
+
+    const haystack = note.searchableTextVersion === NOTE_SEARCH_TEXT_SCHEMA_VERSION
+        && typeof note.searchableText === 'string'
+        ? normalizeSearchToken(note.searchableText)
+        : buildNoteSearchText(note);
+
+    return parsedQuery.included.every((term) => haystack.includes(term))
+        && parsedQuery.excluded.every((term) => !haystack.includes(term));
+};
+
+export const filterNotesBySearchQuery = <T extends SearchableNoteLike>(
+    notes: T[],
+    query: string | NoteSearchQuery
+) => {
+    const parsedQuery = typeof query === 'string' ? parseNoteSearchQuery(query) : query;
+
+    if (!parsedQuery.hasFilters) {
+        return notes;
+    }
+
+    return notes.filter((note) => matchesNoteSearchQuery(note, parsedQuery));
+};
+
+export const getUnknownNoteSearchNodeTypeCounts = () => {
+    return new Map(unknownNoteSearchNodeTypeCounts);
+};
+
+export const resetUnknownNoteSearchNodeTypeCountsForTest = () => {
+    unknownNoteSearchNodeTypeCounts.clear();
+};

--- a/packages/server/src/modules/note-snapshot.ts
+++ b/packages/server/src/modules/note-snapshot.ts
@@ -5,6 +5,7 @@ import {
     SNAPSHOT_MAX_PER_NOTE,
     SNAPSHOT_RETENTION_DAYS
 } from './recovery-retention.js';
+import { buildNoteSearchProjection } from './note-search.js';
 
 interface NoteRecord {
     id: number;
@@ -304,7 +305,13 @@ export const defaultNoteSnapshotService = createNoteSnapshotService({
     updateNote: async (id, input) => {
         return models.note.update({
             where: { id },
-            data: input
+            data: {
+                ...input,
+                ...buildNoteSearchProjection({
+                    title: input.title,
+                    content: input.content
+                })
+            }
         });
     }
 });

--- a/packages/server/src/modules/note-trash.ts
+++ b/packages/server/src/modules/note-trash.ts
@@ -4,6 +4,7 @@ import {
     RECOVERY_CLEANUP_BATCH_LIMIT,
     TRASH_RETENTION_DAYS
 } from './recovery-retention.js';
+import { buildNoteSearchProjection } from './note-search.js';
 
 interface LiveTagRecord {
     id: number;
@@ -361,6 +362,10 @@ const noteTrashService = createNoteTrashService({
                     id: deletedNote.id,
                     title: deletedNote.title,
                     content: restoredContent,
+                    ...buildNoteSearchProjection({
+                        title: deletedNote.title,
+                        content: restoredContent
+                    }),
                     createdAt: deletedNote.createdAt,
                     updatedAt: deletedNote.updatedAt,
                     pinned: deletedNote.pinned,

--- a/packages/server/src/schema/note/index.ts
+++ b/packages/server/src/schema/note/index.ts
@@ -18,6 +18,13 @@ import {
     restoreTrashedNoteById,
     trashNoteById
 } from '~/modules/note-trash.js';
+import {
+    buildNoteSearchProjection,
+    filterNotesBySearchQuery,
+    NOTE_SEARCH_TEXT_SCHEMA_VERSION,
+    parseNoteSearchQuery
+} from '~/modules/note-search.js';
+import { runDataMaintenanceInBackground } from '~/modules/data-maintenance.js';
 import { buildNoteTagNamesWhere, normalizeNoteTagNames, type NoteTagMatchMode } from '~/modules/note-tag-filter.js';
 
 import type { Note, Prisma } from '~/models.js';
@@ -234,70 +241,225 @@ const extractBlocksByType = <T>(type: string, dataArray: BlockNote[]): BlockNote
     return result as unknown as BlockNote<T>[];
 };
 
-export const noteResolvers: IResolvers = {
-    Query: {
-        allNotes: async (_, {
-            searchFilter,
-            pagination
-        }: {
-            searchFilter: SearchFilter;
-            pagination: Pagination;
-        }) => {
-            const queryItems = searchFilter.query.split(' ');
-            const included = queryItems
-                .filter((item: string) => !item.startsWith('-'))
-                .map((word: string) => `%${word}%`);
-            const excluded = queryItems
-                .filter((item: string) => item.startsWith('-'))
-                .map((item: string) => item.slice(1))
-                .map((word: string) => `%${word}%`);
+interface AllNotesResolverDeps {
+    countNotes: (args: { where?: Prisma.NoteWhereInput }) => Promise<number>;
+    findNotes: (args: {
+        orderBy: Prisma.NoteOrderByWithRelationInput[];
+        where?: Prisma.NoteWhereInput;
+        take?: number;
+        skip?: number;
+    }) => Promise<Note[]>;
+    triggerSearchBackfill: () => void;
+}
 
-            const where: Prisma.NoteWhereInput = {
-                AND: [
-                    ...included.map((keyword: string) => ({
-                        OR: [
-                            { title: { contains: keyword } },
-                            { content: { contains: keyword } }
-                        ]
-                    })),
-                    ...excluded.map((keyword: string) => ({
-                        NOT: {
-                            OR: [
-                                { title: { contains: keyword } },
-                                { content: { contains: keyword } }
-                            ]
-                        }
-                    }))
+const buildAllNotesOrderBy = (searchFilter: SearchFilter) => {
+    const sortBy = searchFilter.sortBy || 'updatedAt';
+    const sortOrder = searchFilter.sortOrder || 'desc';
+    const pinnedFirst = searchFilter.pinnedFirst || false;
+    const orderBy: Prisma.NoteOrderByWithRelationInput[] = [];
+
+    if (pinnedFirst) {
+        orderBy.push({ pinned: 'desc' });
+    }
+
+    if (sortBy === 'createdAt') {
+        orderBy.push({ createdAt: sortOrder as 'asc' | 'desc' });
+    } else {
+        orderBy.push({ updatedAt: sortOrder as 'asc' | 'desc' });
+    }
+
+    return orderBy;
+};
+
+const buildAllNotesSearchWhere = (searchFilter: SearchFilter) => {
+    const parsedQuery = parseNoteSearchQuery(searchFilter.query);
+
+    if (!parsedQuery.hasFilters) {
+        return undefined;
+    }
+
+    return {
+        AND: [
+            { searchableTextVersion: NOTE_SEARCH_TEXT_SCHEMA_VERSION },
+            ...parsedQuery.included.map((keyword) => ({ searchableText: { contains: keyword } })),
+            ...parsedQuery.excluded.map((keyword) => ({ NOT: { searchableText: { contains: keyword } } }))
+        ]
+    } satisfies Prisma.NoteWhereInput;
+};
+
+const buildAllNotesStaleCandidateWhere = (searchFilter: SearchFilter) => {
+    const parsedQuery = parseNoteSearchQuery(searchFilter.query);
+
+    return {
+        AND: [
+            { searchableTextVersion: { not: NOTE_SEARCH_TEXT_SCHEMA_VERSION } },
+            ...parsedQuery.included.map((keyword) => ({
+                OR: [
+                    { title: { contains: keyword } },
+                    { content: { contains: keyword } }
                 ]
+            }))
+        ]
+    } satisfies Prisma.NoteWhereInput;
+};
+
+const compareNotesForSearch = (left: Note, right: Note, searchFilter: SearchFilter) => {
+    if (searchFilter.pinnedFirst && left.pinned !== right.pinned) {
+        return left.pinned ? -1 : 1;
+    }
+
+    const sortBy = searchFilter.sortBy || 'updatedAt';
+    const sortOrder = searchFilter.sortOrder || 'desc';
+    const leftValue = sortBy === 'createdAt'
+        ? left.createdAt.getTime()
+        : left.updatedAt.getTime();
+    const rightValue = sortBy === 'createdAt'
+        ? right.createdAt.getTime()
+        : right.updatedAt.getTime();
+
+    if (leftValue === rightValue) {
+        return 0;
+    }
+
+    return sortOrder === 'asc'
+        ? leftValue - rightValue
+        : rightValue - leftValue;
+};
+
+const mergeSortedNotesForSearch = (left: Note[], right: Note[], searchFilter: SearchFilter) => {
+    const merged: Note[] = [];
+    let leftIndex = 0;
+    let rightIndex = 0;
+
+    while (leftIndex < left.length && rightIndex < right.length) {
+        if (compareNotesForSearch(left[leftIndex], right[rightIndex], searchFilter) <= 0) {
+            merged.push(left[leftIndex]);
+            leftIndex += 1;
+        } else {
+            merged.push(right[rightIndex]);
+            rightIndex += 1;
+        }
+    }
+
+    while (leftIndex < left.length) {
+        merged.push(left[leftIndex]);
+        leftIndex += 1;
+    }
+
+    while (rightIndex < right.length) {
+        merged.push(right[rightIndex]);
+        rightIndex += 1;
+    }
+
+    return merged;
+};
+
+export const createAllNotesQueryResolver = (
+    deps: AllNotesResolverDeps = {
+        countNotes: ({ where }) => models.note.count({ where }),
+        findNotes: ({ orderBy, where, take, skip }) => models.note.findMany({
+            orderBy,
+            where,
+            take,
+            skip
+        }),
+        triggerSearchBackfill: () => {
+            void runDataMaintenanceInBackground();
+        }
+    }
+) => {
+    return async (_: unknown, {
+        searchFilter,
+        pagination
+    }: {
+        searchFilter: SearchFilter;
+        pagination: Pagination;
+    }) => {
+        const orderBy = buildAllNotesOrderBy(searchFilter);
+        const limit = Number(pagination.limit);
+        const offset = Number(pagination.offset);
+        const where = buildAllNotesSearchWhere(searchFilter);
+
+        if (!where) {
+            const [notes, totalCount] = await Promise.all([
+                deps.findNotes({
+                    orderBy,
+                    take: limit,
+                    skip: offset
+                }),
+                deps.countNotes({})
+            ]);
+
+            return {
+                totalCount,
+                notes
             };
+        }
 
-            const sortBy = searchFilter.sortBy || 'updatedAt';
-            const sortOrder = searchFilter.sortOrder || 'desc';
-            const pinnedFirst = searchFilter.pinnedFirst || false;
+        const staleCandidateNotes = await deps.findNotes({
+            orderBy,
+            where: buildAllNotesStaleCandidateWhere(searchFilter)
+        });
 
-            const orderBy: Prisma.NoteOrderByWithRelationInput[] = [];
+        if (staleCandidateNotes.length === 0) {
+            const [notes, totalCount] = await Promise.all([
+                deps.findNotes({
+                    orderBy,
+                    where,
+                    take: limit,
+                    skip: offset
+                }),
+                deps.countNotes({ where })
+            ]);
 
-            if (pinnedFirst) {
-                orderBy.push({ pinned: 'desc' });
-            }
+            return {
+                totalCount,
+                notes
+            };
+        }
 
-            if (sortBy === 'createdAt') {
-                orderBy.push({ createdAt: sortOrder as 'asc' | 'desc' });
-            } else {
-                orderBy.push({ updatedAt: sortOrder as 'asc' | 'desc' });
-            }
+        deps.triggerSearchBackfill();
 
-            const $notes = models.note.findMany({
+        const parsedQuery = parseNoteSearchQuery(searchFilter.query);
+        const staleNotes = filterNotesBySearchQuery(staleCandidateNotes, parsedQuery);
+
+        if (staleNotes.length === 0) {
+            const [notes, totalCount] = await Promise.all([
+                deps.findNotes({
+                    orderBy,
+                    where,
+                    take: limit,
+                    skip: offset
+                }),
+                deps.countNotes({ where })
+            ]);
+
+            return {
+                totalCount,
+                notes
+            };
+        }
+
+        const [freshNotesPrefix, freshTotalCount] = await Promise.all([
+            deps.findNotes({
                 orderBy,
                 where,
-                take: Number(pagination.limit),
-                skip: Number(pagination.offset)
-            });
-            return {
-                totalCount: models.note.count({ where }),
-                notes: $notes
-            };
-        },
+                take: offset + limit
+            }),
+            deps.countNotes({ where })
+        ]);
+        const mergedNotes = mergeSortedNotesForSearch(freshNotesPrefix, staleNotes, searchFilter);
+
+        return {
+            totalCount: freshTotalCount + staleNotes.length,
+            notes: mergedNotes.slice(offset, offset + limit)
+        };
+    };
+};
+
+export const noteResolvers: IResolvers = {
+    Query: {
+        allNotes: createAllNotesQueryResolver(),
         notesInDateRange: async (_, { dateRange }: {
             dateRange: {
                 start: string;
@@ -569,6 +731,10 @@ export const noteResolvers: IResolvers = {
                 data: {
                     title: replacedTitle,
                     content: replacedContent,
+                    ...buildNoteSearchProjection({
+                        title: replacedTitle,
+                        content: replacedContent
+                    }),
                     ...(note.layout && { layout: note.layout })
                 }
             });
@@ -600,6 +766,17 @@ export const noteResolvers: IResolvers = {
             const userAgentHeader = context.req?.headers['user-agent'];
             const userAgent = Array.isArray(userAgentHeader) ? userAgentHeader[0] : userAgentHeader;
             let blocks: BlockNote<{ id: string }>[] = [];
+            const existingNote = await models.note.findUnique({
+                where: { id: Number(id) },
+                select: {
+                    title: true,
+                    content: true
+                }
+            });
+
+            if (!existingNote) {
+                throw 'NOT FOUND';
+            }
 
             if (note.content) {
                 blocks = extractBlocksByType<{ id: string }>(
@@ -614,10 +791,17 @@ export const noteResolvers: IResolvers = {
                 meta: createSnapshotMetaFromUserAgent(userAgent)
             });
 
+            const nextTitle = note.title ?? existingNote.title;
+            const nextContent = note.content ?? existingNote.content;
+
             const $note = await models.note.update({
                 where: { id: Number(id) },
                 data: {
                     ...note,
+                    ...buildNoteSearchProjection({
+                        title: nextTitle,
+                        content: nextContent
+                    }),
                     ...(note.content ? { tags: { set: blocks.map(block => ({ id: Number(block.props.id) })) } } : {})
                 }
             });

--- a/packages/server/test/data-maintenance.test.ts
+++ b/packages/server/test/data-maintenance.test.ts
@@ -1,0 +1,89 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createDataMaintenanceService, startDataMaintenanceScheduler } from '../src/modules/data-maintenance.js';
+
+test('data maintenance service runs registered jobs and returns non-zero work only', async () => {
+    const calls: string[] = [];
+    const service = createDataMaintenanceService([
+        {
+            key: 'note-search-projection',
+            run: async () => {
+                calls.push('note-search-projection');
+                return 3;
+            }
+        },
+        {
+            key: 'noop-job',
+            run: async () => {
+                calls.push('noop-job');
+                return 0;
+            }
+        }
+    ]);
+
+    const results = await service.runNow(50);
+
+    assert.deepEqual(calls, ['note-search-projection', 'noop-job']);
+    assert.deepEqual(results, [{
+        key: 'note-search-projection',
+        processedCount: 3
+    }]);
+});
+
+test('data maintenance service deduplicates concurrent background runs', async () => {
+    let runCount = 0;
+    const service = createDataMaintenanceService([{
+        key: 'note-search-projection',
+        run: async () => {
+            runCount += 1;
+            await new Promise<void>((resolve) => {
+                setTimeout(resolve, 10);
+            });
+            return 2;
+        }
+    }]);
+
+    const [left, right] = await Promise.all([
+        service.runInBackground(),
+        service.runInBackground()
+    ]);
+
+    assert.equal(runCount, 1);
+    assert.deepEqual(left, [{
+        key: 'note-search-projection',
+        processedCount: 2
+    }]);
+    assert.deepEqual(right, left);
+});
+
+test('data maintenance scheduler triggers an immediate run and can be stopped', async () => {
+    let runs = 0;
+    const service = createDataMaintenanceService([{
+        key: 'note-search-projection',
+        run: async () => {
+            runs += 1;
+            return 1;
+        }
+    }]);
+
+    const observedResults: Array<Array<{ key: string; processedCount: number }>> = [];
+    const stop = startDataMaintenanceScheduler({
+        intervalMs: 1000,
+        runInBackground: service.runInBackground,
+        onResults: (results) => {
+            observedResults.push(results);
+        }
+    });
+
+    await new Promise<void>((resolve) => {
+        setTimeout(resolve, 20);
+    });
+    stop();
+
+    assert.equal(runs >= 1, true);
+    assert.deepEqual(observedResults[0], [{
+        key: 'note-search-projection',
+        processedCount: 1
+    }]);
+});

--- a/packages/server/test/note-resolver.test.ts
+++ b/packages/server/test/note-resolver.test.ts
@@ -1,0 +1,222 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createAllNotesQueryResolver } from '../src/schema/note/index.js';
+
+test('allNotes resolver uses stored searchable text with DB pagination when no stale notes exist', async () => {
+    const findCalls: unknown[] = [];
+
+    const resolver = createAllNotesQueryResolver({
+        countNotes: async ({ where }) => {
+            assert.deepEqual(where, {
+                AND: [
+                    { searchableTextVersion: 1 },
+                    { searchableText: { contains: '123' } },
+                    { NOT: { searchableText: { contains: 'draft' } } }
+                ]
+            });
+
+            return 2;
+        },
+        triggerSearchBackfill: () => {},
+        findNotes: async (args) => {
+            findCalls.push(args);
+
+            if (
+                'where' in args &&
+                args.where &&
+                typeof args.where === 'object' &&
+                'AND' in args.where &&
+                Array.isArray(args.where.AND) &&
+                args.where.AND.some((item) =>
+                    typeof item === 'object'
+                    && item !== null
+                    && 'searchableTextVersion' in item
+                    && typeof item.searchableTextVersion === 'object'
+                    && item.searchableTextVersion !== null
+                    && 'not' in item.searchableTextVersion
+                )
+            ) {
+                return [] as never;
+            }
+
+            return ([
+                {
+                    id: 2,
+                    title: 'Another match',
+                    content: JSON.stringify([]),
+                    searchableText: 'another match contains 123 here',
+                    searchableTextVersion: 1,
+                    createdAt: new Date('2026-04-01T00:00:00.000Z'),
+                    updatedAt: new Date('2026-04-02T00:00:00.000Z'),
+                    pinned: false,
+                    order: 0,
+                    layout: 'wide'
+                }
+            ]) as never;
+        }
+    });
+
+    const result = await resolver(null, {
+        searchFilter: {
+            query: '123 -draft'
+        },
+        pagination: {
+            limit: 1,
+            offset: 1
+        }
+    });
+
+    assert.deepEqual(findCalls, [
+        {
+            orderBy: [{ updatedAt: 'desc' }],
+            where: {
+                AND: [
+                    { searchableTextVersion: { not: 1 } },
+                    {
+                        OR: [
+                            { title: { contains: '123' } },
+                            { content: { contains: '123' } }
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            orderBy: [{ updatedAt: 'desc' }],
+            where: {
+                AND: [
+                    { searchableTextVersion: 1 },
+                    { searchableText: { contains: '123' } },
+                    { NOT: { searchableText: { contains: 'draft' } } }
+                ]
+            },
+            take: 1,
+            skip: 1
+        }
+    ]);
+    assert.equal(result.totalCount, 2);
+    assert.deepEqual(result.notes.map((note) => note.id), [2]);
+});
+
+test('allNotes resolver merges stale fallback matches with stored-search matches', async () => {
+    const resolver = createAllNotesQueryResolver({
+        countNotes: async ({ where }) => {
+            assert.deepEqual(where, {
+                AND: [
+                    { searchableTextVersion: 1 },
+                    { searchableText: { contains: '123' } }
+                ]
+            });
+
+            return 1;
+        },
+        triggerSearchBackfill: () => {},
+        findNotes: async (args) => {
+            if (
+                'where' in args &&
+                args.where &&
+                typeof args.where === 'object' &&
+                'AND' in args.where &&
+                Array.isArray(args.where.AND) &&
+                args.where.AND.some((item) =>
+                    typeof item === 'object'
+                    && item !== null
+                    && 'searchableTextVersion' in item
+                    && typeof item.searchableTextVersion === 'object'
+                    && item.searchableTextVersion !== null
+                    && 'not' in item.searchableTextVersion
+                )
+            ) {
+                return ([
+                    {
+                        id: 1,
+                        title: 'Legacy stale note',
+                        content: JSON.stringify([{
+                            id: 'paragraph-1',
+                            type: 'paragraph',
+                            props: {},
+                            content: [{
+                                type: 'text',
+                                text: 'Contains 123 here',
+                                styles: {}
+                            }],
+                            children: []
+                        }]),
+                        searchableText: '',
+                        searchableTextVersion: 0,
+                        createdAt: new Date('2026-04-01T00:00:00.000Z'),
+                        updatedAt: new Date('2026-04-03T00:00:00.000Z'),
+                        pinned: false,
+                        order: 0,
+                        layout: 'wide'
+                    }
+                ]) as never;
+            }
+
+            return ([
+                {
+                    id: 2,
+                    title: 'Fresh note',
+                    content: JSON.stringify([]),
+                    searchableText: 'fresh note task 123',
+                    searchableTextVersion: 1,
+                    createdAt: new Date('2026-04-01T00:00:00.000Z'),
+                    updatedAt: new Date('2026-04-02T00:00:00.000Z'),
+                    pinned: false,
+                    order: 0,
+                    layout: 'wide'
+                }
+            ]) as never;
+        }
+    });
+
+    const result = await resolver(null, {
+        searchFilter: {
+            query: '123'
+        },
+        pagination: {
+            limit: 2,
+            offset: 0
+        }
+    });
+
+    assert.equal(result.totalCount, 2);
+    assert.deepEqual(result.notes.map((note) => note.id), [1, 2]);
+});
+
+test('allNotes resolver leaves unfiltered queries on the fast default path', async () => {
+    let countedWhere: unknown;
+    let foundArgs: unknown;
+
+    const resolver = createAllNotesQueryResolver({
+        countNotes: async ({ where }) => {
+            countedWhere = where;
+            return 3;
+        },
+        triggerSearchBackfill: () => {},
+        findNotes: async (args) => {
+            foundArgs = args;
+            return ([] as never);
+        }
+    });
+
+    const result = await resolver(null, {
+        searchFilter: {
+            query: ''
+        },
+        pagination: {
+            limit: 20,
+            offset: 40
+        }
+    });
+
+    assert.equal(countedWhere, undefined);
+    assert.deepEqual(foundArgs, {
+        orderBy: [{ updatedAt: 'desc' }],
+        take: 20,
+        skip: 40
+    });
+    assert.equal(result.totalCount, 3);
+    assert.deepEqual(result.notes, []);
+});

--- a/packages/server/test/note-search-backfill.test.ts
+++ b/packages/server/test/note-search-backfill.test.ts
@@ -1,0 +1,106 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createNoteSearchBackfillService } from '../src/modules/note-search-backfill.js';
+
+test('note search backfill updates stale notes in batches until complete', async () => {
+    const listedLimits: number[] = [];
+    const updatedBatches: Array<Array<{ id: number; searchableText: string; searchableTextVersion: number }>> = [];
+    const batches = [
+        [
+            {
+                id: 1,
+                title: 'Roadmap',
+                content: JSON.stringify([{
+                    id: 'paragraph-1',
+                    type: 'paragraph',
+                    props: {},
+                    content: [{
+                        type: 'text',
+                        text: 'Sprint 42',
+                        styles: {}
+                    }],
+                    children: []
+                }])
+            },
+            {
+                id: 2,
+                title: 'Release',
+                content: JSON.stringify([{
+                    id: 'paragraph-2',
+                    type: 'paragraph',
+                    props: {},
+                    content: [{
+                        type: 'text',
+                        text: 'Candidate',
+                        styles: {}
+                    }],
+                    children: []
+                }])
+            }
+        ],
+        [
+            {
+                id: 3,
+                title: 'Archive',
+                content: JSON.stringify([])
+            }
+        ],
+        []
+    ];
+
+    const service = createNoteSearchBackfillService({
+        listStaleNotes: async (limit) => {
+            listedLimits.push(limit);
+            return batches.shift() ?? [];
+        },
+        updateNotes: async (updates) => {
+            updatedBatches.push(
+                updates.map(({ id, projection }) => ({
+                    id,
+                    searchableText: projection.searchableText,
+                    searchableTextVersion: projection.searchableTextVersion
+                }))
+            );
+        }
+    });
+
+    const backfilled = await service.backfillAll(2);
+
+    assert.equal(backfilled, 3);
+    assert.deepEqual(listedLimits, [2, 2]);
+    assert.deepEqual(updatedBatches, [
+        [
+            {
+                id: 1,
+                searchableText: 'roadmap sprint 42',
+                searchableTextVersion: 1
+            },
+            {
+                id: 2,
+                searchableText: 'release candidate',
+                searchableTextVersion: 1
+            }
+        ],
+        [
+            {
+                id: 3,
+                searchableText: 'archive',
+                searchableTextVersion: 1
+            }
+        ]
+    ]);
+});
+
+test('note search backfill stops cleanly when nothing is stale', async () => {
+    const service = createNoteSearchBackfillService({
+        listStaleNotes: async () => [],
+        updateNotes: async () => {
+            throw new Error('should not update when there is nothing to backfill');
+        }
+    });
+
+    const backfilled = await service.backfillAll(50);
+
+    assert.equal(backfilled, 0);
+});

--- a/packages/server/test/note-search.test.ts
+++ b/packages/server/test/note-search.test.ts
@@ -1,0 +1,368 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+    NOTE_SEARCH_EXTRACTOR_NODE_TYPES,
+    NOTE_SEARCH_IGNORED_NODE_TYPES,
+    NOTE_SEARCH_PASS_THROUGH_NODE_TYPES,
+    NOTE_SEARCH_TEXT_SCHEMA_VERSION,
+    buildNoteSearchProjection,
+    buildNoteSearchText,
+    extractVisibleSearchTextFromContent,
+    getUnknownNoteSearchNodeTypeCounts,
+    matchesNoteSearchQuery,
+    parseNoteSearchQuery,
+    resetUnknownNoteSearchNodeTypeCountsForTest
+} from '../src/modules/note-search.js';
+import {
+    OCEAN_BRAIN_CUSTOM_BLOCK_TYPES,
+    OCEAN_BRAIN_CUSTOM_INLINE_CONTENT_TYPES
+} from '../../client/src/components/schema/custom-types.ts';
+
+test('note search text schema version is explicit for future projection rebuilds', () => {
+    assert.equal(NOTE_SEARCH_TEXT_SCHEMA_VERSION, 1);
+});
+
+test('buildNoteSearchProjection stores normalized lowercase title and visible content', () => {
+    const projection = buildNoteSearchProjection({
+        title: 'Roadmap 123',
+        content: JSON.stringify([{
+            id: 'paragraph-1',
+            type: 'paragraph',
+            props: {},
+            content: [{
+                type: 'text',
+                text: 'Visible Content',
+                styles: {}
+            }],
+            children: []
+        }])
+    });
+
+    assert.deepEqual(projection, {
+        searchableText: 'roadmap 123 visible content',
+        searchableTextVersion: NOTE_SEARCH_TEXT_SCHEMA_VERSION
+    });
+});
+
+test('note search explicitly classifies every Ocean Brain custom BlockNote type', () => {
+    const knownTypes = new Set([
+        ...NOTE_SEARCH_EXTRACTOR_NODE_TYPES,
+        ...NOTE_SEARCH_PASS_THROUGH_NODE_TYPES,
+        ...NOTE_SEARCH_IGNORED_NODE_TYPES
+    ]);
+
+    for (const type of [
+        ...OCEAN_BRAIN_CUSTOM_INLINE_CONTENT_TYPES,
+        ...OCEAN_BRAIN_CUSTOM_BLOCK_TYPES
+    ]) {
+        assert.equal(knownTypes.has(type), true, `expected search handling for custom type "${type}"`);
+    }
+});
+
+test('extractVisibleSearchTextFromContent keeps visible inline and prop text while excluding internal ids and metadata', () => {
+    const content = JSON.stringify([
+        {
+            id: 'paragraph-123',
+            type: 'paragraph',
+            props: {
+                textAlignment: 'left',
+                backgroundColor: 'default'
+            },
+            content: [
+                {
+                    type: 'text',
+                    text: 'Visible roadmap',
+                    styles: {}
+                },
+                {
+                    type: 'text',
+                    text: ' ',
+                    styles: {}
+                },
+                {
+                    type: 'reference',
+                    props: {
+                        id: '44',
+                        title: 'Reference 123'
+                    }
+                },
+                {
+                    type: 'text',
+                    text: ' ',
+                    styles: {}
+                },
+                {
+                    type: 'tag',
+                    props: {
+                        id: '7',
+                        tag: '@project'
+                    }
+                }
+            ],
+            children: []
+        },
+        {
+            id: 'image-9',
+            type: 'image',
+            props: {
+                name: 'Architecture Diagram',
+                caption: 'Search preview',
+                url: 'https://example.com/image.png'
+            },
+            children: []
+        }
+    ]);
+
+    const extracted = extractVisibleSearchTextFromContent(content);
+
+    assert.match(extracted, /Visible roadmap/);
+    assert.match(extracted, /Reference 123/);
+    assert.match(extracted, /@project/);
+    assert.match(extracted, /Architecture Diagram/);
+    assert.match(extracted, /Search preview/);
+    assert.doesNotMatch(extracted, /paragraph-123/);
+    assert.doesNotMatch(extracted, /\bleft\b/);
+    assert.doesNotMatch(extracted, /example\.com/);
+});
+
+test('extractVisibleSearchTextFromContent keeps nested text for unknown nodes without indexing arbitrary props', () => {
+    resetUnknownNoteSearchNodeTypeCountsForTest();
+
+    const content = JSON.stringify([
+        {
+            id: 'custom-1',
+            type: 'futureWidget',
+            props: {
+                internalId: 'widget-123',
+                rawPayload: 'do-not-index'
+            },
+            content: [{
+                type: 'text',
+                text: 'Visible widget text',
+                styles: {}
+            }],
+            children: [{
+                id: 'child-1',
+                type: 'paragraph',
+                props: {},
+                content: [{
+                    type: 'text',
+                    text: 'Nested paragraph text',
+                    styles: {}
+                }],
+                children: []
+            }]
+        }
+    ]);
+
+    const extracted = extractVisibleSearchTextFromContent(content);
+
+    assert.match(extracted, /Visible widget text/);
+    assert.match(extracted, /Nested paragraph text/);
+    assert.doesNotMatch(extracted, /widget-123/);
+    assert.doesNotMatch(extracted, /do-not-index/);
+    assert.deepEqual(
+        [...getUnknownNoteSearchNodeTypeCounts().entries()],
+        [['futureWidget', 1]]
+    );
+});
+
+test('extractVisibleSearchTextFromContent keeps visible link text without indexing href metadata', () => {
+    const content = JSON.stringify([
+        {
+            id: 'paragraph-1',
+            type: 'paragraph',
+            props: {},
+            content: [{
+                type: 'link',
+                href: 'https://oceanbrain.example/docs',
+                content: [{
+                    type: 'text',
+                    text: 'Ocean Brain Docs',
+                    styles: {}
+                }]
+            }],
+            children: []
+        }
+    ]);
+
+    const extracted = extractVisibleSearchTextFromContent(content);
+
+    assert.match(extracted, /Ocean Brain Docs/);
+    assert.doesNotMatch(extracted, /oceanbrain\.example/);
+});
+
+test('extractVisibleSearchTextFromContent counts repeated unknown node types without duplicating rules', () => {
+    resetUnknownNoteSearchNodeTypeCountsForTest();
+
+    const content = JSON.stringify([
+        {
+            id: 'custom-1',
+            type: 'futureWidget',
+            props: {},
+            content: [{
+                type: 'text',
+                text: 'Alpha',
+                styles: {}
+            }]
+        },
+        {
+            id: 'custom-2',
+            type: 'futureWidget',
+            props: {},
+            content: [{
+                type: 'text',
+                text: 'Beta',
+                styles: {}
+            }]
+        }
+    ]);
+
+    const extracted = extractVisibleSearchTextFromContent(content);
+
+    assert.match(extracted, /Alpha/);
+    assert.match(extracted, /Beta/);
+    assert.deepEqual(
+        [...getUnknownNoteSearchNodeTypeCounts().entries()],
+        [['futureWidget', 2]]
+    );
+});
+
+test('matchesNoteSearchQuery ignores internal id noise for numeric searches', () => {
+    const note = {
+        title: 'Roadmap',
+        content: JSON.stringify([
+            {
+                id: 'paragraph-123',
+                type: 'paragraph',
+                props: {},
+                content: [{
+                    type: 'text',
+                    text: 'Visible content only',
+                    styles: {}
+                }],
+                children: []
+            }
+        ])
+    };
+
+    assert.equal(matchesNoteSearchQuery(note, '123'), false);
+});
+
+test('matchesNoteSearchQuery keeps visible numeric matches from table cells, tags, and references', () => {
+    const note = {
+        title: 'Sprint board',
+        content: JSON.stringify([
+            {
+                id: 'table-1',
+                type: 'table',
+                props: {},
+                content: {
+                    type: 'tableContent',
+                    columnWidths: [120],
+                    headerRows: 1,
+                    rows: [{
+                        cells: [{
+                            type: 'tableCell',
+                            props: {
+                                colspan: 1,
+                                rowspan: 1
+                            },
+                            content: [{
+                                type: 'text',
+                                text: 'Task 123',
+                                styles: {}
+                            }]
+                        }]
+                    }]
+                },
+                children: []
+            },
+            {
+                id: 'paragraph-1',
+                type: 'paragraph',
+                props: {},
+                content: [
+                    {
+                        type: 'tag',
+                        props: {
+                            id: '8',
+                            tag: '@release-123'
+                        }
+                    },
+                    {
+                        type: 'text',
+                        text: ' ',
+                        styles: {}
+                    },
+                    {
+                        type: 'reference',
+                        props: {
+                            id: '44',
+                            title: 'Reference 123'
+                        }
+                    }
+                ],
+                children: []
+            }
+        ])
+    };
+
+    assert.equal(matchesNoteSearchQuery(note, '123'), true);
+});
+
+test('matchesNoteSearchQuery can use a precomputed searchable text field', () => {
+    const note = {
+        title: 'Ignored original title',
+        content: JSON.stringify([]),
+        searchableText: buildNoteSearchText({
+            title: 'Roadmap',
+            content: JSON.stringify([{
+                id: 'paragraph-1',
+                type: 'paragraph',
+                props: {},
+                content: [{
+                    type: 'text',
+                    text: 'Sprint 42',
+                    styles: {}
+                }],
+                children: []
+            }])
+        }),
+        searchableTextVersion: NOTE_SEARCH_TEXT_SCHEMA_VERSION
+    };
+
+    assert.equal(matchesNoteSearchQuery(note, 'roadmap 42'), true);
+    assert.equal(matchesNoteSearchQuery(note, 'roadmap -42'), false);
+});
+
+test('matchesNoteSearchQuery applies excluded terms against visible text only', () => {
+    const note = {
+        title: 'Roadmap',
+        content: JSON.stringify([
+            {
+                id: 'paragraph-123',
+                type: 'paragraph',
+                props: {},
+                content: [{
+                    type: 'text',
+                    text: 'Quarterly roadmap',
+                    styles: {}
+                }],
+                children: []
+            }
+        ])
+    };
+
+    assert.equal(matchesNoteSearchQuery(note, 'roadmap -123'), true);
+    assert.equal(matchesNoteSearchQuery(note, 'roadmap -quarterly'), false);
+});
+
+test('parseNoteSearchQuery splits included and excluded tokens', () => {
+    assert.deepEqual(parseNoteSearchQuery(' alpha  beta  -gamma '), {
+        included: ['alpha', 'beta'],
+        excluded: ['gamma'],
+        hasFilters: true
+    });
+});


### PR DESCRIPTION
## :dart: Goal
- Persist note search text so search can use a stable visible-text projection instead of reparsing BlockNote JSON on every request.
- Keep self-hosted upgrades safe by repairing stale rows in the background after migration instead of blocking startup on a one-off full backfill.

## :hammer_and_wrench: Core Changes
- Added `Note.searchableText` and `Note.searchableTextVersion` with a Prisma migration for persisted search projections.
- Updated note create, update, snapshot restore, trash restore, and GraphQL mutation paths to write the current search projection immediately.
- Added a visible-text extractor plus stale-row fallback so `allNotes` can search current rows from stored projections and only re-parse stale candidates when needed.
- Added a shared data maintenance service that runs note-search reconciliation on startup and on a periodic background schedule.

## :brain: Key Decisions
- Chose a versioned search projection over HTML/DOM extraction so searchable content stays tied to an explicit contract instead of renderer output.
- Kept a stale fallback path plus background maintenance because Docker/self-hosted installs cannot rely on a single guaranteed one-time backfill run.
- Treated unknown BlockNote node types conservatively by indexing only nested visible text, which protects search precision from metadata/id false positives.

## :test_tube: Verification Guide
### How to verify
1. `pnpm check:encoding`
2. `pnpm lint`
3. `pnpm type-check`
4. `pnpm test:ci`
5. `pnpm build`
6. `cd packages/server && pnpm exec prisma migrate deploy --schema=prisma/schema.prisma`
7. `cd packages/server && node --import tsx -e 'import models from "./src/models.ts"; import { runDataMaintenance } from "./src/modules/data-maintenance.ts"; try { const results = await runDataMaintenance(); const stale = await models.note.count({ where: { searchableTextVersion: { not: 1 } } }); console.log(JSON.stringify({ results, stale }, null, 2)); } finally { await models.$disconnect(); }'`\n\n### Expected result\n- Encoding, lint, type-check, test, and build all pass. Lint still reports only the pre-existing `no-console` warning in `packages/server/src/schema/image/index.ts:84`.\n- The Prisma migration adds `searchableText` and `searchableTextVersion` to `Note`.\n- Running the maintenance command backfills stale projections and subsequent runs report `stale: 0`.\n- Local build completes successfully. On Node `22.8.0`, Vite prints an upstream version warning but still finishes the build.\n\n## :white_check_mark: Checklist\n- [x] Lint completed\n- [x] Type-check completed\n- [x] Tests completed\n- [x] Documentation updated (if needed)