### PR TITLE
🐛 Exclude current note from reference suggestions

### DIFF
--- a/packages/client/src/components/schema/ReferenceView/ReferenceView.tsx
+++ b/packages/client/src/components/schema/ReferenceView/ReferenceView.tsx
@@ -1,8 +1,10 @@
 import { SuggestionMenuController } from '@blocknote/react';
 
 import { fetchNotes } from '~/apis/note.api';
+import { filterReferenceSuggestionNotes } from './reference-suggestions';
 
 interface ReferenceViewProps {
+    currentNoteId?: string;
     onClick: (content: {
         type: 'reference';
         props: {
@@ -12,7 +14,7 @@ interface ReferenceViewProps {
     }) => void;
 }
 
-const ReferenceView = ({ onClick }: ReferenceViewProps) => {
+const ReferenceView = ({ currentNoteId, onClick }: ReferenceViewProps) => {
     return (
         <SuggestionMenuController
             triggerCharacter="["
@@ -24,7 +26,7 @@ const ReferenceView = ({ onClick }: ReferenceViewProps) => {
                 if (response.type === 'error') {
                     return [];
                 }
-                const { notes } = response.allNotes;
+                const notes = filterReferenceSuggestionNotes(response.allNotes.notes, currentNoteId);
                 return notes.map((note) => ({
                     title: note.title,
                     onItemClick: () =>

--- a/packages/client/src/components/schema/ReferenceView/reference-suggestions.spec.ts
+++ b/packages/client/src/components/schema/ReferenceView/reference-suggestions.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { filterReferenceSuggestionNotes } from './reference-suggestions';
+
+describe('filterReferenceSuggestionNotes', () => {
+    it('excludes the currently edited note from reference suggestions', () => {
+        expect(
+            filterReferenceSuggestionNotes(
+                [
+                    { id: '1', title: 'Current note' },
+                    { id: '2', title: 'Another note' },
+                ],
+                '1',
+            ),
+        ).toEqual([{ id: '2', title: 'Another note' }]);
+    });
+
+    it('returns the original list when there is no current note id', () => {
+        const notes = [
+            { id: '1', title: 'Current note' },
+            { id: '2', title: 'Another note' },
+        ];
+
+        expect(filterReferenceSuggestionNotes(notes)).toEqual(notes);
+    });
+});

--- a/packages/client/src/components/schema/ReferenceView/reference-suggestions.ts
+++ b/packages/client/src/components/schema/ReferenceView/reference-suggestions.ts
@@ -1,0 +1,9 @@
+import type { Note } from '~/models/note.model';
+
+export const filterReferenceSuggestionNotes = (notes: Pick<Note, 'id' | 'title'>[], currentNoteId?: string) => {
+    if (!currentNoteId) {
+        return notes;
+    }
+
+    return notes.filter((note) => note.id !== currentNoteId);
+};

--- a/packages/client/src/components/shared/Editor/Editor.tsx
+++ b/packages/client/src/components/shared/Editor/Editor.tsx
@@ -8,6 +8,7 @@ import { useTheme } from '~/store/theme';
 
 interface EditorProps {
     content?: string;
+    currentNoteId?: string;
     editable?: boolean;
     onChange?: () => void;
 }
@@ -16,7 +17,7 @@ export interface EditorRef {
     getContent: () => string;
 }
 
-const Editor = forwardRef<EditorRef, EditorProps>(({ content, editable, onChange }, ref) => {
+const Editor = forwardRef<EditorRef, EditorProps>(({ content, currentNoteId, editable, onChange }, ref) => {
     const { theme } = useTheme((state) => state);
 
     const editor = useCreateBlockNote(
@@ -40,6 +41,7 @@ const Editor = forwardRef<EditorRef, EditorProps>(({ content, editable, onChange
         <BlockNoteView slashMenu={false} theme={theme} editor={editor} editable={editable} onChange={onChange}>
             <CommandView editor={editor} />
             <ReferenceView
+                currentNoteId={currentNoteId}
                 onClick={(content) => {
                     editor.insertInlineContent([content, ' ']);
                 }}

--- a/packages/client/src/pages/Note.tsx
+++ b/packages/client/src/pages/Note.tsx
@@ -249,6 +249,7 @@ function NoteContent({ id }: NoteContentProps) {
                     key={`${id}:${note.updatedAt}`}
                     ref={editorRef}
                     content={note.content}
+                    currentNoteId={id}
                     onChange={handleChange}
                 />
 


### PR DESCRIPTION
## :dart: Goal
- Prevent the current note from being suggested when inserting a `[` reference inside the editor.
- Avoid self-references from the inline reference suggestion menu while keeping the rest of the suggestion flow unchanged.

## :hammer_and_wrench: Core Changes
- Passed the active note id from the note page into the editor and reference suggestion controller.
- Filtered reference suggestion results so the note currently being edited is excluded before rendering menu items.
- Added a small client-side test for the filtering behavior.

## :brain: Key Decisions
- Kept this as a client-side filter because the note editor already knows the active note id, and the existing `fetchNotes` API response is enough to exclude self-references.
- Did not change server search behavior or deduplicate other reference suggestions; only the self-reference case is handled.

## :test_tube: Verification Guide
### How to verify
1. Open any note editor page.
2. Type `[` and search for the current note title.
3. Confirm the current note does not appear in the reference suggestions, while other notes still do.

### Expected result
- The active note is excluded from the `[` reference suggestion list.
- Other note suggestions still appear and can be inserted normally.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [ ] Documentation updated (if needed)
