### PR TITLE
🐛 Surface MCP note changes in the browser

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -59,6 +59,7 @@
         "@vitejs/plugin-react": "^5.1.4",
         "@vitest/coverage-v8": "^4.0.18",
         "jsdom": "^25.0.1",
+        "react-grab": "^0.1.32",
         "tailwindcss": "^4.1.18",
         "typescript": "^5.9.3",
         "vite": "^7.3.2",

--- a/packages/client/src/components/app/Providers/Providers.tsx
+++ b/packages/client/src/components/app/Providers/Providers.tsx
@@ -5,6 +5,7 @@ import { ConfirmProvider } from '~/components/ui/Confirm';
 import { ToastProvider } from '~/components/ui/Toast';
 
 import queryClient from './configs/query-client';
+import ServerEventBridge from './ServerEventBridge';
 
 interface ProvidersProps {
     children?: React.ReactNode;
@@ -14,7 +15,10 @@ const Providers = ({ children }: ProvidersProps) => {
     return (
         <QueryClientProvider client={queryClient}>
             <ConfirmProvider>
-                <ToastProvider>{children}</ToastProvider>
+                <ToastProvider>
+                    <ServerEventBridge />
+                    {children}
+                </ToastProvider>
             </ConfirmProvider>
         </QueryClientProvider>
     );

--- a/packages/client/src/components/app/Providers/ServerEventBridge.tsx
+++ b/packages/client/src/components/app/Providers/ServerEventBridge.tsx
@@ -1,0 +1,61 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useEffect } from 'react';
+import { invalidateQueriesForServerEvent } from '~/modules/server-event-invalidation';
+import {
+    MCP_NOTE_SERVER_EVENT_TYPES,
+    type McpNoteServerEventType,
+    parseServerEvent,
+    publishServerEvent,
+} from '~/modules/server-events';
+
+const createServerEventListener = (
+    queryClient: ReturnType<typeof useQueryClient>,
+    expectedType: McpNoteServerEventType,
+): EventListener => {
+    return (event) => {
+        if (!(event instanceof MessageEvent) || typeof event.data !== 'string') {
+            return;
+        }
+
+        const serverEvent = parseServerEvent(event.data);
+
+        if (!serverEvent || serverEvent.type !== expectedType) {
+            return;
+        }
+
+        publishServerEvent(serverEvent);
+        void invalidateQueriesForServerEvent(queryClient, serverEvent);
+    };
+};
+
+const ServerEventBridge = () => {
+    const queryClient = useQueryClient();
+
+    useEffect(() => {
+        if (typeof EventSource === 'undefined') {
+            return;
+        }
+
+        const eventSource = new EventSource('/api/events');
+        const cleanupListeners = MCP_NOTE_SERVER_EVENT_TYPES.map((eventType) => {
+            const listener = createServerEventListener(queryClient, eventType);
+
+            eventSource.addEventListener(eventType, listener);
+
+            return () => {
+                eventSource.removeEventListener(eventType, listener);
+            };
+        });
+
+        return () => {
+            cleanupListeners.forEach((cleanup) => {
+                cleanup();
+            });
+            eventSource.close();
+        };
+    }, [queryClient]);
+
+    return null;
+};
+
+export default ServerEventBridge;

--- a/packages/client/src/components/shared/Callout/Callout.tsx
+++ b/packages/client/src/components/shared/Callout/Callout.tsx
@@ -9,9 +9,9 @@ interface CalloutProps {
 const Callout = ({ children, className = '' }: CalloutProps) => {
     return (
         <div
-            className={`flex items-start gap-2.5 rounded-[12px] border border-border-subtle bg-hover-subtle/50 px-4 py-3 ${className}`}
+            className={`flex items-center gap-2.5 rounded-[12px] border border-border-subtle bg-hover-subtle/50 px-4 py-3 ${className}`}
         >
-            <Icon.Info className="mt-0.5 h-4 w-4 shrink-0 text-fg-tertiary" />
+            <Icon.Info className="h-4 w-4 shrink-0 text-fg-tertiary" />
             <Text as="div" variant="meta" weight="medium" tone="secondary">
                 {children}
             </Text>

--- a/packages/client/src/main.tsx
+++ b/packages/client/src/main.tsx
@@ -9,6 +9,10 @@ import { initializeTheme } from './store/theme-dom.ts';
 import './styles/main.scss';
 import './styles/tailwind.css';
 
+if (import.meta.env.DEV) {
+    void import('react-grab');
+}
+
 useTheme.setState({ theme: initializeTheme() });
 
 ReactDOM.createRoot(document.getElementById('root')!).render(

--- a/packages/client/src/modules/query-key-factory.ts
+++ b/packages/client/src/modules/query-key-factory.ts
@@ -70,6 +70,7 @@ export const queryKeys = {
                 },
             ] as const,
         pinned: () => ['notes', 'pinned'] as const,
+        backReferencesAll: () => ['notes', 'back-references'] as const,
         backReferences: (noteId: string) => ['notes', 'back-references', { noteId }] as const,
         graph: () => ['notes', 'graph'] as const,
     },
@@ -151,6 +152,7 @@ export const queryKeys = {
             ] as const,
     },
     calendar: {
+        all: () => ['calendar'] as const,
         notesInDateRange: (year: number, month: number) =>
             [
                 'calendar',

--- a/packages/client/src/modules/server-event-invalidation.spec.ts
+++ b/packages/client/src/modules/server-event-invalidation.spec.ts
@@ -1,0 +1,75 @@
+import type { QueryClient } from '@tanstack/react-query';
+import { describe, expect, it, vi } from 'vitest';
+import { queryKeys } from './query-key-factory';
+import { invalidateQueriesForServerEvent } from './server-event-invalidation';
+
+const createQueryClientMock = () => {
+    return {
+        invalidateQueries: vi.fn().mockResolvedValue(undefined),
+    } as unknown as QueryClient;
+};
+
+describe('server-event-invalidation', () => {
+    it('invalidates note collection queries for MCP note updates', async () => {
+        const queryClient = createQueryClientMock();
+
+        await invalidateQueriesForServerEvent(queryClient, {
+            type: 'mcp.note.updated',
+            source: 'mcp',
+            noteId: '7',
+            updatedAt: '2026-04-14T00:00:00.000Z',
+        });
+
+        expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+            queryKey: queryKeys.notes.listAll(),
+            exact: false,
+        });
+        expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+            queryKey: queryKeys.notes.tagListAll(),
+            exact: false,
+        });
+        expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+            queryKey: queryKeys.notes.pinned(),
+            exact: true,
+        });
+        expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+            queryKey: queryKeys.notes.backReferencesAll(),
+            exact: false,
+        });
+        expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+            queryKey: queryKeys.notes.graph(),
+            exact: true,
+        });
+        expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+            queryKey: queryKeys.tags.all(),
+            exact: false,
+        });
+    });
+
+    it('invalidates trash-related queries for MCP note deletes', async () => {
+        const queryClient = createQueryClientMock();
+
+        await invalidateQueriesForServerEvent(queryClient, {
+            type: 'mcp.note.deleted',
+            source: 'mcp',
+            noteId: '11',
+        });
+
+        expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+            queryKey: queryKeys.notes.trashAll(),
+            exact: false,
+        });
+        expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+            queryKey: queryKeys.reminders.all(),
+            exact: false,
+        });
+        expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+            queryKey: queryKeys.images.all(),
+            exact: false,
+        });
+        expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+            queryKey: queryKeys.calendar.all(),
+            exact: false,
+        });
+    });
+});

--- a/packages/client/src/modules/server-event-invalidation.ts
+++ b/packages/client/src/modules/server-event-invalidation.ts
@@ -1,0 +1,81 @@
+import type { QueryClient } from '@tanstack/react-query';
+import { queryKeys } from './query-key-factory';
+import type { ServerEvent } from './server-events';
+
+export const invalidateQueriesForServerEvent = async (queryClient: QueryClient, event: ServerEvent) => {
+    switch (event.type) {
+        case 'mcp.note.created':
+        case 'mcp.note.updated':
+            await Promise.all([
+                queryClient.invalidateQueries({
+                    queryKey: queryKeys.notes.listAll(),
+                    exact: false,
+                }),
+                queryClient.invalidateQueries({
+                    queryKey: queryKeys.notes.tagListAll(),
+                    exact: false,
+                }),
+                queryClient.invalidateQueries({
+                    queryKey: queryKeys.notes.pinned(),
+                    exact: true,
+                }),
+                queryClient.invalidateQueries({
+                    queryKey: queryKeys.notes.backReferencesAll(),
+                    exact: false,
+                }),
+                queryClient.invalidateQueries({
+                    queryKey: queryKeys.notes.graph(),
+                    exact: true,
+                }),
+                queryClient.invalidateQueries({
+                    queryKey: queryKeys.tags.all(),
+                    exact: false,
+                }),
+            ]);
+            return;
+        case 'mcp.note.deleted':
+            await Promise.all([
+                queryClient.invalidateQueries({
+                    queryKey: queryKeys.notes.listAll(),
+                    exact: false,
+                }),
+                queryClient.invalidateQueries({
+                    queryKey: queryKeys.notes.tagListAll(),
+                    exact: false,
+                }),
+                queryClient.invalidateQueries({
+                    queryKey: queryKeys.notes.trashAll(),
+                    exact: false,
+                }),
+                queryClient.invalidateQueries({
+                    queryKey: queryKeys.notes.pinned(),
+                    exact: true,
+                }),
+                queryClient.invalidateQueries({
+                    queryKey: queryKeys.notes.backReferencesAll(),
+                    exact: false,
+                }),
+                queryClient.invalidateQueries({
+                    queryKey: queryKeys.notes.graph(),
+                    exact: true,
+                }),
+                queryClient.invalidateQueries({
+                    queryKey: queryKeys.tags.all(),
+                    exact: false,
+                }),
+                queryClient.invalidateQueries({
+                    queryKey: queryKeys.reminders.all(),
+                    exact: false,
+                }),
+                queryClient.invalidateQueries({
+                    queryKey: queryKeys.images.all(),
+                    exact: false,
+                }),
+                queryClient.invalidateQueries({
+                    queryKey: queryKeys.calendar.all(),
+                    exact: false,
+                }),
+            ]);
+            return;
+    }
+};

--- a/packages/client/src/modules/server-events.spec.ts
+++ b/packages/client/src/modules/server-events.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest';
+import { parseServerEvent, publishServerEvent, subscribeServerEvent } from './server-events';
+
+describe('server-events', () => {
+    it('parses valid MCP note events', () => {
+        expect(
+            parseServerEvent(
+                JSON.stringify({
+                    type: 'mcp.note.updated',
+                    source: 'mcp',
+                    noteId: '7',
+                    updatedAt: '2026-04-14T00:00:00.000Z',
+                }),
+            ),
+        ).toEqual({
+            type: 'mcp.note.updated',
+            source: 'mcp',
+            noteId: '7',
+            updatedAt: '2026-04-14T00:00:00.000Z',
+        });
+    });
+
+    it('ignores invalid event payloads', () => {
+        expect(parseServerEvent('{"type":"mcp.note.updated"}')).toBeNull();
+        expect(parseServerEvent('not-json')).toBeNull();
+    });
+
+    it('publishes events to subscribers', () => {
+        const listener = vi.fn();
+        const unsubscribe = subscribeServerEvent(listener);
+
+        publishServerEvent({
+            type: 'mcp.note.deleted',
+            source: 'mcp',
+            noteId: '11',
+        });
+
+        unsubscribe();
+
+        expect(listener).toHaveBeenCalledWith({
+            type: 'mcp.note.deleted',
+            source: 'mcp',
+            noteId: '11',
+        });
+    });
+});

--- a/packages/client/src/modules/server-events.ts
+++ b/packages/client/src/modules/server-events.ts
@@ -1,0 +1,84 @@
+export const MCP_NOTE_SERVER_EVENT_TYPES = ['mcp.note.created', 'mcp.note.updated', 'mcp.note.deleted'] as const;
+
+export type McpNoteServerEventType = (typeof MCP_NOTE_SERVER_EVENT_TYPES)[number];
+
+interface BaseMcpNoteServerEvent {
+    noteId: string;
+    source: 'mcp';
+}
+
+export interface McpNoteCreatedServerEvent extends BaseMcpNoteServerEvent {
+    type: 'mcp.note.created';
+    updatedAt: string;
+}
+
+export interface McpNoteUpdatedServerEvent extends BaseMcpNoteServerEvent {
+    type: 'mcp.note.updated';
+    updatedAt: string;
+}
+
+export interface McpNoteDeletedServerEvent extends BaseMcpNoteServerEvent {
+    type: 'mcp.note.deleted';
+}
+
+export type ServerEvent = McpNoteCreatedServerEvent | McpNoteUpdatedServerEvent | McpNoteDeletedServerEvent;
+
+type ServerEventListener = (event: ServerEvent) => void;
+
+const serverEventListeners = new Set<ServerEventListener>();
+
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+    return typeof value === 'object' && value !== null;
+};
+
+const isMcpNoteServerEvent = (value: unknown): value is ServerEvent => {
+    if (
+        !isRecord(value) ||
+        value.source !== 'mcp' ||
+        typeof value.noteId !== 'string' ||
+        typeof value.type !== 'string'
+    ) {
+        return false;
+    }
+
+    if (value.type === 'mcp.note.deleted') {
+        return true;
+    }
+
+    if (
+        (value.type === 'mcp.note.created' || value.type === 'mcp.note.updated') &&
+        typeof value.updatedAt === 'string'
+    ) {
+        return true;
+    }
+
+    return false;
+};
+
+export const parseServerEvent = (raw: string) => {
+    try {
+        const parsed = JSON.parse(raw);
+
+        if (!isMcpNoteServerEvent(parsed)) {
+            return null;
+        }
+
+        return parsed;
+    } catch {
+        return null;
+    }
+};
+
+export const publishServerEvent = (event: ServerEvent) => {
+    serverEventListeners.forEach((listener) => {
+        listener(event);
+    });
+};
+
+export const subscribeServerEvent = (listener: ServerEventListener) => {
+    serverEventListeners.add(listener);
+
+    return () => {
+        serverEventListeners.delete(listener);
+    };
+};

--- a/packages/client/src/pages/Note.tsx
+++ b/packages/client/src/pages/Note.tsx
@@ -9,7 +9,7 @@ import { BackReferences } from '~/components/entities';
 import * as Icon from '~/components/icon';
 import { LayoutModal, RestoreSnapshotModal } from '~/components/note';
 import { ReminderPanel } from '~/components/reminder';
-import { AuxiliaryPanelHeader, Button, Dropdown, PageLayout, Skeleton } from '~/components/shared';
+import { AuxiliaryPanelHeader, Button, Callout, Dropdown, PageLayout, Skeleton } from '~/components/shared';
 import type { EditorRef } from '~/components/shared/Editor';
 import Editor from '~/components/shared/Editor';
 import { Text, useToast } from '~/components/ui';
@@ -17,6 +17,7 @@ import useNoteMutate from '~/hooks/resource/useNoteMutate';
 import useDebounce from '~/hooks/useDebounce';
 import type { NoteLayout } from '~/models/note.model';
 import { queryKeys } from '~/modules/query-key-factory';
+import { subscribeServerEvent } from '~/modules/server-events';
 import { NOTE_ROUTE, SETTINGS_TRASH_ROUTE } from '~/modules/url';
 
 const Route = getRouteApi(NOTE_ROUTE);
@@ -52,6 +53,8 @@ interface NoteContentProps {
     id: string;
 }
 
+type ExternalNoteChange = { type: 'updated'; updatedAt: string } | { type: 'deleted' };
+
 function NoteContent({ id }: NoteContentProps) {
     const toast = useToast();
     const navigate = Route.useNavigate();
@@ -59,7 +62,7 @@ function NoteContent({ id }: NoteContentProps) {
     const titleRef = useRef<HTMLInputElement>(null);
     const editSessionIdRef = useRef<string>(createEditSessionId());
 
-    const { data: note } = useSuspenseQuery({
+    const noteQuery = useSuspenseQuery({
         queryKey: queryKeys.notes.detail(id),
         queryFn: async () => {
             const response = await fetchNote(id);
@@ -70,6 +73,7 @@ function NoteContent({ id }: NoteContentProps) {
         },
         gcTime: 0,
     });
+    const note = noteQuery.data;
 
     const [title, setTitle] = useState(note.title);
     const [lastSavedAt, setLastSavedAt] = useState(() => formatSavedAt(note.updatedAt));
@@ -77,6 +81,7 @@ function NoteContent({ id }: NoteContentProps) {
     const [layout, setLayout] = useState<NoteLayout>(note.layout || 'wide');
     const [isLayoutModalOpen, setIsLayoutModalOpen] = useState(false);
     const [isRestoreModalOpen, setIsRestoreModalOpen] = useState(false);
+    const [externalNoteChange, setExternalNoteChange] = useState<ExternalNoteChange | null>(null);
     const [isMountedEvent, mountEvent] = useDebounce(1000);
 
     useEffect(() => {
@@ -88,7 +93,42 @@ function NoteContent({ id }: NoteContentProps) {
 
     useEffect(() => {
         editSessionIdRef.current = createEditSessionId();
+        setExternalNoteChange(null);
     }, [id]);
+
+    useEffect(() => {
+        setExternalNoteChange((current) => {
+            if (current?.type === 'updated' && current.updatedAt === note.updatedAt) {
+                return null;
+            }
+
+            return current;
+        });
+    }, [note.updatedAt]);
+
+    useEffect(() => {
+        return subscribeServerEvent((event) => {
+            if (event.noteId !== id) {
+                return;
+            }
+
+            if (event.type === 'mcp.note.updated') {
+                if (event.updatedAt === note.updatedAt) {
+                    return;
+                }
+
+                setExternalNoteChange({
+                    type: 'updated',
+                    updatedAt: event.updatedAt,
+                });
+                return;
+            }
+
+            if (event.type === 'mcp.note.deleted') {
+                setExternalNoteChange({ type: 'deleted' });
+            }
+        });
+    }, [id, note.updatedAt]);
 
     const save = async ({ title: nextTitle = '', content = '' }) => {
         mountEvent(async () => {
@@ -138,6 +178,17 @@ function NoteContent({ id }: NoteContentProps) {
 
         setLayout(newLayout);
         toast('Layout has been updated.');
+    };
+
+    const handleReloadExternalChange = async () => {
+        const response = await noteQuery.refetch();
+
+        if (response.error || !response.data) {
+            toast('Failed to reload the latest note state.');
+            return;
+        }
+
+        setExternalNoteChange(null);
     };
 
     const { onCreate, onDelete, onPinned } = useNoteMutate();
@@ -244,6 +295,45 @@ function NoteContent({ id }: NoteContentProps) {
                         </div>
                     </div>
                 </div>
+
+                {externalNoteChange && (
+                    <Callout className="mb-6">
+                        <div className="flex w-full flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                            <span>
+                                {externalNoteChange.type === 'updated'
+                                    ? 'This note changed in MCP. Reload to review the latest version.'
+                                    : 'This note was moved to trash from MCP. Open trash to review it.'}
+                            </span>
+                            {externalNoteChange.type === 'updated' ? (
+                                <Button
+                                    type="button"
+                                    size="sm"
+                                    variant="subtle"
+                                    className="self-start"
+                                    isLoading={noteQuery.isRefetching}
+                                    onClick={handleReloadExternalChange}
+                                >
+                                    Reload
+                                </Button>
+                            ) : (
+                                <Button
+                                    type="button"
+                                    size="sm"
+                                    variant="subtle"
+                                    className="self-start"
+                                    onClick={() =>
+                                        navigate({
+                                            to: SETTINGS_TRASH_ROUTE,
+                                            search: { page: 1 },
+                                        })
+                                    }
+                                >
+                                    Open trash
+                                </Button>
+                            )}
+                        </div>
+                    </Callout>
+                )}
 
                 <Editor
                     key={`${id}:${note.updatedAt}`}

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -1,7 +1,12 @@
 import express from 'express';
 import { createHandler } from 'graphql-http/lib/use/express';
 import path from 'path';
-import { createSessionMiddleware, isAuthenticatedRequest, requireSessionForGraphql } from './modules/auth-guard.js';
+import {
+    createSessionMiddleware,
+    isAuthenticatedRequest,
+    requireSessionForGraphql,
+    requireSessionForWrite,
+} from './modules/auth-guard.js';
 import type { AuthConfig } from './modules/auth-mode.js';
 import { createErrorHandler } from './modules/error-handler.js';
 import logger from './modules/logger.js';
@@ -15,6 +20,7 @@ import schema from './schema/index.js';
 import { createApiRouter } from './urls.js';
 import { createLoginPageHandler, createLoginPageSubmitHandler, createLogoutPageHandler } from './views/auth.js';
 import { createMcpCreateNoteHandler, createMcpDeleteNoteHandler, createMcpUpdateNoteHandler } from './views/note.js';
+import { createServerEventsHandler } from './views/server-events.js';
 import { createMcpCreateTagHandler } from './views/tag.js';
 
 const shouldBlockClientRoute = (authConfig: AuthConfig, requestPath: string, authenticated: boolean) => {
@@ -68,6 +74,7 @@ export const createAppWithMcpAuth = (authConfig: AuthConfig, mcpAdminService: Mc
             createMcpAuthMiddleware(authConfig, mcpAdminService),
             useAsync(createMcpDeleteNoteHandler()),
         )
+        .get('/api/events', requireSessionForWrite(authConfig), createServerEventsHandler())
         .use('/api', createApiRouter(authConfig, mcpAdminService))
         .get('/auth/login', createLoginPageHandler(authConfig))
         .post('/auth/login', createLoginPageSubmitHandler(authConfig))

--- a/packages/server/src/modules/server-events.ts
+++ b/packages/server/src/modules/server-events.ts
@@ -1,0 +1,63 @@
+import { EventEmitter } from 'node:events';
+
+export type McpNoteServerEventType = 'mcp.note.created' | 'mcp.note.updated' | 'mcp.note.deleted';
+
+interface BaseMcpNoteServerEvent {
+    id: string;
+    noteId: string;
+    source: 'mcp';
+}
+
+export interface McpNoteCreatedServerEvent extends BaseMcpNoteServerEvent {
+    type: 'mcp.note.created';
+    updatedAt: string;
+}
+
+export interface McpNoteUpdatedServerEvent extends BaseMcpNoteServerEvent {
+    type: 'mcp.note.updated';
+    updatedAt: string;
+}
+
+export interface McpNoteDeletedServerEvent extends BaseMcpNoteServerEvent {
+    type: 'mcp.note.deleted';
+}
+
+export type ServerEvent = McpNoteCreatedServerEvent | McpNoteUpdatedServerEvent | McpNoteDeletedServerEvent;
+
+export type ServerEventInput =
+    | Omit<McpNoteCreatedServerEvent, 'id'>
+    | Omit<McpNoteUpdatedServerEvent, 'id'>
+    | Omit<McpNoteDeletedServerEvent, 'id'>;
+
+type ServerEventListener = (event: ServerEvent) => void;
+
+const SERVER_EVENT_CHANNEL = 'server-event';
+
+const serverEventEmitter = new EventEmitter();
+
+serverEventEmitter.setMaxListeners(0);
+
+let nextServerEventId = 1;
+
+export const emitServerEvent = (event: ServerEventInput) => {
+    const nextEvent = {
+        id: String(nextServerEventId++),
+        ...event,
+    } as ServerEvent;
+
+    serverEventEmitter.emit(SERVER_EVENT_CHANNEL, nextEvent);
+
+    return nextEvent;
+};
+
+export const subscribeServerEvents = (listener: ServerEventListener) => {
+    serverEventEmitter.on(SERVER_EVENT_CHANNEL, listener);
+
+    return () => {
+        serverEventEmitter.off(SERVER_EVENT_CHANNEL, listener);
+    };
+};
+
+export const serializeServerEvent = (event: ServerEvent) => {
+    return `id: ${event.id}\nevent: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`;
+};

--- a/packages/server/src/views/note.ts
+++ b/packages/server/src/views/note.ts
@@ -7,6 +7,7 @@ import {
 } from '~/modules/note-authoring.js';
 import { deleteNoteById } from '~/modules/note-cleanup.js';
 import { MCP_SNAPSHOT_META } from '~/modules/note-snapshot.js';
+import { emitServerEvent, type ServerEventInput } from '~/modules/server-events.js';
 import type { Controller } from '~/types/index.js';
 
 const NOTE_LAYOUTS = new Set<NoteLayout>(['narrow', 'wide', 'full']);
@@ -23,7 +24,12 @@ const resolveNoteLayout = (value: unknown): NoteLayout | null | undefined => {
     return null;
 };
 
-export const createMcpCreateNoteHandler = (createNote = createNoteFromMarkdown): Controller => {
+type EmitServerEvent = (event: ServerEventInput) => unknown;
+
+export const createMcpCreateNoteHandler = (
+    createNote = createNoteFromMarkdown,
+    emitEvent: EmitServerEvent = emitServerEvent,
+): Controller => {
     return async (req, res) => {
         const { title, markdown, layout } = req.body ?? {};
         const resolvedLayout = resolveNoteLayout(layout);
@@ -47,6 +53,13 @@ export const createMcpCreateNoteHandler = (createNote = createNoteFromMarkdown):
                 ...(resolvedLayout ? { layout: resolvedLayout } : {}),
             });
 
+            emitEvent({
+                type: 'mcp.note.created',
+                source: 'mcp',
+                noteId: note.id,
+                updatedAt: note.updatedAt,
+            });
+
             res.status(200)
                 .json({
                     created: true,
@@ -63,7 +76,10 @@ export const createMcpCreateNoteHandler = (createNote = createNoteFromMarkdown):
     };
 };
 
-export const createMcpUpdateNoteHandler = (updateNote = updateNoteFromMarkdown): Controller => {
+export const createMcpUpdateNoteHandler = (
+    updateNote = updateNoteFromMarkdown,
+    emitEvent: EmitServerEvent = emitServerEvent,
+): Controller => {
     return async (req, res) => {
         const { id, title, markdown, layout, editSessionId } = req.body ?? {};
         const noteId = Number(id);
@@ -107,6 +123,13 @@ export const createMcpUpdateNoteHandler = (updateNote = updateNoteFromMarkdown):
                 throw createAppError(404, 'NOTE_NOT_FOUND', 'The requested note was not found.');
             }
 
+            emitEvent({
+                type: 'mcp.note.updated',
+                source: 'mcp',
+                noteId: note.id,
+                updatedAt: note.updatedAt,
+            });
+
             res.status(200)
                 .json({
                     updated: true,
@@ -123,7 +146,10 @@ export const createMcpUpdateNoteHandler = (updateNote = updateNoteFromMarkdown):
     };
 };
 
-export const createMcpDeleteNoteHandler = (deleteNote = deleteNoteById): Controller => {
+export const createMcpDeleteNoteHandler = (
+    deleteNote = deleteNoteById,
+    emitEvent: EmitServerEvent = emitServerEvent,
+): Controller => {
     return async (req, res) => {
         const id = Number(req.body?.id);
 
@@ -136,6 +162,12 @@ export const createMcpDeleteNoteHandler = (deleteNote = deleteNoteById): Control
         if (!deletedNote) {
             throw createAppError(404, 'NOTE_NOT_FOUND', 'The requested note was not found.');
         }
+
+        emitEvent({
+            type: 'mcp.note.deleted',
+            source: 'mcp',
+            noteId: deletedNote.id,
+        });
 
         res.status(200)
             .json({

--- a/packages/server/src/views/server-events.ts
+++ b/packages/server/src/views/server-events.ts
@@ -1,0 +1,39 @@
+import { serializeServerEvent, subscribeServerEvents } from '~/modules/server-events.js';
+import type { Controller } from '~/types/index.js';
+
+const KEEP_ALIVE_INTERVAL_MS = 30_000;
+
+export const createServerEventsHandler = (): Controller => {
+    return async (req, res) => {
+        res.status(200);
+        res.setHeader('Content-Type', 'text/event-stream; charset=utf-8');
+        res.setHeader('Cache-Control', 'no-cache, no-transform');
+        res.setHeader('Connection', 'keep-alive');
+        res.setHeader('X-Accel-Buffering', 'no');
+        res.flushHeaders?.();
+        res.write(': connected\n\n');
+
+        const unsubscribe = subscribeServerEvents((event) => {
+            res.write(serializeServerEvent(event));
+        });
+
+        const keepAliveTimer = setInterval(() => {
+            res.write(': keepalive\n\n');
+        }, KEEP_ALIVE_INTERVAL_MS);
+
+        let cleanedUp = false;
+
+        const cleanup = () => {
+            if (cleanedUp) {
+                return;
+            }
+
+            cleanedUp = true;
+            clearInterval(keepAliveTimer);
+            unsubscribe();
+        };
+
+        req.on('close', cleanup);
+        res.on('close', cleanup);
+    };
+};

--- a/packages/server/test/mcp-auth.test.ts
+++ b/packages/server/test/mcp-auth.test.ts
@@ -87,6 +87,14 @@ const createNoteRequest = async (baseUrl: string, body: Record<string, unknown>,
     };
 };
 
+const connectServerEvents = async (baseUrl: string) => {
+    return fetch(`${baseUrl}/api/events`, {
+        headers: {
+            Accept: 'text/event-stream',
+        },
+    });
+};
+
 const updateNoteRequest = async (baseUrl: string, body: Record<string, unknown>, bearerToken?: string) => {
     const response = await fetch(`${baseUrl}/api/mcp/notes/update`, {
         method: 'POST',
@@ -169,6 +177,44 @@ test('password mode requires a valid bearer token on the MCP graphql endpoint', 
     const authorized = await graphRequest(baseUrl, '/graphql/mcp', 'query { __typename }', 'mcp-secret');
     assert.equal(authorized.status, 200);
     assert.equal((authorized.body.data as { __typename?: string }).__typename, 'Query');
+});
+
+test('password mode requires a session on the server events endpoint', async (t) => {
+    const { baseUrl } = await startServer(
+        t,
+        {
+            mode: 'password',
+            password: 'secret',
+            sessionSecret: 'session-secret',
+            source: 'override',
+        },
+        createMcpAdminAuth({ enabled: true, expectedToken: 'mcp-secret' }),
+    );
+
+    const response = await connectServerEvents(baseUrl);
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(await response.json(), {
+        code: 'UNAUTHORIZED',
+        message: 'Authentication required',
+    });
+});
+
+test('disabled mode exposes the server events endpoint as an event stream', async (t) => {
+    const { baseUrl } = await startServer(
+        t,
+        {
+            mode: 'disabled',
+            source: 'override',
+        },
+        createMcpAdminAuth({ enabled: true, expectedToken: 'mcp-secret' }),
+    );
+
+    const response = await connectServerEvents(baseUrl);
+
+    assert.equal(response.status, 200);
+    assert.match(response.headers.get('content-type') ?? '', /^text\/event-stream/);
+    await response.body?.cancel();
 });
 
 test('password mode keeps the MCP graphql endpoint read-only even with a valid bearer token', async (t) => {

--- a/packages/server/test/mcp-delete-note-handler.test.ts
+++ b/packages/server/test/mcp-delete-note-handler.test.ts
@@ -86,3 +86,34 @@ test('mcp delete note handler returns the deleted note payload', async () => {
         },
     });
 });
+
+test('mcp delete note handler emits a deleted server event', async () => {
+    const emittedEvents: unknown[] = [];
+    const handler = createMcpDeleteNoteHandler(
+        async () => ({
+            id: '7',
+            title: 'Temp note',
+            updatedAt: '2026-03-30T00:00:00.000Z',
+            pinned: false,
+            tagNames: ['temp'],
+            reminderCount: 0,
+            backReferences: [],
+            orphanedTagNames: ['temp'],
+            requiresForce: true,
+            forceReasons: ['orphan_tags'],
+        }),
+        (event) => {
+            emittedEvents.push(event);
+        },
+    );
+
+    await handler({ body: { id: '7' } } as never, createResponse() as never);
+
+    assert.deepEqual(emittedEvents, [
+        {
+            type: 'mcp.note.deleted',
+            source: 'mcp',
+            noteId: '7',
+        },
+    ]);
+});

--- a/packages/server/test/mcp-note-authoring-handler.test.ts
+++ b/packages/server/test/mcp-note-authoring-handler.test.ts
@@ -78,6 +78,40 @@ test('mcp create note handler returns the created note payload', async () => {
     });
 });
 
+test('mcp create note handler emits a created server event', async () => {
+    const emittedEvents: unknown[] = [];
+    const handler = createMcpCreateNoteHandler(
+        async () => ({
+            id: '3',
+            title: 'Draft note',
+            layout: 'full',
+            createdAt: '2026-03-31T00:00:00.000Z',
+            updatedAt: '2026-03-31T00:00:00.000Z',
+        }),
+        (event) => {
+            emittedEvents.push(event);
+        },
+    );
+
+    await handler(
+        {
+            body: {
+                title: 'Draft note',
+            },
+        } as never,
+        createResponse() as never,
+    );
+
+    assert.deepEqual(emittedEvents, [
+        {
+            type: 'mcp.note.created',
+            source: 'mcp',
+            noteId: '3',
+            updatedAt: '2026-03-31T00:00:00.000Z',
+        },
+    ]);
+});
+
 test('mcp create note handler rejects invalid note layouts', async () => {
     const handler = createMcpCreateNoteHandler(async () => ({
         id: '1',
@@ -184,6 +218,41 @@ test('mcp update note handler returns the updated note payload', async () => {
             updatedAt: '2026-04-01T00:00:00.000Z',
         },
     });
+});
+
+test('mcp update note handler emits an updated server event', async () => {
+    const emittedEvents: unknown[] = [];
+    const handler = createMcpUpdateNoteHandler(
+        async () => ({
+            id: '7',
+            title: 'Renamed',
+            layout: 'wide',
+            createdAt: '2026-03-31T00:00:00.000Z',
+            updatedAt: '2026-04-01T00:00:00.000Z',
+        }),
+        (event) => {
+            emittedEvents.push(event);
+        },
+    );
+
+    await handler(
+        {
+            body: {
+                id: '7',
+                title: 'Renamed',
+            },
+        } as never,
+        createResponse() as never,
+    );
+
+    assert.deepEqual(emittedEvents, [
+        {
+            type: 'mcp.note.updated',
+            source: 'mcp',
+            noteId: '7',
+            updatedAt: '2026-04-01T00:00:00.000Z',
+        },
+    ]);
 });
 
 test('mcp update note handler rejects empty updates', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,6 +198,9 @@ importers:
       jsdom:
         specifier: ^25.0.1
         version: 25.0.1
+      react-grab:
+        specifier: ^0.1.32
+        version: 0.1.32(react@19.2.4)
       tailwindcss:
         specifier: ^4.1.18
         version: 4.2.1
@@ -276,6 +279,10 @@ packages:
 
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
+
+  '@antfu/ni@0.23.2':
+    resolution: {integrity: sha512-FSEVWXvwroExDXUu8qV6Wqp2X3D1nJ0Li4LFymCyvCVrm7I3lNfG0zZWSWvGU1RE7891eTnFTyh31L3igOwNKQ==}
+    hasBin: true
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
@@ -1872,6 +1879,10 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@react-grab/cli@0.1.32':
+    resolution: {integrity: sha512-TI4SHATLH2yM1DMRXgH3dt/8b3Rj51BplDOqOQiHQKAMOuKVAR9WE2WGWJRT3LwFpl8BXR9ytAM9vrGDrB7QGw==}
+    hasBin: true
+
   '@remirror/core-constants@3.0.0':
     resolution: {integrity: sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==}
 
@@ -2542,6 +2553,10 @@ packages:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
   ansi-styles@3.2.1:
     resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
     engines: {node: '>=4'}
@@ -2641,6 +2656,11 @@ packages:
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
 
+  bippy@0.5.39:
+    resolution: {integrity: sha512-8hE8rKSl8JWyeaY+JjpnmceWAZPpLEyzOZQpWXM5Rc7861c5WotMJHy2aRZKZrGA8nMpvLNF01t4yQQ+HcZG3w==}
+    peerDependencies:
+      react: '>=17.0.1'
+
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
@@ -2727,6 +2747,10 @@ packages:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
     engines: {node: '>=4'}
 
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
 
@@ -2769,6 +2793,14 @@ packages:
 
   clean-stack@2.2.0:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
+    engines: {node: '>=6'}
+
+  cli-cursor@5.0.0:
+    resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
+    engines: {node: '>=18'}
+
+  cli-spinners@2.9.2:
+    resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
     engines: {node: '>=6'}
 
   clsx@2.1.1:
@@ -3080,6 +3112,9 @@ packages:
   emoji-mart@5.6.0:
     resolution: {integrity: sha512-eJp3QRe79pjwa+duv+n7+5YsNhRcMl812EcFVwrnRvYKoNPoQb5qxU8DG6Bgwji0akHdp6D4Ln6tYLG58MFSow==}
 
+  emoji-regex@10.6.0:
+    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
@@ -3332,6 +3367,10 @@ packages:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
+  get-east-asian-width@1.5.0:
+    resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
+    engines: {node: '>=18'}
+
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
@@ -3516,6 +3555,10 @@ packages:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
 
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
+    engines: {node: '>= 4'}
+
   immutable@5.1.5:
     resolution: {integrity: sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==}
 
@@ -3583,6 +3626,10 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
+  is-interactive@2.0.0:
+    resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
+    engines: {node: '>=12'}
+
   is-lambda@1.0.1:
     resolution: {integrity: sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==}
 
@@ -3603,6 +3650,14 @@ packages:
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
+
+  is-unicode-supported@1.3.0:
+    resolution: {integrity: sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==}
+    engines: {node: '>=12'}
+
+  is-unicode-supported@2.1.0:
+    resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
+    engines: {node: '>=18'}
 
   isbot@5.1.35:
     resolution: {integrity: sha512-waFfC72ZNfwLLuJ2iLaoVaqcNo+CAaLR7xCpAn0Y5WfGzkNHv7ZN39Vbi1y+kb+Zs46XHOX3tZNExroFUPX+Kg==}
@@ -3679,9 +3734,16 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
+
   kapsule@1.16.3:
     resolution: {integrity: sha512-4+5mNNf4vZDSwPhKprKwz3330iisPrb08JyMgbsdFrimBCKNHecua/WBwvVg3n7vwx0C1ARjfhwIpbrbd9n5wg==}
     engines: {node: '>=12'}
+
+  kleur@3.0.3:
+    resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
+    engines: {node: '>=6'}
 
   kuler@2.0.0:
     resolution: {integrity: sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==}
@@ -3789,6 +3851,10 @@ packages:
 
   lodash@4.17.23:
     resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+
+  log-symbols@6.0.0:
+    resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
+    engines: {node: '>=18'}
 
   logform@2.7.0:
     resolution: {integrity: sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==}
@@ -4002,6 +4068,10 @@ packages:
     resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
     engines: {node: '>=18'}
 
+  mimic-function@5.0.1:
+    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
+    engines: {node: '>=18'}
+
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
@@ -4167,6 +4237,14 @@ packages:
   one-time@1.0.0:
     resolution: {integrity: sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==}
 
+  onetime@7.0.0:
+    resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
+    engines: {node: '>=18'}
+
+  ora@8.2.0:
+    resolution: {integrity: sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==}
+    engines: {node: '>=18'}
+
   orderedmap@2.1.1:
     resolution: {integrity: sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==}
 
@@ -4306,6 +4384,10 @@ packages:
   promise-retry@2.0.1:
     resolution: {integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==}
     engines: {node: '>=10'}
+
+  prompts@2.4.2:
+    resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
+    engines: {node: '>= 6'}
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
@@ -4472,6 +4554,15 @@ packages:
     peerDependencies:
       react: '*'
 
+  react-grab@0.1.32:
+    resolution: {integrity: sha512-ODZkzu4zjwX/5a1VxTdIkagPD6uPnp8IkSN2v5FDgFMZkH5r/YEMq43hIsdpHV5/R2ymqS9zLxp4H7SNSRx5ng==}
+    hasBin: true
+    peerDependencies:
+      react: '>=17.0.0'
+    peerDependenciesMeta:
+      react:
+        optional: true
+
   react-helmet@6.1.0:
     resolution: {integrity: sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==}
     peerDependencies:
@@ -4630,6 +4721,10 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
+  restore-cursor@5.1.0:
+    resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
+    engines: {node: '>=18'}
+
   retry@0.12.0:
     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
     engines: {node: '>= 4'}
@@ -4749,11 +4844,18 @@ packages:
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
   simple-concat@1.0.1:
     resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
 
   simple-get@4.0.1:
     resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
@@ -4762,6 +4864,10 @@ packages:
   smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+
+  smol-toml@1.6.1:
+    resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
+    engines: {node: '>= 18'}
 
   snake-case@3.0.4:
     resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
@@ -4805,9 +4911,17 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
+  stdin-discarder@0.2.2:
+    resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
+    engines: {node: '>=18'}
+
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
+
+  string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
@@ -4818,6 +4932,10 @@ packages:
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
 
   strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
@@ -5348,6 +5466,8 @@ packages:
 snapshots:
 
   '@adobe/css-tools@4.4.4': {}
+
+  '@antfu/ni@0.23.2': {}
 
   '@asamuzakjp/css-color@3.2.0':
     dependencies:
@@ -7032,6 +7152,17 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@react-grab/cli@0.1.32':
+    dependencies:
+      '@antfu/ni': 0.23.2
+      commander: 14.0.3
+      ignore: 7.0.5
+      jsonc-parser: 3.3.1
+      ora: 8.2.0
+      picocolors: 1.1.1
+      prompts: 2.4.2
+      smol-toml: 1.6.1
+
   '@remirror/core-constants@3.0.0': {}
 
   '@rolldown/pluginutils@1.0.0-rc.3': {}
@@ -7694,6 +7825,8 @@ snapshots:
 
   ansi-regex@5.0.1: {}
 
+  ansi-regex@6.2.2: {}
+
   ansi-styles@3.2.1:
     dependencies:
       color-convert: 1.9.3
@@ -7792,6 +7925,10 @@ snapshots:
   bindings@1.5.0:
     dependencies:
       file-uri-to-path: 1.0.0
+
+  bippy@0.5.39(react@19.2.4):
+    dependencies:
+      react: 19.2.4
 
   bl@4.1.0:
     dependencies:
@@ -7918,6 +8055,8 @@ snapshots:
       escape-string-regexp: 1.0.5
       supports-color: 5.5.0
 
+  chalk@5.6.2: {}
+
   character-entities-html4@2.1.0: {}
 
   character-entities-legacy@3.0.0: {}
@@ -7961,6 +8100,12 @@ snapshots:
 
   clean-stack@2.2.0:
     optional: true
+
+  cli-cursor@5.0.0:
+    dependencies:
+      restore-cursor: 5.1.0
+
+  cli-spinners@2.9.2: {}
 
   clsx@2.1.1: {}
 
@@ -8223,6 +8368,8 @@ snapshots:
   electron-to-chromium@1.5.286: {}
 
   emoji-mart@5.6.0: {}
+
+  emoji-regex@10.6.0: {}
 
   emoji-regex@8.0.0:
     optional: true
@@ -8547,6 +8694,8 @@ snapshots:
 
   gensync@1.0.0-beta.2: {}
 
+  get-east-asian-width@1.5.0: {}
+
   get-intrinsic@1.3.0:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -8832,6 +8981,8 @@ snapshots:
 
   ignore@5.3.2: {}
 
+  ignore@7.0.5: {}
+
   immutable@5.1.5: {}
 
   import-fresh@3.3.1:
@@ -8884,6 +9035,8 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
+  is-interactive@2.0.0: {}
+
   is-lambda@1.0.1:
     optional: true
 
@@ -8896,6 +9049,10 @@ snapshots:
   is-promise@4.0.0: {}
 
   is-stream@2.0.1: {}
+
+  is-unicode-supported@1.3.0: {}
+
+  is-unicode-supported@2.1.0: {}
 
   isbot@5.1.35: {}
 
@@ -8970,9 +9127,13 @@ snapshots:
 
   json5@2.2.3: {}
 
+  jsonc-parser@3.3.1: {}
+
   kapsule@1.16.3:
     dependencies:
       lodash-es: 4.17.23
+
+  kleur@3.0.3: {}
 
   kuler@2.0.0: {}
 
@@ -9048,6 +9209,11 @@ snapshots:
   lodash.merge@4.6.2: {}
 
   lodash@4.17.23: {}
+
+  log-symbols@6.0.0:
+    dependencies:
+      chalk: 5.6.2
+      is-unicode-supported: 1.3.0
 
   logform@2.7.0:
     dependencies:
@@ -9463,6 +9629,8 @@ snapshots:
     dependencies:
       mime-db: 1.54.0
 
+  mimic-function@5.0.1: {}
+
   mimic-response@3.1.0: {}
 
   min-indent@1.0.1: {}
@@ -9634,6 +9802,22 @@ snapshots:
     dependencies:
       fn.name: 1.1.0
 
+  onetime@7.0.0:
+    dependencies:
+      mimic-function: 5.0.1
+
+  ora@8.2.0:
+    dependencies:
+      chalk: 5.6.2
+      cli-cursor: 5.0.0
+      cli-spinners: 2.9.2
+      is-interactive: 2.0.0
+      is-unicode-supported: 2.1.0
+      log-symbols: 6.0.0
+      stdin-discarder: 0.2.2
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+
   orderedmap@2.1.1: {}
 
   p-map@4.0.0:
@@ -9760,6 +9944,11 @@ snapshots:
       err-code: 2.0.3
       retry: 0.12.0
     optional: true
+
+  prompts@2.4.2:
+    dependencies:
+      kleur: 3.0.3
+      sisteransi: 1.0.5
 
   prop-types@15.8.1:
     dependencies:
@@ -9943,6 +10132,13 @@ snapshots:
       prop-types: 15.8.1
       react: 19.2.4
       react-kapsule: 2.5.7(react@19.2.4)
+
+  react-grab@0.1.32(react@19.2.4):
+    dependencies:
+      '@react-grab/cli': 0.1.32
+      bippy: 0.5.39(react@19.2.4)
+    optionalDependencies:
+      react: 19.2.4
 
   react-helmet@6.1.0(react@19.2.4):
     dependencies:
@@ -10130,6 +10326,11 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
+  restore-cursor@5.1.0:
+    dependencies:
+      onetime: 7.0.0
+      signal-exit: 4.1.0
+
   retry@0.12.0:
     optional: true
 
@@ -10290,6 +10491,8 @@ snapshots:
   signal-exit@3.0.7:
     optional: true
 
+  signal-exit@4.1.0: {}
+
   simple-concat@1.0.1: {}
 
   simple-get@4.0.1:
@@ -10298,10 +10501,14 @@ snapshots:
       once: 1.4.0
       simple-concat: 1.0.1
 
+  sisteransi@1.0.5: {}
+
   slash@3.0.0: {}
 
   smart-buffer@4.2.0:
     optional: true
+
+  smol-toml@1.6.1: {}
 
   snake-case@3.0.4:
     dependencies:
@@ -10354,12 +10561,20 @@ snapshots:
 
   std-env@3.10.0: {}
 
+  stdin-discarder@0.2.2: {}
+
   string-width@4.2.3:
     dependencies:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
     optional: true
+
+  string-width@7.2.0:
+    dependencies:
+      emoji-regex: 10.6.0
+      get-east-asian-width: 1.5.0
+      strip-ansi: 7.2.0
 
   string_decoder@1.3.0:
     dependencies:
@@ -10374,6 +10589,10 @@ snapshots:
     dependencies:
       ansi-regex: 5.0.1
     optional: true
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
 
   strip-indent@3.0.0:
     dependencies:


### PR DESCRIPTION
## :dart: Goal
- Surface MCP-driven note create, update, and delete changes in the browser immediately.
- Refresh note lists right away while keeping the currently open note safe from silent overwrite.

## :hammer_and_wrench: Core Changes
- Added an in-memory SSE event bus and `/api/events` stream on the server.
- Emitted `mcp.note.created`, `mcp.note.updated`, and `mcp.note.deleted` events after MCP note mutations succeed.
- Added a global `EventSource` bridge on the client and invalidated only the related React Query cache keys.
- Kept the active note detail view on a safe path by showing an external-change notice with `Reload` / `Open trash` actions instead of auto-replacing the editor content.
- Adjusted `Callout` icon alignment so the new notice UI stays visually aligned.
- Loaded `react-grab` only in development via a dev-only import in `main.tsx`.

## :brain: Key Decisions
- Chose SSE over WebSocket or socket.io because this requirement only needs one-way freshness propagation from MCP to the browser.
- Did not auto-refresh the currently open note body because MCP changes could otherwise overwrite an in-progress browser draft.
- Scoped invalidation to MCP note create/update/delete only instead of expanding to tags, hero banner, or all GraphQL mutations in the same change.
- Kept `react-grab` out of production bundles by loading it only when `import.meta.env.DEV` is true.

## :test_tube: Verification Guide
### How to verify
1. `pnpm --filter @ocean-brain/client lint`
2. `pnpm --filter @ocean-brain/client type-check`
3. `pnpm --filter @ocean-brain/client test -- --run src/modules/server-events.spec.ts src/modules/server-event-invalidation.spec.ts`
4. `pnpm --filter @ocean-brain/server lint`
5. `pnpm --filter @ocean-brain/server test -- mcp-note-authoring-handler.test.ts mcp-delete-note-handler.test.ts mcp-auth.test.ts`
6. Run a local manual check.
7. Call `POST /api/mcp-admin/token/rotate` to issue a token.
8. Call `POST /api/mcp/notes/create`, `POST /api/mcp/notes/update`, and `POST /api/mcp/notes/delete`.
9. Confirm the matching SSE events arrive through `/api/events`.
10. Confirm note lists refresh immediately and the active note detail view shows the external-change notice with `Reload`.

### Expected result
- MCP note create, update, and delete events propagate to the browser immediately.
- Note list surfaces refresh without a full-app refetch.
- The currently open note stays protected from silent overwrite and shows a clear external-change notice.
- `react-grab` loads only in development.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)