### PR TITLE
♻️ Split server route composition

### DIFF
--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -1,39 +1,12 @@
 import express from 'express';
-import { createHandler } from 'graphql-http/lib/use/express';
-import path from 'path';
-import {
-    createSessionMiddleware,
-    isAuthenticatedRequest,
-    requireSessionForGraphql,
-    requireSessionForWrite,
-} from './modules/auth-guard.js';
+import { createSessionMiddleware } from './modules/auth-guard.js';
 import type { AuthConfig } from './modules/auth-mode.js';
 import { createErrorHandler } from './modules/error-handler.js';
 import logger from './modules/logger.js';
 import { createMcpAdminService, type McpAdminService } from './modules/mcp-admin.js';
-import { createMcpAuthMiddleware, createReadOnlyMcpValidationRule } from './modules/mcp-auth.js';
 import { purgeExpiredNoteSnapshots } from './modules/note-snapshot.js';
 import { purgeExpiredTrashedNotes } from './modules/note-trash.js';
-import useAsync from './modules/use-async.js';
-import { paths } from './paths.js';
-import schema from './schema/index.js';
-import { createApiRouter } from './urls.js';
-import { createLoginPageHandler, createLoginPageSubmitHandler, createLogoutPageHandler } from './views/auth.js';
-import { createMcpCreateNoteHandler, createMcpDeleteNoteHandler, createMcpUpdateNoteHandler } from './views/note.js';
-import { createServerEventsHandler } from './views/server-events.js';
-import { createMcpCreateTagHandler } from './views/tag.js';
-
-const shouldBlockClientRoute = (authConfig: AuthConfig, requestPath: string, authenticated: boolean) => {
-    if (authConfig.mode !== 'password' || authenticated) {
-        return false;
-    }
-
-    if (requestPath.startsWith('/api') || requestPath.startsWith('/graphql') || requestPath.startsWith('/auth')) {
-        return false;
-    }
-
-    return path.extname(requestPath) === '';
-};
+import { createApiRouter, createAuthPagesRouter, createClientRouter, createGraphqlRouter } from './routes/index.js';
 
 export const createApp = (authConfig: AuthConfig) => {
     const mcpAdminService = createMcpAdminService();
@@ -53,74 +26,10 @@ export const createAppWithMcpAuth = (authConfig: AuthConfig, mcpAdminService: Mc
         .use(createSessionMiddleware(authConfig))
         .use(express.urlencoded({ extended: false }))
         .use(express.json({ limit: '50mb' }))
-        .use('/assets/images/', express.static(paths.imageDir))
-        .post(
-            '/api/mcp/notes/create',
-            createMcpAuthMiddleware(authConfig, mcpAdminService),
-            useAsync(createMcpCreateNoteHandler()),
-        )
-        .post(
-            '/api/mcp/notes/update',
-            createMcpAuthMiddleware(authConfig, mcpAdminService),
-            useAsync(createMcpUpdateNoteHandler()),
-        )
-        .post(
-            '/api/mcp/tags/create',
-            createMcpAuthMiddleware(authConfig, mcpAdminService),
-            useAsync(createMcpCreateTagHandler()),
-        )
-        .post(
-            '/api/mcp/notes/delete',
-            createMcpAuthMiddleware(authConfig, mcpAdminService),
-            useAsync(createMcpDeleteNoteHandler()),
-        )
-        .get('/api/events', requireSessionForWrite(authConfig), createServerEventsHandler())
         .use('/api', createApiRouter(authConfig, mcpAdminService))
-        .get('/auth/login', createLoginPageHandler(authConfig))
-        .post('/auth/login', createLoginPageSubmitHandler(authConfig))
-        .post('/auth/logout', createLogoutPageHandler(authConfig))
-        .use(
-            '/graphql/mcp',
-            createMcpAuthMiddleware(authConfig, mcpAdminService),
-            createHandler({
-                schema,
-                context: (req) => ({
-                    authMode: authConfig.mode,
-                    isAuthenticated: isAuthenticatedRequest(req.raw),
-                    req: req.raw,
-                    res: req.context.res,
-                }),
-                validationRules: (_req, _args, specifiedRules) => {
-                    return [...specifiedRules, createReadOnlyMcpValidationRule()];
-                },
-            }),
-        )
-        .use(
-            '/graphql',
-            requireSessionForGraphql(authConfig),
-            createHandler({
-                schema,
-                context: (req) => ({
-                    authMode: authConfig.mode,
-                    isAuthenticated: isAuthenticatedRequest(req.raw),
-                    req: req.raw,
-                    res: req.context.res,
-                }),
-            }),
-        )
-        .use((req, res, next) => {
-            if (shouldBlockClientRoute(authConfig, req.path, isAuthenticatedRequest(req))) {
-                const redirectPath = encodeURIComponent(req.originalUrl || '/');
-                res.redirect(303, `/auth/login?next=${redirectPath}`);
-                return;
-            }
-
-            next();
-        })
-        .use(express.static(paths.clientDist, { extensions: ['html'] }))
-        .get(/.*/, (_req, res) => {
-            res.sendFile(paths.clientIndex);
-        })
+        .use('/auth', createAuthPagesRouter(authConfig))
+        .use('/graphql', createGraphqlRouter(authConfig, mcpAdminService))
+        .use(createClientRouter(authConfig))
         .use(createErrorHandler());
 
     return app;

--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -1,14 +1,20 @@
 import { Router } from 'express';
-import { requireSessionForWrite } from './modules/auth-guard.js';
-import type { AuthConfig } from './modules/auth-mode.js';
-import type { McpAdminService } from './modules/mcp-admin.js';
-import useAsync from './modules/use-async.js';
-import * as views from './views/index.js';
+import { requireSessionForWrite } from '../modules/auth-guard.js';
+import type { AuthConfig } from '../modules/auth-mode.js';
+import type { McpAdminService } from '../modules/mcp-admin.js';
+import useAsync from '../modules/use-async.js';
+import * as views from '../views/index.js';
+import { createServerEventsHandler } from '../views/server-events.js';
+import { createMcpRouter } from './mcp.js';
 
-type McpAdminApiService = Pick<McpAdminService, 'getStatus' | 'setEnabled' | 'rotateToken' | 'revokeActiveToken'>;
+type McpAdminApiService = Pick<
+    McpAdminService,
+    'getStatus' | 'setEnabled' | 'rotateToken' | 'revokeActiveToken' | 'validatePresentedToken'
+>;
 
 export const createApiRouter = (authConfig: AuthConfig, mcpAdminService: McpAdminApiService) =>
     Router()
+        .use('/mcp', createMcpRouter(authConfig, mcpAdminService))
         .post('/auth/login', useAsync(views.createLoginHandler(authConfig)))
         .post('/auth/logout', useAsync(views.createLogoutHandler(authConfig)))
         .get('/auth/session', useAsync(views.createSessionStatusHandler(authConfig)))
@@ -33,4 +39,5 @@ export const createApiRouter = (authConfig: AuthConfig, mcpAdminService: McpAdmi
             useAsync(views.createMcpAdminRevokeTokenHandler(mcpAdminService)),
         )
         .post('/image', requireSessionForWrite(authConfig), useAsync(views.uploadImage))
-        .post('/image-from-src', requireSessionForWrite(authConfig), useAsync(views.uploadImageFromSrc));
+        .post('/image-from-src', requireSessionForWrite(authConfig), useAsync(views.uploadImageFromSrc))
+        .get('/events', requireSessionForWrite(authConfig), createServerEventsHandler());

--- a/packages/server/src/routes/auth-pages.ts
+++ b/packages/server/src/routes/auth-pages.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import type { AuthConfig } from '../modules/auth-mode.js';
+import { createLoginPageHandler, createLoginPageSubmitHandler, createLogoutPageHandler } from '../views/auth.js';
+
+export const createAuthPagesRouter = (authConfig: AuthConfig) =>
+    Router()
+        .get('/login', createLoginPageHandler(authConfig))
+        .post('/login', createLoginPageSubmitHandler(authConfig))
+        .post('/logout', createLogoutPageHandler(authConfig));

--- a/packages/server/src/routes/client.ts
+++ b/packages/server/src/routes/client.ts
@@ -1,0 +1,34 @@
+import express, { Router } from 'express';
+import path from 'path';
+import { isAuthenticatedRequest } from '../modules/auth-guard.js';
+import type { AuthConfig } from '../modules/auth-mode.js';
+import { paths } from '../paths.js';
+
+const shouldBlockClientRoute = (authConfig: AuthConfig, requestPath: string, authenticated: boolean) => {
+    if (authConfig.mode !== 'password' || authenticated) {
+        return false;
+    }
+
+    if (requestPath.startsWith('/api') || requestPath.startsWith('/graphql') || requestPath.startsWith('/auth')) {
+        return false;
+    }
+
+    return path.extname(requestPath) === '';
+};
+
+export const createClientRouter = (authConfig: AuthConfig) =>
+    Router()
+        .use('/assets/images', express.static(paths.imageDir))
+        .use((req, res, next) => {
+            if (shouldBlockClientRoute(authConfig, req.path, isAuthenticatedRequest(req))) {
+                const redirectPath = encodeURIComponent(req.originalUrl || '/');
+                res.redirect(303, `/auth/login?next=${redirectPath}`);
+                return;
+            }
+
+            next();
+        })
+        .use(express.static(paths.clientDist, { extensions: ['html'] }))
+        .get(/.*/, (_req, res) => {
+            res.sendFile(paths.clientIndex);
+        });

--- a/packages/server/src/routes/graphql.ts
+++ b/packages/server/src/routes/graphql.ts
@@ -1,0 +1,39 @@
+import { type Request, type Response, Router } from 'express';
+import { createHandler } from 'graphql-http/lib/use/express';
+import { isAuthenticatedRequest, requireSessionForGraphql } from '../modules/auth-guard.js';
+import type { AuthConfig } from '../modules/auth-mode.js';
+import type { McpAdminService } from '../modules/mcp-admin.js';
+import { createMcpAuthMiddleware, createReadOnlyMcpValidationRule } from '../modules/mcp-auth.js';
+import schema from '../schema/index.js';
+
+type McpGraphqlService = Pick<McpAdminService, 'getStatus' | 'validatePresentedToken'>;
+type GraphqlRequestContext = { raw: Request; context: { res: Response } };
+
+const createGraphqlContext = (authConfig: AuthConfig) => (req: GraphqlRequestContext) => ({
+    authMode: authConfig.mode,
+    isAuthenticated: isAuthenticatedRequest(req.raw),
+    req: req.raw,
+    res: req.context.res,
+});
+
+export const createGraphqlRouter = (authConfig: AuthConfig, mcpAdminService: McpGraphqlService) =>
+    Router()
+        .use(
+            '/mcp',
+            createMcpAuthMiddleware(authConfig, mcpAdminService),
+            createHandler({
+                schema,
+                context: createGraphqlContext(authConfig),
+                validationRules: (_req, _args, specifiedRules) => {
+                    return [...specifiedRules, createReadOnlyMcpValidationRule()];
+                },
+            }),
+        )
+        .use(
+            '/',
+            requireSessionForGraphql(authConfig),
+            createHandler({
+                schema,
+                context: createGraphqlContext(authConfig),
+            }),
+        );

--- a/packages/server/src/routes/index.ts
+++ b/packages/server/src/routes/index.ts
@@ -1,0 +1,4 @@
+export { createApiRouter } from './api.js';
+export { createAuthPagesRouter } from './auth-pages.js';
+export { createClientRouter } from './client.js';
+export { createGraphqlRouter } from './graphql.js';

--- a/packages/server/src/routes/mcp.ts
+++ b/packages/server/src/routes/mcp.ts
@@ -1,0 +1,32 @@
+import { Router } from 'express';
+import type { AuthConfig } from '../modules/auth-mode.js';
+import type { McpAdminService } from '../modules/mcp-admin.js';
+import { createMcpAuthMiddleware } from '../modules/mcp-auth.js';
+import useAsync from '../modules/use-async.js';
+import { createMcpCreateNoteHandler, createMcpDeleteNoteHandler, createMcpUpdateNoteHandler } from '../views/note.js';
+import { createMcpCreateTagHandler } from '../views/tag.js';
+
+type McpRouteService = Pick<McpAdminService, 'getStatus' | 'validatePresentedToken'>;
+
+export const createMcpRouter = (authConfig: AuthConfig, mcpAdminService: McpRouteService) =>
+    Router()
+        .post(
+            '/notes/create',
+            createMcpAuthMiddleware(authConfig, mcpAdminService),
+            useAsync(createMcpCreateNoteHandler()),
+        )
+        .post(
+            '/notes/update',
+            createMcpAuthMiddleware(authConfig, mcpAdminService),
+            useAsync(createMcpUpdateNoteHandler()),
+        )
+        .post(
+            '/notes/delete',
+            createMcpAuthMiddleware(authConfig, mcpAdminService),
+            useAsync(createMcpDeleteNoteHandler()),
+        )
+        .post(
+            '/tags/create',
+            createMcpAuthMiddleware(authConfig, mcpAdminService),
+            useAsync(createMcpCreateTagHandler()),
+        );


### PR DESCRIPTION
## :dart: Goal
- Reduce the amount of HTTP wiring owned directly by `app.ts`.
- Make the server entry point read as route composition instead of a long middleware chain.
- Keep behavior unchanged while preparing the backend for follow-up feature-first refactors.

## :hammer_and_wrench: Core Changes
- Split HTTP composition into dedicated routers for `/api`, `/api/mcp`, `/auth`, `/graphql`, and client/static serving.
- Moved the previous `urls.ts` API wiring into `routes/api.ts` and added new route modules for auth pages, GraphQL, MCP, and client delivery.
- Simplified `app.ts` so it only sets up shared middleware, mounts routers, and registers the error handler.
- Preserved the existing auth gates, MCP token validation, GraphQL handler configuration, and client redirect behavior.

## :brain: Key Decisions
- This PR only covers route composition. It intentionally does not include the larger note feature-directory move.
- `mcp-admin` stays in REST because it is operational control-plane behavior, not product graph data.
- The route split keeps the current transport choices intact and makes later internal refactors safer.

## :test_tube: Verification Guide
- `pnpm --filter @ocean-brain/server type-check`
- `pnpm --filter @ocean-brain/server lint`
- `pnpm --filter @ocean-brain/server test`

## :white_check_mark: Checklist
- [x] `app.ts` is reduced to top-level server composition.
- [x] Existing API, MCP, GraphQL, auth-page, and client-serving behavior is preserved.
- [x] Server type-check, lint, and tests pass.