### PR TITLE
♻️ Reorganize MCP admin feature layout

### DIFF
--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -1,11 +1,11 @@
 import express from 'express';
+import { createMcpAdminService, type McpAdminService } from './features/mcp-admin/service.js';
 import { purgeExpiredNoteSnapshots } from './features/note/services/snapshot.js';
 import { purgeExpiredTrashedNotes } from './features/note/services/trash.js';
 import { createSessionMiddleware } from './modules/auth-guard.js';
 import type { AuthConfig } from './modules/auth-mode.js';
 import { createErrorHandler } from './modules/error-handler.js';
 import logger from './modules/logger.js';
-import { createMcpAdminService, type McpAdminService } from './modules/mcp-admin.js';
 import { createApiRouter, createAuthPagesRouter, createClientRouter, createGraphqlRouter } from './routes/index.js';
 
 export const createApp = (authConfig: AuthConfig) => {

--- a/packages/server/src/features/mcp-admin/http/handlers.test.ts
+++ b/packages/server/src/features/mcp-admin/http/handlers.test.ts
@@ -1,9 +1,9 @@
 import assert from 'node:assert/strict';
 import type { AddressInfo } from 'node:net';
 import test, { type TestContext } from 'node:test';
-import { createAppWithMcpAuth } from '../src/app.js';
-import type { AuthConfig } from '../src/modules/auth-mode.js';
-import type { McpAdminService } from '../src/modules/mcp-admin.js';
+import { createAppWithMcpAuth } from '~/app.js';
+import type { AuthConfig } from '~/modules/auth-mode.js';
+import type { McpAdminService } from '../service.js';
 
 const createStubMcpAdminService = (input: { enabled?: boolean; hasActiveToken?: boolean } = {}): McpAdminService => {
     let enabled = input.enabled ?? true;

--- a/packages/server/src/features/mcp-admin/http/handlers.ts
+++ b/packages/server/src/features/mcp-admin/http/handlers.ts
@@ -1,6 +1,6 @@
 import { createAppError } from '~/modules/error-handler.js';
-import { createMcpAdminService, type McpAdminService } from '~/modules/mcp-admin.js';
 import type { Controller } from '~/types/index.js';
+import { createMcpAdminService, type McpAdminService } from '../service.js';
 
 type McpAdminControllerService = Pick<
     McpAdminService,

--- a/packages/server/src/features/mcp-admin/service.test.ts
+++ b/packages/server/src/features/mcp-admin/service.test.ts
@@ -37,7 +37,10 @@ interface FakeDb {
             where: { revokedAt: Date | null };
             orderBy: { createdAt: 'desc' | 'asc' };
         }) => Promise<TokenRow | null>;
-        updateMany: (args: { where: { revokedAt: Date | null }; data: { revokedAt: Date } }) => Promise<{ count: number }>;
+        updateMany: (args: {
+            where: { revokedAt: Date | null };
+            data: { revokedAt: Date };
+        }) => Promise<{ count: number }>;
         create: (args: { data: { tokenHash: string } }) => Promise<TokenRow>;
         update: (args: { where: { id: number }; data: { lastUsedAt: Date } }) => Promise<TokenRow>;
     };

--- a/packages/server/src/features/mcp-admin/service.test.ts
+++ b/packages/server/src/features/mcp-admin/service.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { createMcpAdminService } from '../src/modules/mcp-admin.js';
+import { createMcpAdminService } from './service.js';
 
 interface TokenRow {
     id: number;
@@ -11,12 +11,45 @@ interface TokenRow {
     revokedAt: Date | null;
 }
 
+interface FakeDb {
+    cache: {
+        findUnique: (args: { where: { key: string } }) => Promise<{
+            key: string;
+            value: string;
+            id: number;
+            createdAt: Date;
+            updatedAt: Date;
+        } | null>;
+        upsert: (args: {
+            where: { key: string };
+            create: { key: string; value: string };
+            update: { value: string };
+        }) => Promise<{
+            id: number;
+            key: string;
+            value: string;
+            createdAt: Date;
+            updatedAt: Date;
+        }>;
+    };
+    mcpToken: {
+        findFirst: (args: {
+            where: { revokedAt: Date | null };
+            orderBy: { createdAt: 'desc' | 'asc' };
+        }) => Promise<TokenRow | null>;
+        updateMany: (args: { where: { revokedAt: Date | null }; data: { revokedAt: Date } }) => Promise<{ count: number }>;
+        create: (args: { data: { tokenHash: string } }) => Promise<TokenRow>;
+        update: (args: { where: { id: number }; data: { lastUsedAt: Date } }) => Promise<TokenRow>;
+    };
+    $transaction: <T>(callback: (tx: FakeDb) => Promise<T>) => Promise<T>;
+}
+
 const createFakeDb = () => {
     const cacheStore = new Map<string, string>();
     const tokens: TokenRow[] = [];
     let nextId = 1;
 
-    const fakeDb = {
+    const fakeDb: FakeDb = {
         cache: {
             async findUnique({ where }: { where: { key: string } }) {
                 const value = cacheStore.get(where.key);
@@ -104,7 +137,7 @@ const createFakeDb = () => {
                 return row;
             },
         },
-        async $transaction<T>(callback: (tx: typeof fakeDb) => Promise<T>) {
+        async $transaction<T>(callback: (tx: FakeDb) => Promise<T>) {
             return callback(fakeDb);
         },
     };
@@ -159,5 +192,5 @@ test('validatePresentedToken accepts the active token and updates lastUsedAt', a
 
     assert.deepEqual(accepted, { ok: true });
     assert.deepEqual(rejected, { ok: false, reason: 'forbidden' });
-    assert.ok(tokens[0].lastUsedAt instanceof Date);
+    assert.ok(tokens[0]?.lastUsedAt instanceof Date);
 });

--- a/packages/server/src/features/mcp-admin/service.ts
+++ b/packages/server/src/features/mcp-admin/service.ts
@@ -1,5 +1,5 @@
 import models from '~/models.js';
-import { issueMcpToken, verifyMcpToken } from './mcp-token.js';
+import { issueMcpToken, verifyMcpToken } from '~/modules/mcp-token.js';
 
 const MCP_ENABLED_CACHE_KEY = 'MCP_ENABLED';
 

--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -1,8 +1,14 @@
 import { Router } from 'express';
 import { createUploadImageFromSrcHandler, createUploadImageHandler } from '../features/image/http/upload.js';
+import {
+    createMcpAdminRevokeTokenHandler,
+    createMcpAdminRotateTokenHandler,
+    createMcpAdminSetEnabledHandler,
+    createMcpAdminStatusHandler,
+} from '../features/mcp-admin/http/handlers.js';
+import type { McpAdminService } from '../features/mcp-admin/service.js';
 import { requireSessionForWrite } from '../modules/auth-guard.js';
 import type { AuthConfig } from '../modules/auth-mode.js';
-import type { McpAdminService } from '../modules/mcp-admin.js';
 import useAsync from '../modules/use-async.js';
 import * as views from '../views/index.js';
 import { createServerEventsHandler } from '../views/server-events.js';
@@ -22,22 +28,22 @@ export const createApiRouter = (authConfig: AuthConfig, mcpAdminService: McpAdmi
         .get(
             '/mcp-admin/status',
             requireSessionForWrite(authConfig),
-            useAsync(views.createMcpAdminStatusHandler(mcpAdminService)),
+            useAsync(createMcpAdminStatusHandler(mcpAdminService)),
         )
         .post(
             '/mcp-admin/enabled',
             requireSessionForWrite(authConfig),
-            useAsync(views.createMcpAdminSetEnabledHandler(mcpAdminService)),
+            useAsync(createMcpAdminSetEnabledHandler(mcpAdminService)),
         )
         .post(
             '/mcp-admin/token/rotate',
             requireSessionForWrite(authConfig),
-            useAsync(views.createMcpAdminRotateTokenHandler(mcpAdminService)),
+            useAsync(createMcpAdminRotateTokenHandler(mcpAdminService)),
         )
         .post(
             '/mcp-admin/token/revoke',
             requireSessionForWrite(authConfig),
-            useAsync(views.createMcpAdminRevokeTokenHandler(mcpAdminService)),
+            useAsync(createMcpAdminRevokeTokenHandler(mcpAdminService)),
         )
         .post('/image', requireSessionForWrite(authConfig), useAsync(createUploadImageHandler()))
         .post('/image-from-src', requireSessionForWrite(authConfig), useAsync(createUploadImageFromSrcHandler()))

--- a/packages/server/src/routes/graphql.ts
+++ b/packages/server/src/routes/graphql.ts
@@ -1,8 +1,8 @@
 import { type Request, type Response, Router } from 'express';
 import { createHandler } from 'graphql-http/lib/use/express';
+import type { McpAdminService } from '../features/mcp-admin/service.js';
 import { isAuthenticatedRequest, requireSessionForGraphql } from '../modules/auth-guard.js';
 import type { AuthConfig } from '../modules/auth-mode.js';
-import type { McpAdminService } from '../modules/mcp-admin.js';
 import { createMcpAuthMiddleware, createReadOnlyMcpValidationRule } from '../modules/mcp-auth.js';
 import schema from '../schema/index.js';
 

--- a/packages/server/src/routes/mcp.ts
+++ b/packages/server/src/routes/mcp.ts
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+import type { McpAdminService } from '../features/mcp-admin/service.js';
 import {
     createMcpCreateNoteHandler,
     createMcpDeleteNoteHandler,
@@ -6,7 +7,6 @@ import {
 } from '../features/note/http/mcp.js';
 import { createMcpCreateTagHandler } from '../features/tag/http/mcp.js';
 import type { AuthConfig } from '../modules/auth-mode.js';
-import type { McpAdminService } from '../modules/mcp-admin.js';
 import { createMcpAuthMiddleware } from '../modules/mcp-auth.js';
 import useAsync from '../modules/use-async.js';
 

--- a/packages/server/src/views/index.ts
+++ b/packages/server/src/views/index.ts
@@ -1,2 +1,1 @@
 export * from './auth.js';
-export * from './mcp-admin.js';

--- a/packages/server/test/mcp-auth.test.ts
+++ b/packages/server/test/mcp-auth.test.ts
@@ -2,8 +2,8 @@ import assert from 'node:assert/strict';
 import type { AddressInfo } from 'node:net';
 import test, { type TestContext } from 'node:test';
 import { createAppWithMcpAuth } from '../src/app.js';
+import type { McpAdminService } from '../src/features/mcp-admin/service.js';
 import type { AuthConfig } from '../src/modules/auth-mode.js';
-import type { McpAdminService } from '../src/modules/mcp-admin.js';
 
 const startServer = async (t: TestContext, authConfig: AuthConfig, mcpAdminAuth: McpAdminService) => {
     const app = createAppWithMcpAuth(authConfig, mcpAdminAuth);


### PR DESCRIPTION
## :dart: Goal

- Move MCP admin service and HTTP handlers into the feature-first server layout.
- Co-locate MCP admin tests with the implementation they cover.

## :hammer_and_wrench: Core Changes

- Moved the MCP admin service to `packages/server/src/features/mcp-admin/service.ts`.
- Moved MCP admin HTTP handlers to `packages/server/src/features/mcp-admin/http/handlers.ts`.
- Moved MCP admin tests next to the feature implementation under `packages/server/src/features/mcp-admin`.
- Updated app, route, and test imports to use the new feature paths directly.

## :brain: Key Decisions

- Kept `mcp-auth` and `mcp-token` outside the feature because they remain shared MCP infrastructure.
- Kept the scope limited to MCP admin ownership so this refactor stays consistent with the earlier feature migrations.

## :test_tube: Verification Guide

1. Run `pnpm --filter @ocean-brain/server lint`.
2. Run `pnpm --filter @ocean-brain/server type-check`.
3. Run `pnpm --filter @ocean-brain/server test`.
4. Run `pnpm --filter @ocean-brain/server build`.

Expected:
- All commands pass.
- MCP admin imports resolve from `packages/server/src/features/mcp-admin/*`.
- The old `modules/mcp-admin.ts` and `views/mcp-admin.ts` files are gone.

## :white_check_mark: Checklist

- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [ ] Documentation updated (if needed)
