### PR TITLE
✨ Add trash note purge

### DIFF
--- a/packages/client/src/apis/note.api.spec.ts
+++ b/packages/client/src/apis/note.api.spec.ts
@@ -1,0 +1,25 @@
+import { purgeTrashedNote } from '~/apis/note.api';
+import { graphQuery } from '~/modules/graph-query';
+
+vi.mock('~/modules/graph-query', () => ({ graphQuery: vi.fn() }));
+
+describe('note.api', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('sends trashed note purge requests through GraphQL variables', async () => {
+        vi.mocked(graphQuery).mockResolvedValue({
+            type: 'success',
+            purgeTrashedNote: true,
+        } as never);
+
+        const response = await purgeTrashedNote('7');
+
+        expect(graphQuery).toHaveBeenCalledWith(expect.stringContaining('mutation PurgeTrashedNote'), { id: '7' });
+        expect(response).toEqual({
+            type: 'success',
+            purgeTrashedNote: true,
+        });
+    });
+});

--- a/packages/client/src/apis/note.api.ts
+++ b/packages/client/src/apis/note.api.ts
@@ -428,6 +428,20 @@ export function restoreTrashedNote(id: string) {
     );
 }
 
+export function purgeTrashedNote(id: string) {
+    return graphQuery<
+        {
+            purgeTrashedNote: boolean;
+        },
+        { id: string }
+    >(
+        `mutation PurgeTrashedNote($id: ID!) {
+            purgeTrashedNote(id: $id)
+        }`,
+        { id },
+    );
+}
+
 export function pinNote(id: string, pinned: boolean) {
     return graphQuery<
         {

--- a/packages/client/src/pages/setting/trash.spec.tsx
+++ b/packages/client/src/pages/setting/trash.spec.tsx
@@ -1,0 +1,100 @@
+import { QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { fetchTrashedNotes, purgeTrashedNote, restoreTrashedNote } from '~/apis/note.api';
+import { ConfirmProvider, ToastProvider } from '~/components/ui';
+import { queryKeys } from '~/modules/query-key-factory';
+import { createTestQueryClient } from '~/test/test-utils';
+import Trash from './trash';
+
+const { mockNavigate } = vi.hoisted(() => ({
+    mockNavigate: vi.fn(),
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+    getRouteApi: () => ({
+        useSearch: () => ({ page: 1 }),
+        useNavigate: () => mockNavigate,
+    }),
+}));
+
+vi.mock('~/apis/note.api', () => ({
+    fetchTrashedNotes: vi.fn(),
+    purgeTrashedNote: vi.fn(),
+    restoreTrashedNote: vi.fn(),
+}));
+
+const trashedNote = {
+    id: '7',
+    title: 'Disposable note',
+    createdAt: '2026-03-01T00:00:00.000Z',
+    updatedAt: '2026-03-10T12:00:00.000Z',
+    deletedAt: '2026-03-31T01:00:00.000Z',
+    pinned: false,
+    order: 0,
+    layout: 'wide' as const,
+    tagNames: ['trash'],
+};
+
+const renderPage = () => {
+    const queryClient = createTestQueryClient();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries').mockResolvedValue(undefined);
+
+    render(
+        <QueryClientProvider client={queryClient}>
+            <ConfirmProvider>
+                <ToastProvider>
+                    <Trash />
+                </ToastProvider>
+            </ConfirmProvider>
+        </QueryClientProvider>,
+    );
+
+    return { invalidateSpy };
+};
+
+describe('<Trash />', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(fetchTrashedNotes).mockResolvedValue({
+            type: 'success',
+            trashedNotes: {
+                totalCount: 1,
+                notes: [trashedNote],
+            },
+        } as never);
+        vi.mocked(restoreTrashedNote).mockResolvedValue({
+            type: 'success',
+            restoreTrashedNote: {
+                id: '7',
+                title: 'Disposable note',
+                updatedAt: '1774915200000',
+                layout: 'wide',
+                pinned: false,
+                content: 'content',
+            },
+        } as never);
+    });
+
+    it('permanently deletes a trashed note after confirmation', async () => {
+        vi.mocked(purgeTrashedNote).mockResolvedValue({
+            type: 'success',
+            purgeTrashedNote: true,
+        } as never);
+
+        const { invalidateSpy } = renderPage();
+
+        await userEvent.click(await screen.findByRole('button', { name: /delete now/i }));
+        expect(purgeTrashedNote).not.toHaveBeenCalled();
+
+        await userEvent.click(screen.getByRole('button', { name: /ok/i }));
+
+        await waitFor(() => {
+            expect(vi.mocked(purgeTrashedNote).mock.calls[0]?.[0]).toBe('7');
+            expect(invalidateSpy).toHaveBeenCalledWith({
+                queryKey: queryKeys.notes.trashAll(),
+                exact: false,
+            });
+        });
+    });
+});

--- a/packages/client/src/pages/setting/trash.tsx
+++ b/packages/client/src/pages/setting/trash.tsx
@@ -1,11 +1,11 @@
 import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
 import { getRouteApi } from '@tanstack/react-router';
 import dayjs from 'dayjs';
-import { fetchTrashedNotes, restoreTrashedNote } from '~/apis/note.api';
+import { fetchTrashedNotes, purgeTrashedNote, restoreTrashedNote } from '~/apis/note.api';
 import { QueryBoundary } from '~/components/app';
 import * as Icon from '~/components/icon';
 import { Button, Empty, PageLayout, Pagination, Skeleton, SurfaceCard } from '~/components/shared';
-import { Text, useToast } from '~/components/ui';
+import { Text, useConfirm, useToast } from '~/components/ui';
 import { queryKeys } from '~/modules/query-key-factory';
 import { NOTE_ROUTE, SETTINGS_TRASH_ROUTE } from '~/modules/url';
 
@@ -51,6 +51,7 @@ const TrashContent = () => {
     const navigate = Route.useNavigate();
     const queryClient = useQueryClient();
     const toast = useToast();
+    const confirm = useConfirm();
 
     const { data } = useSuspenseQuery({
         queryKey: queryKeys.notes.trash({
@@ -96,7 +97,7 @@ const TrashContent = () => {
                     exact: false,
                 }),
                 queryClient.invalidateQueries({
-                    queryKey: ['calendar'],
+                    queryKey: queryKeys.calendar.all(),
                     exact: false,
                 }),
             ]);
@@ -111,6 +112,31 @@ const TrashContent = () => {
             toast('Failed to restore the note.');
         },
     });
+
+    const purgeMutation = useMutation({
+        mutationFn: purgeTrashedNote,
+        onSuccess: async (response) => {
+            if (response.type === 'error') {
+                throw response;
+            }
+
+            await queryClient.invalidateQueries({
+                queryKey: queryKeys.notes.trashAll(),
+                exact: false,
+            });
+
+            toast('The note has been permanently deleted.');
+        },
+        onError: () => {
+            toast('Failed to permanently delete the note.');
+        },
+    });
+
+    const handlePurge = async (id: string) => {
+        if (await confirm('Permanently delete this note? This cannot be undone.')) {
+            purgeMutation.mutate(id);
+        }
+    };
 
     const heading = data.totalCount > 0 ? `Trash (${data.totalCount})` : undefined;
 
@@ -173,15 +199,24 @@ const TrashContent = () => {
                                         </div>
                                     )}
                                 </div>
-                                <Button
-                                    variant="subtle"
-                                    size="sm"
-                                    className="self-start"
-                                    isLoading={restoreMutation.isPending && restoreMutation.variables === note.id}
-                                    onClick={() => restoreMutation.mutate(note.id)}
-                                >
-                                    Restore
-                                </Button>
+                                <div className="flex shrink-0 flex-wrap gap-2 sm:justify-end">
+                                    <Button
+                                        variant="subtle"
+                                        size="sm"
+                                        isLoading={restoreMutation.isPending && restoreMutation.variables === note.id}
+                                        onClick={() => restoreMutation.mutate(note.id)}
+                                    >
+                                        Restore
+                                    </Button>
+                                    <Button
+                                        variant="soft-danger"
+                                        size="sm"
+                                        isLoading={purgeMutation.isPending && purgeMutation.variables === note.id}
+                                        onClick={() => handlePurge(note.id)}
+                                    >
+                                        Delete now
+                                    </Button>
+                                </div>
                             </div>
                         </SurfaceCard>
                     ))}

--- a/packages/server/src/features/note/graphql/note.mutation.resolver.ts
+++ b/packages/server/src/features/note/graphql/note.mutation.resolver.ts
@@ -6,7 +6,7 @@ import {
     createSnapshotMetaFromUserAgent,
     restoreNoteSnapshot,
 } from '~/features/note/services/snapshot.js';
-import { restoreTrashedNoteById, trashNoteById } from '~/features/note/services/trash.js';
+import { purgeTrashedNoteById, restoreTrashedNoteById, trashNoteById } from '~/features/note/services/trash.js';
 import models from '~/models.js';
 import type { NoteInput } from '~/types/index.js';
 import { extractBlocksByType } from './note.graphql.shared.js';
@@ -154,6 +154,15 @@ export const noteMutationResolvers: NoteMutationResolvers = {
         }
 
         return note;
+    },
+    purgeTrashedNote: async (_, { id }: { id: string }) => {
+        const purgedNote = await purgeTrashedNoteById(Number(id));
+
+        if (!purgedNote) {
+            throw 'NOT FOUND';
+        }
+
+        return true;
     },
     pinNote: (_, { id, pinned }: { id: string; pinned: boolean }) =>
         models.note.update({

--- a/packages/server/src/features/note/graphql/note.type-defs.ts
+++ b/packages/server/src/features/note/graphql/note.type-defs.ts
@@ -168,6 +168,7 @@ export const noteMutation = gql`
         deleteNote(id: ID!): Boolean!
         restoreNoteSnapshot(id: ID!): Note!
         restoreTrashedNote(id: ID!): Note!
+        purgeTrashedNote(id: ID!): Boolean!
         pinNote(id: ID!, pinned: Boolean!): Note!
         reorderNotes(notes: [NoteOrderInput!]!): [Note!]!
     }

--- a/packages/server/src/features/note/services/trash.test.ts
+++ b/packages/server/src/features/note/services/trash.test.ts
@@ -40,6 +40,9 @@ test('note trash service moves a live note to trash and returns a summary', asyn
                 reminders: [],
             };
         },
+        purgeDeletedNote: async () => {
+            throw new Error('purge should not run');
+        },
         purgeExpiredDeletedNotes: async () => 0,
         restoreDeletedNote: async () => {
             throw new Error('restore should not run');
@@ -84,6 +87,9 @@ test('note trash service restores a deleted note', async () => {
         liveNoteExists: async () => false,
         moveNoteToTrash: async () => {
             throw new Error('trash should not run');
+        },
+        purgeDeletedNote: async () => {
+            throw new Error('purge should not run');
         },
         purgeExpiredDeletedNotes: async () => 0,
         restoreDeletedNote: async (note) => {
@@ -131,6 +137,9 @@ test('note trash service rejects restore when the live note id already exists', 
         moveNoteToTrash: async () => {
             throw new Error('trash should not run');
         },
+        purgeDeletedNote: async () => {
+            throw new Error('purge should not run');
+        },
         purgeExpiredDeletedNotes: async () => 0,
         restoreDeletedNote: async () => {
             throw new Error('restore should not run');
@@ -168,6 +177,9 @@ test('listTrashedNotes runs retention cleanup before returning trash data', asyn
         moveNoteToTrash: async () => {
             throw new Error('trash should not run');
         },
+        purgeDeletedNote: async () => {
+            throw new Error('purge should not run');
+        },
         purgeExpiredDeletedNotes: async () => {
             calls.push('purge');
             return 1;
@@ -185,4 +197,84 @@ test('listTrashedNotes runs retention cleanup before returning trash data', asyn
     assert.deepEqual(calls, ['purge']);
     assert.equal(result.totalCount, 1);
     assert.equal(result.notes[0]?.title, 'Old deleted note');
+});
+
+test('note trash service permanently deletes a trashed note', async () => {
+    const calls: string[] = [];
+    const service = createNoteTrashService({
+        countDeletedNotes: async () => 0,
+        findDeletedNote: async (id) => ({
+            id,
+            title: 'Disposable note',
+            content: 'content',
+            createdAt: new Date('2026-03-01T00:00:00.000Z'),
+            updatedAt: new Date('2026-03-10T12:00:00.000Z'),
+            deletedAt: new Date('2026-03-31T01:00:00.000Z'),
+            pinned: false,
+            order: 0,
+            layout: 'wide',
+            tags: [{ name: 'trash' }],
+            reminders: [],
+        }),
+        findLiveNote: async () => null,
+        listDeletedNotes: async () => [],
+        liveNoteExists: async () => false,
+        moveNoteToTrash: async () => {
+            throw new Error('trash should not run');
+        },
+        purgeDeletedNote: async (note) => {
+            calls.push(`purge:${note.id}`);
+        },
+        purgeExpiredDeletedNotes: async () => {
+            calls.push('retention');
+            return 0;
+        },
+        restoreDeletedNote: async () => {
+            throw new Error('restore should not run');
+        },
+    });
+
+    const purged = await service.purgeNoteById(12);
+
+    assert.deepEqual(calls, ['retention', 'purge:12']);
+    assert.deepEqual(purged, {
+        id: '12',
+        title: 'Disposable note',
+        createdAt: '2026-03-01T00:00:00.000Z',
+        updatedAt: '2026-03-10T12:00:00.000Z',
+        deletedAt: '2026-03-31T01:00:00.000Z',
+        pinned: false,
+        order: 0,
+        layout: 'wide',
+        tagNames: ['trash'],
+    });
+});
+
+test('note trash service returns null when purging a missing trashed note', async () => {
+    const calls: string[] = [];
+    const service = createNoteTrashService({
+        countDeletedNotes: async () => 0,
+        findDeletedNote: async () => null,
+        findLiveNote: async () => null,
+        listDeletedNotes: async () => [],
+        liveNoteExists: async () => false,
+        moveNoteToTrash: async () => {
+            throw new Error('trash should not run');
+        },
+        purgeDeletedNote: async () => {
+            throw new Error('purge should not run');
+        },
+        purgeExpiredDeletedNotes: async () => {
+            calls.push('retention');
+            return 0;
+        },
+        restoreDeletedNote: async () => {
+            throw new Error('restore should not run');
+        },
+    });
+
+    const purged = await service.purgeNoteById(404);
+
+    assert.deepEqual(calls, ['retention']);
+    assert.equal(purged, null);
 });

--- a/packages/server/src/features/note/services/trash.ts
+++ b/packages/server/src/features/note/services/trash.ts
@@ -111,6 +111,7 @@ interface NoteTrashServiceDeps {
     listDeletedNotes: (skip: number, take: number) => Promise<DeletedNoteRecord[]>;
     liveNoteExists: (id: number) => Promise<boolean>;
     moveNoteToTrash: (note: LiveNoteRecord) => Promise<DeletedNoteRecord>;
+    purgeDeletedNote: (note: DeletedNoteRecord) => Promise<void>;
     purgeExpiredDeletedNotes: (before: Date, limit: number) => Promise<number>;
     restoreDeletedNote: (note: DeletedNoteRecord) => Promise<RestoredNoteRecord>;
 }
@@ -205,6 +206,20 @@ export const createNoteTrashService = (deps: NoteTrashServiceDeps) => ({
 
         return deps.restoreDeletedNote(deletedNote);
     },
+
+    purgeNoteById: async (id: number): Promise<TrashedNoteSummary | null> => {
+        await deps.purgeExpiredDeletedNotes(createRetentionCutoff(TRASH_RETENTION_DAYS), RECOVERY_CLEANUP_BATCH_LIMIT);
+
+        const deletedNote = await deps.findDeletedNote(id);
+
+        if (!deletedNote) {
+            return null;
+        }
+
+        const summary = serializeTrashedNote(deletedNote);
+        await deps.purgeDeletedNote(deletedNote);
+        return summary;
+    },
 });
 
 const includeDeletedNote = {
@@ -262,6 +277,9 @@ const noteTrashService = createNoteTrashService({
         return Boolean(note);
     },
     purgeExpiredDeletedNotes: defaultPurgeExpiredDeletedNotes,
+    purgeDeletedNote: async (deletedNote) => {
+        await models.deletedNote.delete({ where: { id: deletedNote.id } });
+    },
     moveNoteToTrash: async (note) => {
         return models.$transaction(async (tx) => {
             await tx.deletedNote.create({
@@ -386,6 +404,7 @@ const noteTrashService = createNoteTrashService({
 export const listTrashedNotes = noteTrashService.listTrashedNotes;
 export const trashNoteById = noteTrashService.trashNoteById;
 export const restoreTrashedNoteById = noteTrashService.restoreNoteById;
+export const purgeTrashedNoteById = noteTrashService.purgeNoteById;
 export const purgeExpiredTrashedNotes = async () => {
     return defaultPurgeExpiredDeletedNotes(createRetentionCutoff(TRASH_RETENTION_DAYS), RECOVERY_CLEANUP_BATCH_LIMIT);
 };


### PR DESCRIPTION
## :dart: Goal
- Let users permanently delete a specific note from Trash when they are ready to remove it beyond recovery.
- Keep the existing note delete behavior as a safe soft delete into Trash.

## :hammer_and_wrench: Core Changes
- Added a server-side trash purge path and GraphQL `purgeTrashedNote` mutation.
- Added a client API wrapper and a Trash page `Delete now` action guarded by the existing confirmation dialog.
- Added focused tests for the trash service, GraphQL API client contract, and Trash page purge flow.
- Updated the Ocean Brain TODO note to record the completed work and removed the completed task note.

## :brain: Key Decisions
- Kept `deleteNote` as "move to trash" and introduced `purgeTrashedNote` for unrecoverable deletion to keep soft delete and permanent delete semantics separate.
- Limited the first UI pass to single-note purge rather than bulk empty-trash behavior.
- Invalidated the trash query namespace after purge because the live note/tag/reminder caches are not changed by deleting an already-trashed note.

## :test_tube: Verification Guide
### How to verify
1. `pnpm check:encoding`
2. `pnpm lint`
3. `pnpm type-check`
4. `pnpm test:ci`
5. `pnpm build`

### Expected result
- All commands pass.
- On Node 22.8.0, `pnpm build` may print Vite's Node version warning, but the build still completes successfully.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)
