### PR TITLE
♻️ Fix BlockNote heading hierarchy to respect note title scale

### DIFF
--- a/packages/client/src/styles/main.scss
+++ b/packages/client/src/styles/main.scss
@@ -122,6 +122,53 @@ div:focus {
     max-width: 100%;
 }
 
+/* BlockNote body typography hierarchy */
+.bn-default-styles {
+    h1 {
+        font-size: 1.125rem;
+        font-weight: 700;
+        line-height: 1.35;
+        letter-spacing: -0.01em;
+
+        @media (min-width: 640px) {
+            font-size: 1.25rem;
+        }
+    }
+
+    h2 {
+        font-size: 1rem;
+        font-weight: 600;
+        line-height: 1.4;
+        letter-spacing: -0.005em;
+
+        @media (min-width: 640px) {
+            font-size: 1.125rem;
+        }
+    }
+
+    h3 {
+        font-size: 1rem;
+        font-weight: 600;
+        line-height: 1.5;
+    }
+
+    h4,
+    h5,
+    h6 {
+        font-size: 1rem;
+        font-weight: 500;
+        line-height: 1.5;
+    }
+
+    p {
+        line-height: 1.7;
+    }
+
+    li {
+        line-height: 1.65;
+    }
+}
+
 .bn-block-outer:not([data-prev-type])>.bn-block>.bn-block-content[data-content-type="numberedListItem"]::before {
     content: var(--index) ".";
     white-space: nowrap;


### PR DESCRIPTION
## :dart: Goal
- Fix the broken note hierarchy where BlockNote body headings (h1-h3) were rendered much larger than the note title by browser defaults.
- Restore the contract that the note title is the top-level identifier for a document.

## :hammer_and_wrench: Core Changes
- Add heading typography hierarchy for `.bn-default-styles` in `packages/client/src/styles/main.scss`.
- h1: 1.125rem on mobile / 1.25rem on desktop, bold; always smaller than the note title max size of 1.375rem.
- h2: 1rem on mobile / 1.125rem on desktop, semibold.
- h3: 1rem, semibold so it stays distinct from body text through weight.
- h4-h6: 1rem, medium.
- p: line-height 1.7, li: line-height 1.65 to improve reading rhythm.

## :brain: Key Decisions
- The browser default h1 size, roughly 2em or 32px, was much larger than the note title max size of 22px and broke the hierarchy. This change keeps h1 below the title size.
- Avoid adding a new type-scale token and keep the adjustment editor-specific within the existing display, heading, and body roles.
- Accept the visible size reduction because the previous heading scale was incorrect for the note hierarchy.

## :test_tube: Verification Guide
### How to verify
1. Run `pnpm dev` and open the note editor.
2. Open or create a note containing h1, h2, and h3 headings.
3. Confirm the size hierarchy reads as note title -> h1 -> h2 -> h3 -> body.
4. Confirm the hierarchy still holds below a 640px viewport.

### Expected result
- The note title is always larger than or equal to h1.
- The title > h1 > h2 >= h3 > body hierarchy can be scanned quickly.
- Mobile heading typography reads quietly without competing with the title.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [ ] Tests completed
- [ ] Documentation updated (if needed)