### PR TITLE
✨ Add code block copy button

### DIFF
--- a/packages/client/src/components/schema/CodeBlock.tsx
+++ b/packages/client/src/components/schema/CodeBlock.tsx
@@ -1,0 +1,28 @@
+import type { defaultBlockSpecs } from '@blocknote/core';
+import type { ReactCustomBlockRenderProps } from '@blocknote/react';
+import { useCallback, useRef } from 'react';
+import { CodeBlockCopyButton } from './CodeBlockCopyButton';
+
+type DefaultCodeBlockSpec = typeof defaultBlockSpecs.codeBlock;
+type CodeBlockProps = ReactCustomBlockRenderProps<'codeBlock', DefaultCodeBlockSpec['config']['propSchema'], 'inline'>;
+
+export const CodeBlock = ({ contentRef }: CodeBlockProps) => {
+    const codeRef = useRef<HTMLElement | null>(null);
+
+    const setCodeRef = useCallback(
+        (element: HTMLElement | null) => {
+            codeRef.current = element;
+            contentRef(element);
+        },
+        [contentRef],
+    );
+
+    return (
+        <>
+            <pre>
+                <code ref={setCodeRef} />
+            </pre>
+            <CodeBlockCopyButton getText={() => codeRef.current?.textContent?.trimEnd() ?? ''} />
+        </>
+    );
+};

--- a/packages/client/src/components/schema/CodeBlockCopyButton.spec.tsx
+++ b/packages/client/src/components/schema/CodeBlockCopyButton.spec.tsx
@@ -1,0 +1,40 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { CodeBlockCopyButton } from './CodeBlockCopyButton';
+
+const mockClipboard = (writeText: (text: string) => Promise<void>) => {
+    Object.defineProperty(navigator, 'clipboard', {
+        configurable: true,
+        value: { writeText },
+    });
+};
+
+describe('CodeBlockCopyButton', () => {
+    it('copies code text and resets the copied state', async () => {
+        const writeText = vi.fn<(text: string) => Promise<void>>().mockResolvedValue(undefined);
+        const user = userEvent.setup();
+        mockClipboard(writeText);
+
+        render(<CodeBlockCopyButton getText={() => 'const value = 1;'} resetDelayMs={50} />);
+
+        await user.click(screen.getByRole('button', { name: 'Copy' }));
+
+        expect(writeText).toHaveBeenCalledWith('const value = 1;');
+        expect(await screen.findByRole('button', { name: 'Copied' })).toBeInTheDocument();
+
+        await waitFor(() => expect(screen.getByRole('button', { name: 'Copy' })).toBeInTheDocument());
+    });
+
+    it('shows a failure state when clipboard writing fails', async () => {
+        const writeText = vi.fn<(text: string) => Promise<void>>().mockRejectedValue(new Error('Clipboard failed'));
+        const user = userEvent.setup();
+        mockClipboard(writeText);
+
+        render(<CodeBlockCopyButton getText={() => 'const value = 1;'} />);
+
+        await user.click(screen.getByRole('button', { name: 'Copy' }));
+
+        expect(await screen.findByRole('button', { name: 'Copy failed' })).toBeInTheDocument();
+    });
+});

--- a/packages/client/src/components/schema/CodeBlockCopyButton.tsx
+++ b/packages/client/src/components/schema/CodeBlockCopyButton.tsx
@@ -1,0 +1,88 @@
+import classNames from 'classnames';
+import type { MouseEvent } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import * as Icon from '~/components/icon';
+
+type CopyStatus = 'idle' | 'copied' | 'failed';
+
+interface CodeBlockCopyButtonProps {
+    getText: () => string;
+    resetDelayMs?: number;
+}
+
+const copyButtonBaseClassName =
+    'pointer-events-auto inline-flex h-7 cursor-pointer select-none items-center gap-1.5 rounded-[8px] border border-white/10 bg-white/10 px-2.5 text-xs font-medium text-white/60 opacity-75 shadow-[0_8px_18px_-14px_rgba(0,0,0,0.45)] backdrop-blur-sm transition-colors hover:bg-white/20 hover:text-white/90 hover:opacity-100 focus-ring-soft focus:text-white/90 focus:opacity-100';
+
+const copyButtonStatusClassName: Record<CopyStatus, string> = {
+    idle: '',
+    copied: 'text-accent-success hover:text-accent-success focus:text-accent-success',
+    failed: 'text-fg-error hover:text-fg-error focus:text-fg-error',
+};
+
+const copyStatusLabel: Record<CopyStatus, string> = {
+    idle: 'Copy',
+    copied: 'Copied',
+    failed: 'Copy failed',
+};
+
+export const CodeBlockCopyButton = ({ getText, resetDelayMs = 2000 }: CodeBlockCopyButtonProps) => {
+    const [status, setStatus] = useState<CopyStatus>('idle');
+    const resetTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    const clearResetTimer = useCallback(() => {
+        if (resetTimeoutRef.current) {
+            clearTimeout(resetTimeoutRef.current);
+            resetTimeoutRef.current = null;
+        }
+    }, []);
+
+    const scheduleReset = useCallback(() => {
+        clearResetTimer();
+        resetTimeoutRef.current = setTimeout(() => {
+            setStatus('idle');
+            resetTimeoutRef.current = null;
+        }, resetDelayMs);
+    }, [clearResetTimer, resetDelayMs]);
+
+    useEffect(() => clearResetTimer, [clearResetTimer]);
+
+    const stopEditorEvent = (event: MouseEvent) => {
+        event.stopPropagation();
+    };
+
+    const preventEditorFocus = (event: MouseEvent) => {
+        event.preventDefault();
+        event.stopPropagation();
+    };
+
+    const handleCopy = async (event: MouseEvent<HTMLButtonElement>) => {
+        stopEditorEvent(event);
+
+        try {
+            await navigator.clipboard.writeText(getText());
+            setStatus('copied');
+        } catch {
+            setStatus('failed');
+        }
+
+        scheduleReset();
+    };
+
+    return (
+        <div
+            className="pointer-events-none absolute right-3 top-2 z-[1]"
+            contentEditable={false}
+            onMouseDown={preventEditorFocus}
+        >
+            <button
+                type="button"
+                className={classNames(copyButtonBaseClassName, copyButtonStatusClassName[status])}
+                contentEditable={false}
+                onClick={handleCopy}
+            >
+                <Icon.Copy className="h-3.5 w-3.5" />
+                <span aria-live="polite">{copyStatusLabel[status]}</span>
+            </button>
+        </div>
+    );
+};

--- a/packages/client/src/components/schema/schema.tsx
+++ b/packages/client/src/components/schema/schema.tsx
@@ -1,4 +1,6 @@
 import { BlockNoteSchema, defaultBlockSpecs, defaultInlineContentSpecs } from '@blocknote/core';
+import { createReactBlockSpec } from '@blocknote/react';
+import { CodeBlock } from './CodeBlock';
 import type { OceanBrainCustomBlockType, OceanBrainCustomInlineContentType } from './custom-types';
 import Reference from './Reference';
 import TableOfContents from './TableOfContents';
@@ -19,6 +21,26 @@ const oceanBrainInlineContentSpecs = defineOceanBrainInlineContentSpecs({
 
 const oceanBrainBlockSpecs = defineOceanBrainBlockSpecs({ tableOfContents: TableOfContents });
 
+type CodeBlockSpec = typeof defaultBlockSpecs.codeBlock;
+
+const defaultCodeBlock = defaultBlockSpecs.codeBlock;
+const reactCodeBlockWithCopyButton = createReactBlockSpec(defaultCodeBlock.config, {
+    meta: defaultCodeBlock.implementation.meta,
+    parse: defaultCodeBlock.implementation.parse,
+    parseContent: defaultCodeBlock.implementation.parseContent,
+    runsBefore: defaultCodeBlock.implementation.runsBefore,
+    render: CodeBlock,
+})();
+
+const codeBlockWithCopyButton: CodeBlockSpec = {
+    ...reactCodeBlockWithCopyButton,
+    extensions: defaultCodeBlock.extensions,
+    implementation: {
+        ...reactCodeBlockWithCopyButton.implementation,
+        toExternalHTML: defaultCodeBlock.implementation.toExternalHTML,
+    },
+};
+
 const schema = BlockNoteSchema.create({
     inlineContentSpecs: {
         ...defaultInlineContentSpecs,
@@ -26,6 +48,7 @@ const schema = BlockNoteSchema.create({
     },
     blockSpecs: {
         ...defaultBlockSpecs,
+        codeBlock: codeBlockWithCopyButton,
         ...oceanBrainBlockSpecs,
     },
 });


### PR DESCRIPTION
## :dart: Goal
- Add a stable copy action for code blocks in the BlockNote editor.
- Keep the implementation aligned with BlockNote's React block lifecycle.

## :hammer_and_wrench: Core Changes
- Override the default code block render path with a React BlockNote spec while preserving default parsing, external HTML, and extensions.
- Add a Tailwind-styled copy button with clipboard success and failure states.
- Add focused tests for copy success and failure behavior.

## :brain: Key Decisions
- Use `createReactBlockSpec` and `contentRef` instead of manually mounting React roots into BlockNote DOM nodes.
- Mark the copy UI as non-editable and stop editor mouse events so the button does not show an editor text cursor.

## :test_tube: Verification Guide
### How to verify
1. Run `pnpm --filter @ocean-brain/client lint`.
2. Run `pnpm --filter @ocean-brain/client type-check`.
3. Run `pnpm --filter @ocean-brain/client test CodeBlockCopyButton`.
4. Run `pnpm --filter @ocean-brain/client build`.

### Expected result
- All commands complete successfully.
- The build may show existing Vite Node version and chunk size warnings, but it should exit successfully.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (not needed)