### PR TITLE
🔖 Bump version to 0.4.0

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ocean-brain",
-    "version": "0.3.4",
+    "version": "0.4.0",
     "type": "module",
     "repository": {
         "type": "git",


### PR DESCRIPTION
## :dart: Goal
- Prepare the minor `ocean-brain` CLI release for version `0.4.0`.
- Expected tag after merge: `v0.4.0`.

## :hammer_and_wrench: Core Changes
- Bump `packages/cli/package.json` from `0.3.4` to `0.4.0`.
- Include all changes merged after `v0.3.4`; no breaking changes are expected.

## :brain: Key Decisions
- Use a minor version bump because this release includes new product behavior and editor/server improvements without a breaking change.
- Keep the release change limited to the publishable CLI package version, matching the release runbook.

## :test_tube: Verification Guide
### How to verify
1. Confirm `packages/cli/package.json` reports version `0.4.0`.
2. Confirm CI and CLI SMOKE checks passed on this PR.
3. After merge, tag the merged `main` commit as `v0.4.0`.

### Expected result
- Local verification passed: `pnpm check:encoding`, Prisma generate, `pnpm lint`, `pnpm type-check`, `pnpm test:ci`, `pnpm build`, `node scripts/release/prepublish.mjs`.
- GitHub verification passed: CI and CLI SMOKE on ubuntu-latest, macos-latest, and windows-latest.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)