### PR TITLE
✨ Add trash note content inspection

### DIFF
--- a/packages/client/src/apis/note.api.spec.ts
+++ b/packages/client/src/apis/note.api.spec.ts
@@ -1,4 +1,4 @@
-import { purgeTrashedNote } from '~/apis/note.api';
+import { fetchTrashedNote, fetchTrashedNotes, purgeTrashedNote } from '~/apis/note.api';
 import { graphQuery } from '~/modules/graph-query';
 
 vi.mock('~/modules/graph-query', () => ({ graphQuery: vi.fn() }));
@@ -20,6 +20,71 @@ describe('note.api', () => {
         expect(response).toEqual({
             type: 'success',
             purgeTrashedNote: true,
+        });
+    });
+
+    it('requests trashed note content previews with pagination variables', async () => {
+        vi.mocked(graphQuery).mockResolvedValue({
+            type: 'success',
+            trashedNotes: {
+                totalCount: 0,
+                notes: [],
+            },
+        } as never);
+
+        const response = await fetchTrashedNotes({ limit: 10, offset: 20 });
+
+        expect(graphQuery).toHaveBeenCalledWith(expect.stringContaining('contentPreview'), {
+            pagination: {
+                limit: 10,
+                offset: 20,
+            },
+        });
+        expect(response).toEqual({
+            type: 'success',
+            trashedNotes: {
+                totalCount: 0,
+                notes: [],
+            },
+        });
+    });
+
+    it('requests a single trashed note with full markdown content through GraphQL variables', async () => {
+        vi.mocked(graphQuery).mockResolvedValue({
+            type: 'success',
+            trashedNote: {
+                id: '7',
+                title: 'Deleted note',
+                createdAt: '2026-03-01T00:00:00.000Z',
+                updatedAt: '2026-03-10T12:00:00.000Z',
+                deletedAt: '2026-03-31T01:00:00.000Z',
+                contentPreview: 'Preview',
+                contentAsMarkdown: 'Full deleted body',
+                pinned: false,
+                order: 0,
+                layout: 'wide',
+                tagNames: [],
+            },
+        } as never);
+
+        const response = await fetchTrashedNote('7');
+
+        expect(graphQuery).toHaveBeenCalledWith(expect.stringContaining('query FetchTrashedNote'), { id: '7' });
+        expect(response).toEqual({
+            type: 'success',
+            trashedNote: {
+                id: '7',
+                title: 'Deleted note',
+                createdAt: '2026-03-01T00:00:00.000Z',
+                updatedAt: '2026-03-10T12:00:00.000Z',
+                deletedAt: '2026-03-31T01:00:00.000Z',
+                contentPreview: 'Preview',
+                contentAsMarkdown: 'Full deleted body',
+                pinned: false,
+                order: 0,
+                layout: 'wide',
+                tagNames: [],
+            },
         });
     });
 });

--- a/packages/client/src/apis/note.api.ts
+++ b/packages/client/src/apis/note.api.ts
@@ -287,10 +287,15 @@ export interface TrashedNote {
     createdAt: string;
     updatedAt: string;
     deletedAt: string;
+    contentPreview: string;
     pinned: boolean;
     order: number;
     layout: Note['layout'];
     tagNames: string[];
+}
+
+export interface TrashedNoteDetail extends TrashedNote {
+    contentAsMarkdown: string;
 }
 
 export const updateNote = ({ id, editSessionId, ...note }: UpdateNoteRequestData) => {
@@ -391,6 +396,7 @@ export function fetchTrashedNotes({ limit = 25, offset = 0 }: Pick<FetchNotesPar
                     createdAt
                     updatedAt
                     deletedAt
+                    contentPreview
                     pinned
                     order
                     layout
@@ -404,6 +410,32 @@ export function fetchTrashedNotes({ limit = 25, offset = 0 }: Pick<FetchNotesPar
                 offset,
             },
         },
+    );
+}
+
+export function fetchTrashedNote(id: string) {
+    return graphQuery<
+        {
+            trashedNote: TrashedNoteDetail | null;
+        },
+        { id: string }
+    >(
+        `query FetchTrashedNote($id: ID!) {
+            trashedNote(id: $id) {
+                id
+                title
+                createdAt
+                updatedAt
+                deletedAt
+                contentPreview
+                contentAsMarkdown
+                pinned
+                order
+                layout
+                tagNames
+            }
+        }`,
+        { id },
     );
 }
 

--- a/packages/client/src/modules/query-key-factory.ts
+++ b/packages/client/src/modules/query-key-factory.ts
@@ -89,6 +89,7 @@ export const queryKeys = {
                     offset: params.offset ?? 0,
                 },
             ] as const,
+        trashDetail: (id: string) => ['notes', 'trash', 'detail', { id }] as const,
         pinned: () => ['notes', 'pinned'] as const,
         backReferencesAll: () => ['notes', 'back-references'] as const,
         backReferences: (noteId: string) => ['notes', 'back-references', { noteId }] as const,

--- a/packages/client/src/pages/setting/trash.spec.tsx
+++ b/packages/client/src/pages/setting/trash.spec.tsx
@@ -1,7 +1,7 @@
 import { QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { fetchTrashedNotes, purgeTrashedNote, restoreTrashedNote } from '~/apis/note.api';
+import { fetchTrashedNote, fetchTrashedNotes, purgeTrashedNote, restoreTrashedNote } from '~/apis/note.api';
 import { ConfirmProvider, ToastProvider } from '~/components/ui';
 import { queryKeys } from '~/modules/query-key-factory';
 import { createTestQueryClient } from '~/test/test-utils';
@@ -19,6 +19,7 @@ vi.mock('@tanstack/react-router', () => ({
 }));
 
 vi.mock('~/apis/note.api', () => ({
+    fetchTrashedNote: vi.fn(),
     fetchTrashedNotes: vi.fn(),
     purgeTrashedNote: vi.fn(),
     restoreTrashedNote: vi.fn(),
@@ -30,6 +31,7 @@ const trashedNote = {
     createdAt: '2026-03-01T00:00:00.000Z',
     updatedAt: '2026-03-10T12:00:00.000Z',
     deletedAt: '2026-03-31T01:00:00.000Z',
+    contentPreview: 'This is a deleted body preview.',
     pinned: false,
     order: 0,
     layout: 'wide' as const,
@@ -74,6 +76,31 @@ describe('<Trash />', () => {
                 content: 'content',
             },
         } as never);
+        vi.mocked(fetchTrashedNote).mockResolvedValue({
+            type: 'success',
+            trashedNote: {
+                ...trashedNote,
+                contentAsMarkdown: 'Full deleted body\n\nSecond line',
+            },
+        } as never);
+    });
+
+    it('shows a readable preview for trashed note content', async () => {
+        renderPage();
+
+        expect(await screen.findByText('This is a deleted body preview.')).toBeInTheDocument();
+    });
+
+    it('opens a modal with the full trashed note body', async () => {
+        renderPage();
+
+        await userEvent.click(await screen.findByRole('button', { name: /view content/i }));
+
+        await waitFor(() => {
+            expect(fetchTrashedNote).toHaveBeenCalledWith('7');
+        });
+        expect(await screen.findByText(/Full deleted body/)).toBeInTheDocument();
+        expect(screen.getByText(/Second line/)).toBeInTheDocument();
     });
 
     it('permanently deletes a trashed note after confirmation', async () => {

--- a/packages/client/src/pages/setting/trash.tsx
+++ b/packages/client/src/pages/setting/trash.tsx
@@ -1,10 +1,12 @@
-import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
 import { getRouteApi } from '@tanstack/react-router';
 import dayjs from 'dayjs';
-import { fetchTrashedNotes, purgeTrashedNote, restoreTrashedNote } from '~/apis/note.api';
+import { useState } from 'react';
+import type { TrashedNote } from '~/apis/note.api';
+import { fetchTrashedNote, fetchTrashedNotes, purgeTrashedNote, restoreTrashedNote } from '~/apis/note.api';
 import { QueryBoundary } from '~/components/app';
 import * as Icon from '~/components/icon';
-import { Button, Empty, PageLayout, Pagination, Skeleton, SurfaceCard } from '~/components/shared';
+import { Button, Empty, Modal, PageLayout, Pagination, Skeleton, SurfaceCard } from '~/components/shared';
 import { Text, useConfirm, useToast } from '~/components/ui';
 import { queryKeys } from '~/modules/query-key-factory';
 import { NOTE_ROUTE, SETTINGS_TRASH_ROUTE } from '~/modules/url';
@@ -15,6 +17,79 @@ const TRASH_RETENTION_DAYS = 30;
 const PAGE_DESCRIPTION = `Deleted notes stay here for ${TRASH_RETENTION_DAYS} days before permanent removal`;
 
 const formatDate = (value: string) => dayjs(value).format('YYYY-MM-DD HH:mm');
+
+interface TrashedNoteContentModalProps {
+    note: TrashedNote | null;
+    onClose: () => void;
+}
+
+const TrashedNoteContentModal = ({ note, onClose }: TrashedNoteContentModalProps) => {
+    const noteId = note?.id ?? '';
+    const title = note?.title || 'Untitled note';
+    const noteQuery = useQuery({
+        queryKey: queryKeys.notes.trashDetail(noteId),
+        enabled: Boolean(note),
+        queryFn: async () => {
+            const response = await fetchTrashedNote(noteId);
+
+            if (response.type === 'error') {
+                throw response;
+            }
+
+            if (!response.trashedNote) {
+                throw new Error('Trashed note not found');
+            }
+
+            return response.trashedNote;
+        },
+    });
+    const content = noteQuery.data?.contentAsMarkdown.trim() ?? '';
+
+    return (
+        <Modal isOpen={Boolean(note)} onClose={onClose} variant="inspect">
+            <Modal.Header title={title} onClose={onClose} />
+            <Modal.Body>
+                <div className="flex flex-col gap-3">
+                    {note && (
+                        <Text as="p" variant="meta" tone="secondary">
+                            Deleted {formatDate(note.deletedAt)}
+                        </Text>
+                    )}
+                    {noteQuery.isLoading && (
+                        <Text as="p" variant="meta" tone="secondary">
+                            Loading deleted note content...
+                        </Text>
+                    )}
+                    {noteQuery.isError && (
+                        <Text as="p" variant="meta" tone="error">
+                            Failed to load deleted note content.
+                        </Text>
+                    )}
+                    {!noteQuery.isLoading && !noteQuery.isError && content && (
+                        <pre className="max-h-[60vh] overflow-auto whitespace-pre-wrap break-words rounded-[14px] border border-border-subtle bg-hover-subtle/50 px-4 py-3 text-sm leading-6 text-fg-secondary">
+                            {content}
+                        </pre>
+                    )}
+                    {!noteQuery.isLoading && !noteQuery.isError && !content && (
+                        <Text
+                            as="p"
+                            variant="meta"
+                            tone="secondary"
+                            className="rounded-[14px] border border-border-subtle bg-hover-subtle/50 px-4 py-3"
+                        >
+                            No readable content was found for this deleted note.
+                        </Text>
+                    )}
+                </div>
+            </Modal.Body>
+            <Modal.Footer>
+                <Button variant="ghost" size="sm" onClick={onClose}>
+                    Close
+                </Button>
+            </Modal.Footer>
+        </Modal>
+    );
+};
 
 const TrashSkeleton = () => (
     <PageLayout
@@ -52,6 +127,7 @@ const TrashContent = () => {
     const queryClient = useQueryClient();
     const toast = useToast();
     const confirm = useConfirm();
+    const [selectedContentNoteId, setSelectedContentNoteId] = useState<string | null>(null);
 
     const { data } = useSuspenseQuery({
         queryKey: queryKeys.notes.trash({
@@ -139,6 +215,7 @@ const TrashContent = () => {
     };
 
     const heading = data.totalCount > 0 ? `Trash (${data.totalCount})` : undefined;
+    const selectedContentNote = data.notes.find((note) => note.id === selectedContentNoteId) ?? null;
 
     if (data.notes.length === 0) {
         return (
@@ -198,8 +275,27 @@ const TrashContent = () => {
                                             ))}
                                         </div>
                                     )}
+                                    {note.contentPreview && (
+                                        <div className="mt-3 rounded-[14px] border border-border-subtle bg-hover-subtle/50 px-3 py-2">
+                                            <Text
+                                                as="p"
+                                                variant="meta"
+                                                tone="secondary"
+                                                className="line-clamp-3 whitespace-pre-wrap break-words"
+                                            >
+                                                {note.contentPreview}
+                                            </Text>
+                                        </div>
+                                    )}
                                 </div>
                                 <div className="flex shrink-0 flex-wrap gap-2 sm:justify-end">
+                                    <Button
+                                        variant="subtle"
+                                        size="sm"
+                                        onClick={() => setSelectedContentNoteId(note.id)}
+                                    >
+                                        View content
+                                    </Button>
                                     <Button
                                         variant="subtle"
                                         size="sm"
@@ -236,6 +332,7 @@ const TrashContent = () => {
                     />
                 )}
             </div>
+            <TrashedNoteContentModal note={selectedContentNote} onClose={() => setSelectedContentNoteId(null)} />
         </PageLayout>
     );
 };

--- a/packages/server/src/features/note/graphql/note.query.resolver.ts
+++ b/packages/server/src/features/note/graphql/note.query.resolver.ts
@@ -11,7 +11,7 @@ import {
     type NoteTagMatchMode,
     normalizeNoteTagNames,
 } from '~/features/note/services/tag-filter.js';
-import { listTrashedNotes } from '~/features/note/services/trash.js';
+import { getTrashedNoteById, listTrashedNotes } from '~/features/note/services/trash.js';
 import type { Note, Prisma } from '~/models.js';
 import models from '~/models.js';
 import { runDataMaintenanceInBackground } from '~/modules/data-maintenance.js';
@@ -431,6 +431,9 @@ export const noteQueryResolvers: NoteQueryResolvers = {
         },
     ) => {
         return listNoteSnapshots(Number(id), Number(limit));
+    },
+    trashedNote: async (_, { id }: { id: string }) => {
+        return getTrashedNoteById(Number(id));
     },
     trashedNotes: async (
         _,

--- a/packages/server/src/features/note/graphql/note.type-defs.ts
+++ b/packages/server/src/features/note/graphql/note.type-defs.ts
@@ -115,6 +115,8 @@ export const noteType = gql`
         createdAt: String!
         updatedAt: String!
         deletedAt: String!
+        contentPreview: String!
+        contentAsMarkdown: String
         pinned: Boolean!
         order: Int!
         layout: NoteLayout!
@@ -156,6 +158,7 @@ export const noteQuery = gql`
         noteCleanupCandidates(query: String, pagination: PaginationInput): [NoteCleanupCandidate!]!
         noteCleanupPreview(id: ID!): NoteCleanupPreview
         noteSnapshots(id: ID!, limit: Int): [NoteSnapshot!]!
+        trashedNote(id: ID!): DeletedNote
         trashedNotes(pagination: PaginationInput): DeletedNotes!
         noteGraph: NoteGraph!
     }

--- a/packages/server/src/features/note/services/trash.test.ts
+++ b/packages/server/src/features/note/services/trash.test.ts
@@ -5,13 +5,28 @@ import { createNoteTrashService, NoteRestoreConflictError } from './trash.js';
 
 test('note trash service moves a live note to trash and returns a summary', async () => {
     const movedIds: number[] = [];
+    const content = JSON.stringify([
+        {
+            id: 'paragraph-1',
+            type: 'paragraph',
+            props: {},
+            content: [
+                {
+                    type: 'text',
+                    text: 'Visible trash body',
+                    styles: {},
+                },
+            ],
+            children: [],
+        },
+    ]);
     const service = createNoteTrashService({
         countDeletedNotes: async () => 1,
         findDeletedNote: async () => null,
         findLiveNote: async (id) => ({
             id,
             title: 'Temp note',
-            content: 'content',
+            content,
             createdAt: new Date('2026-03-01T00:00:00.000Z'),
             updatedAt: new Date('2026-03-10T12:00:00.000Z'),
             pinned: false,
@@ -58,6 +73,7 @@ test('note trash service moves a live note to trash and returns a summary', asyn
         createdAt: '2026-03-01T00:00:00.000Z',
         updatedAt: '2026-03-10T12:00:00.000Z',
         deletedAt: '2026-03-31T01:00:00.000Z',
+        contentPreview: 'Visible trash body',
         pinned: false,
         order: 0,
         layout: 'wide',
@@ -162,7 +178,21 @@ test('listTrashedNotes runs retention cleanup before returning trash data', asyn
             {
                 id: 4,
                 title: 'Old deleted note',
-                content: 'content',
+                content: JSON.stringify([
+                    {
+                        id: 'paragraph-1',
+                        type: 'paragraph',
+                        props: {},
+                        content: [
+                            {
+                                type: 'text',
+                                text: 'Retention list preview',
+                                styles: {},
+                            },
+                        ],
+                        children: [],
+                    },
+                ]),
                 createdAt: new Date('2026-03-01T00:00:00.000Z'),
                 updatedAt: new Date('2026-03-10T12:00:00.000Z'),
                 deletedAt: new Date('2026-03-31T01:00:00.000Z'),
@@ -197,6 +227,58 @@ test('listTrashedNotes runs retention cleanup before returning trash data', asyn
     assert.deepEqual(calls, ['purge']);
     assert.equal(result.totalCount, 1);
     assert.equal(result.notes[0]?.title, 'Old deleted note');
+    assert.equal(result.notes[0]?.contentPreview, 'Retention list preview');
+});
+
+test('note trash service returns full markdown content for a trashed note', async () => {
+    const service = createNoteTrashService({
+        countDeletedNotes: async () => 0,
+        findDeletedNote: async (id) => ({
+            id,
+            title: 'Full body note',
+            content: JSON.stringify([
+                {
+                    id: 'paragraph-1',
+                    type: 'paragraph',
+                    props: {},
+                    content: [
+                        {
+                            type: 'text',
+                            text: 'Full deleted body',
+                            styles: {},
+                        },
+                    ],
+                    children: [],
+                },
+            ]),
+            createdAt: new Date('2026-03-01T00:00:00.000Z'),
+            updatedAt: new Date('2026-03-10T12:00:00.000Z'),
+            deletedAt: new Date('2026-03-31T01:00:00.000Z'),
+            pinned: false,
+            order: 0,
+            layout: 'wide',
+            tags: [],
+            reminders: [],
+        }),
+        findLiveNote: async () => null,
+        listDeletedNotes: async () => [],
+        liveNoteExists: async () => false,
+        moveNoteToTrash: async () => {
+            throw new Error('trash should not run');
+        },
+        purgeDeletedNote: async () => {
+            throw new Error('purge should not run');
+        },
+        purgeExpiredDeletedNotes: async () => 0,
+        restoreDeletedNote: async () => {
+            throw new Error('restore should not run');
+        },
+    });
+
+    const note = await service.getNoteById(14);
+
+    assert.equal(note?.id, '14');
+    assert.match(note?.contentAsMarkdown ?? '', /Full deleted body/);
 });
 
 test('note trash service permanently deletes a trashed note', async () => {
@@ -243,6 +325,7 @@ test('note trash service permanently deletes a trashed note', async () => {
         createdAt: '2026-03-01T00:00:00.000Z',
         updatedAt: '2026-03-10T12:00:00.000Z',
         deletedAt: '2026-03-31T01:00:00.000Z',
+        contentPreview: '',
         pinned: false,
         order: 0,
         layout: 'wide',

--- a/packages/server/src/features/note/services/trash.ts
+++ b/packages/server/src/features/note/services/trash.ts
@@ -4,7 +4,9 @@ import {
     RECOVERY_CLEANUP_BATCH_LIMIT,
     TRASH_RETENTION_DAYS,
 } from '~/modules/recovery-retention.js';
-import { buildNoteSearchProjection } from './search.js';
+import { buildNoteSearchProjection, extractVisibleSearchTextFromContent } from './search.js';
+
+const TRASHED_NOTE_CONTENT_PREVIEW_MAX_LENGTH = 240;
 
 interface LiveTagRecord {
     id: number;
@@ -86,6 +88,7 @@ export interface TrashedNoteSummary {
     createdAt: string;
     updatedAt: string;
     deletedAt: string;
+    contentPreview: string;
     pinned: boolean;
     order: number;
     layout: NoteLayout;
@@ -95,6 +98,10 @@ export interface TrashedNoteSummary {
 export interface TrashedNotesResult {
     totalCount: number;
     notes: TrashedNoteSummary[];
+}
+
+export interface TrashedNoteDetail extends TrashedNoteSummary {
+    contentAsMarkdown: string;
 }
 
 export class NoteRestoreConflictError extends Error {
@@ -116,17 +123,30 @@ interface NoteTrashServiceDeps {
     restoreDeletedNote: (note: DeletedNoteRecord) => Promise<RestoredNoteRecord>;
 }
 
-const serializeTrashedNote = (note: DeletedNoteRecord): TrashedNoteSummary => ({
-    id: String(note.id),
-    title: note.title,
-    createdAt: note.createdAt.toISOString(),
-    updatedAt: note.updatedAt.toISOString(),
-    deletedAt: note.deletedAt.toISOString(),
-    pinned: note.pinned,
-    order: note.order,
-    layout: note.layout,
-    tagNames: note.tags.map((tag) => tag.name),
-});
+const buildTrashedNoteContentPreview = (content: string) => {
+    const text = extractVisibleSearchTextFromContent(content);
+
+    if (text.length <= TRASHED_NOTE_CONTENT_PREVIEW_MAX_LENGTH) {
+        return text;
+    }
+
+    return `${text.slice(0, TRASHED_NOTE_CONTENT_PREVIEW_MAX_LENGTH).trimEnd()}…`;
+};
+
+const serializeTrashedNote = (note: DeletedNoteRecord): TrashedNoteSummary => {
+    return {
+        id: String(note.id),
+        title: note.title,
+        createdAt: note.createdAt.toISOString(),
+        updatedAt: note.updatedAt.toISOString(),
+        deletedAt: note.deletedAt.toISOString(),
+        contentPreview: buildTrashedNoteContentPreview(note.content),
+        pinned: note.pinned,
+        order: note.order,
+        layout: note.layout,
+        tagNames: note.tags.map((tag) => tag.name),
+    };
+};
 
 const restoreTagIdsInContent = (content: string, tagIdByName: Map<string, number>) => {
     const rewriteNodes = (nodes: BlockNoteNode[]): BlockNoteNode[] => {
@@ -189,6 +209,23 @@ export const createNoteTrashService = (deps: NoteTrashServiceDeps) => ({
 
         const trashedNote = await deps.moveNoteToTrash(note);
         return serializeTrashedNote(trashedNote);
+    },
+
+    getNoteById: async (id: number): Promise<TrashedNoteDetail | null> => {
+        await deps.purgeExpiredDeletedNotes(createRetentionCutoff(TRASH_RETENTION_DAYS), RECOVERY_CLEANUP_BATCH_LIMIT);
+
+        const deletedNote = await deps.findDeletedNote(id);
+
+        if (!deletedNote) {
+            return null;
+        }
+
+        const { blocksToMarkdown } = await import('~/modules/blocknote.js');
+
+        return {
+            ...serializeTrashedNote(deletedNote),
+            contentAsMarkdown: await blocksToMarkdown(deletedNote.content),
+        };
     },
 
     restoreNoteById: async (id: number) => {
@@ -402,6 +439,7 @@ const noteTrashService = createNoteTrashService({
 });
 
 export const listTrashedNotes = noteTrashService.listTrashedNotes;
+export const getTrashedNoteById = noteTrashService.getNoteById;
 export const trashNoteById = noteTrashService.trashNoteById;
 export const restoreTrashedNoteById = noteTrashService.restoreNoteById;
 export const purgeTrashedNoteById = noteTrashService.purgeNoteById;


### PR DESCRIPTION
## :dart: Goal
- Let users inspect deleted note contents from the Trash page before restoring or permanently deleting notes.
- Cover both quick identification in the list and full body confirmation when needed.

## :hammer_and_wrench: Core Changes
- Added `contentPreview` to trash list items for quick scanning.
- Added a single-note `trashedNote(id: ID!)` GraphQL query that returns full deleted note content as markdown.
- Added a Trash page "View content" action that opens a modal and loads the full deleted note body on demand.
- Added server, API, query-key, and UI tests for preview and full-content inspection flows.

## :brain: Key Decisions
- Kept the list lightweight by showing only a short plaintext preview there.
- Loaded full content on demand per note instead of converting every trashed note to markdown during list fetch.
- Returned markdown for the full body instead of raw stored BlockNote JSON so the modal stays readable.

## :test_tube: Verification Guide
### How to verify
1. `pnpm check:encoding`
2. `pnpm lint`
3. `pnpm test:ci`
4. `pnpm type-check`
5. `pnpm build`

### Expected result
- Encoding, lint, test, type-check, and build commands complete successfully.
- Trash page cards show a short content preview when deleted note content has visible text.
- Clicking `View content` opens a modal with the full deleted note body.
- Notes with unparsable or empty content do not break the Trash page and show an empty-content fallback in the modal.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)