### PR TITLE
🔐 Standardize human auth routes

### DIFF
--- a/packages/client/src/dev-auth-gate.ts
+++ b/packages/client/src/dev-auth-gate.ts
@@ -31,13 +31,14 @@ export const shouldBypassDevAuthGate = (pathname: string) => {
         pathname.startsWith('/api') ||
         pathname.startsWith('/graphql') ||
         pathname.startsWith('/assets') ||
-        pathname.startsWith('/auth') ||
+        pathname === '/login' ||
+        pathname === '/logout' ||
         pathname === '/favicon.ico'
     );
 };
 
 export const buildDevAuthLoginRedirect = (requestUrl: string) => {
-    return `/auth/login?next=${encodeURIComponent(requestUrl)}`;
+    return `/login?next=${encodeURIComponent(requestUrl)}`;
 };
 
 export const createDevAuthGateMiddleware = (options: { backendOrigin: string; fetchImpl?: typeof fetch }) => {

--- a/packages/client/src/modules/auth-redirect.spec.ts
+++ b/packages/client/src/modules/auth-redirect.spec.ts
@@ -16,7 +16,7 @@ describe('auth-redirect', () => {
                 search: '?tab=edit',
                 hash: '#title',
             }),
-        ).toBe('/auth/login?next=%2Fnotes%2F123%3Ftab%3Dedit%23title');
+        ).toBe('/login?next=%2Fnotes%2F123%3Ftab%3Dedit%23title');
     });
 
     it('redirects API and GraphQL 401 responses to login', () => {
@@ -28,7 +28,8 @@ describe('auth-redirect', () => {
     });
 
     it('does not redirect auth route failures', () => {
-        expect(shouldRedirectToLogin(createAxiosError(401, '/auth/login'))).toBe(false);
+        expect(shouldRedirectToLogin(createAxiosError(401, '/api/auth/login'))).toBe(false);
+        expect(shouldRedirectToLogin(createAxiosError(401, '/login'))).toBe(false);
     });
 
     it('detects expired password sessions', () => {

--- a/packages/client/src/modules/auth-redirect.ts
+++ b/packages/client/src/modules/auth-redirect.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 
-const LOGIN_PATH = '/auth/login';
+const LOGIN_PATH = '/login';
+const AUTH_API_PATH_PREFIX = '/api/auth/';
 
 interface AuthSessionResponse {
     authRequired?: boolean;
@@ -25,7 +26,7 @@ export const shouldRedirectToLogin = (error: unknown) => {
 
     const requestUrl = error.config?.url ?? '';
 
-    return !requestUrl.startsWith('/auth/');
+    return !requestUrl.startsWith(AUTH_API_PATH_PREFIX) && requestUrl !== LOGIN_PATH;
 };
 
 export const isExpiredAuthSession = (session: AuthSessionResponse) => {

--- a/packages/client/src/test/dev-auth-gate.test.ts
+++ b/packages/client/src/test/dev-auth-gate.test.ts
@@ -8,12 +8,13 @@ describe('dev auth gate', () => {
         expect(shouldBypassDevAuthGate('/src/main.tsx')).toBe(true);
         expect(shouldBypassDevAuthGate('/api/auth/session')).toBe(true);
         expect(shouldBypassDevAuthGate('/graphql')).toBe(true);
+        expect(shouldBypassDevAuthGate('/login')).toBe(true);
         expect(shouldBypassDevAuthGate('/notes')).toBe(false);
     });
 
     it('builds a login redirect that preserves the original dev url', () => {
         expect(buildDevAuthLoginRedirect('http://localhost:5173/notes?tag=1')).toBe(
-            '/auth/login?next=http%3A%2F%2Flocalhost%3A5173%2Fnotes%3Ftag%3D1',
+            '/login?next=http%3A%2F%2Flocalhost%3A5173%2Fnotes%3Ftag%3D1',
         );
     });
 
@@ -54,7 +55,7 @@ describe('dev auth gate', () => {
 
         expect(fetchImpl).toHaveBeenCalledWith('http://localhost:6683/api/auth/session', { headers: {} });
         expect(response.statusCode).toBe(303);
-        expect(response.headers.Location).toBe('/auth/login?next=http%3A%2F%2Flocalhost%3A5173%2Fnotes');
+        expect(response.headers.Location).toBe('/login?next=http%3A%2F%2Flocalhost%3A5173%2Fnotes');
         expect(next).not.toHaveBeenCalled();
     });
 

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -27,7 +27,7 @@ export const createAppWithMcpAuth = (authConfig: AuthConfig, mcpAdminService: Mc
         .use(express.urlencoded({ extended: false }))
         .use(express.json({ limit: '50mb' }))
         .use('/api', createApiRouter(authConfig, mcpAdminService))
-        .use('/auth', createAuthPagesRouter(authConfig))
+        .use(createAuthPagesRouter(authConfig))
         .use('/graphql', createGraphqlRouter(authConfig, mcpAdminService))
         .use(createClientRouter(authConfig))
         .use(createErrorHandler());

--- a/packages/server/src/features/auth/http/login-page.html
+++ b/packages/server/src/features/auth/http/login-page.html
@@ -192,7 +192,7 @@
             <h1 id="login-title">Sign in</h1>
             <p class="lead">Enter the workspace password to continue.</p>
             <!-- OCEAN_BRAIN_LOGIN_ERROR -->
-            <form method="post" action="/auth/login">
+            <form method="post" action="/login">
                 <input type="hidden" name="next" value="OCEAN_BRAIN_NEXT_PATH" />
                 <div class="field">
                     <label for="password">Password</label>

--- a/packages/server/src/features/auth/http/pages.test.ts
+++ b/packages/server/src/features/auth/http/pages.test.ts
@@ -52,9 +52,9 @@ test('password mode blocks client routes until the server-side login form succee
     const blockedHome = await fetch(`${baseUrl}/`, { redirect: 'manual' });
 
     assert.equal(blockedHome.status, 303);
-    assert.equal(blockedHome.headers.get('location'), '/auth/login?next=%2F');
+    assert.equal(blockedHome.headers.get('location'), '/login?next=%2F');
 
-    const loginPage = await fetch(`${baseUrl}/auth/login?next=%2Fnotes`);
+    const loginPage = await fetch(`${baseUrl}/login?next=%2Fnotes`);
     const loginPageHtml = await loginPage.text();
 
     assert.equal(loginPage.status, 200);
@@ -62,9 +62,10 @@ test('password mode blocks client routes until the server-side login form succee
     assert.match(loginPageHtml, /Enter the workspace password to continue/);
     assert.match(loginPageHtml, /color-scheme: light dark/);
     assert.match(loginPageHtml, /prefers-color-scheme: dark/);
+    assert.match(loginPageHtml, /<form method="post" action="\/login">/);
     assert.match(loginPageHtml, /name="next" value="\/notes"/);
 
-    const invalidLogin = await formRequest(baseUrl, '/auth/login', {
+    const invalidLogin = await formRequest(baseUrl, '/login', {
         next: '/notes',
         password: 'wrong',
     });
@@ -72,7 +73,7 @@ test('password mode blocks client routes until the server-side login form succee
     assert.equal(invalidLogin.status, 401);
     assert.match(invalidLogin.text, /Invalid password/);
 
-    const validLogin = await formRequest(baseUrl, '/auth/login', {
+    const validLogin = await formRequest(baseUrl, '/login', {
         next: '/notes',
         password: 'secret',
     });
@@ -90,7 +91,7 @@ test('password mode blocks client routes until the server-side login form succee
         authenticated: true,
     });
 
-    const logout = await formRequest(baseUrl, '/auth/logout', {}, validLogin.cookie);
+    const logout = await formRequest(baseUrl, '/logout', {}, validLogin.cookie);
     assert.equal(logout.status, 303);
-    assert.equal(logout.location, '/auth/login');
+    assert.equal(logout.location, '/login');
 });

--- a/packages/server/src/features/auth/http/pages.ts
+++ b/packages/server/src/features/auth/http/pages.ts
@@ -50,7 +50,7 @@ export const createLogoutPageHandler = (authConfig: AuthConfig): Controller => {
     return async (req, res) => {
         if (authConfig.mode === 'password') {
             await destroySession(req);
-            res.redirect(303, '/auth/login');
+            res.redirect(303, '/login');
             return;
         }
 

--- a/packages/server/src/features/auth/service.ts
+++ b/packages/server/src/features/auth/service.ts
@@ -76,7 +76,17 @@ export const sanitizeRedirectPath = (value: unknown) => {
     }
 
     if (value.startsWith('/')) {
-        if (value.startsWith('//') || value.startsWith('/auth/login')) {
+        if (
+            value.startsWith('//') ||
+            value === '/login' ||
+            value.startsWith('/login?') ||
+            value === '/logout' ||
+            value.startsWith('/logout?') ||
+            value === '/auth/login' ||
+            value.startsWith('/auth/login?') ||
+            value === '/auth/logout' ||
+            value.startsWith('/auth/logout?')
+        ) {
             return '/';
         }
 
@@ -95,7 +105,12 @@ export const sanitizeRedirectPath = (value: unknown) => {
             return '/';
         }
 
-        if (redirectUrl.pathname.startsWith('/auth/login')) {
+        if (
+            redirectUrl.pathname === '/login' ||
+            redirectUrl.pathname === '/logout' ||
+            redirectUrl.pathname === '/auth/login' ||
+            redirectUrl.pathname === '/auth/logout'
+        ) {
             return '/';
         }
 

--- a/packages/server/src/features/auth/service.ts
+++ b/packages/server/src/features/auth/service.ts
@@ -81,11 +81,7 @@ export const sanitizeRedirectPath = (value: unknown) => {
             value === '/login' ||
             value.startsWith('/login?') ||
             value === '/logout' ||
-            value.startsWith('/logout?') ||
-            value === '/auth/login' ||
-            value.startsWith('/auth/login?') ||
-            value === '/auth/logout' ||
-            value.startsWith('/auth/logout?')
+            value.startsWith('/logout?')
         ) {
             return '/';
         }
@@ -105,12 +101,7 @@ export const sanitizeRedirectPath = (value: unknown) => {
             return '/';
         }
 
-        if (
-            redirectUrl.pathname === '/login' ||
-            redirectUrl.pathname === '/logout' ||
-            redirectUrl.pathname === '/auth/login' ||
-            redirectUrl.pathname === '/auth/logout'
-        ) {
+        if (redirectUrl.pathname === '/login' || redirectUrl.pathname === '/logout') {
             return '/';
         }
 

--- a/packages/server/src/routes/client.ts
+++ b/packages/server/src/routes/client.ts
@@ -9,7 +9,12 @@ const shouldBlockClientRoute = (authConfig: AuthConfig, requestPath: string, aut
         return false;
     }
 
-    if (requestPath.startsWith('/api') || requestPath.startsWith('/graphql') || requestPath.startsWith('/auth')) {
+    if (
+        requestPath.startsWith('/api') ||
+        requestPath.startsWith('/graphql') ||
+        requestPath === '/login' ||
+        requestPath === '/logout'
+    ) {
         return false;
     }
 
@@ -22,7 +27,7 @@ export const createClientRouter = (authConfig: AuthConfig) =>
         .use((req, res, next) => {
             if (shouldBlockClientRoute(authConfig, req.path, isAuthenticatedRequest(req))) {
                 const redirectPath = encodeURIComponent(req.originalUrl || '/');
-                res.redirect(303, `/auth/login?next=${redirectPath}`);
+                res.redirect(303, `/login?next=${redirectPath}`);
                 return;
             }
 


### PR DESCRIPTION
## :dart: Goal
- Standardize Ocean Brain's human login surface to the shared Ocean auth contract.
- Remove the old `/auth/login` path so the app uses the same server-owned `/login` and `/logout` routes as the other Ocean apps.

## :hammer_and_wrench: Core Changes
- Switched the server-rendered login form and logout redirect to `GET/POST /login` and `POST /logout`.
- Updated client route gating and dev auth gate redirects to point at `/login` instead of `/auth/login`.
- Updated auth redirect helpers and tests so expired-session handling ignores only the auth API routes plus the new login page.

## :brain: Key Decisions
- Kept the login page server-owned instead of moving auth UI into the client app, so password entry still happens on the server-rendered surface.
- Removed the legacy human auth path instead of keeping an alias, because the Ocean auth guide now requires one canonical login route across apps.

## :test_tube: Verification Guide
### How to verify
1. Run `pnpm -r type-check`.
2. Run `pnpm --filter @ocean-brain/server test`.
3. Start the app in password mode and confirm unauthenticated client routes redirect to `/login?next=...`, then submit the login form and verify `POST /logout` returns to `/login`.

### Expected result
- Human auth only uses `/login` and `/logout`.
- Password mode still blocks client routes until the server-owned login form succeeds.
- Client-side expired-session redirects no longer target `/auth/login`.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)
