### PR TITLE
♻️ Use shared auth and UI packages

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -30,6 +30,7 @@
         "type-check": "tsc --noEmit"
     },
     "dependencies": {
+        "@baejino/auth": "0.1.1",
         "@blocknote/server-util": "^0.46.2",
         "@graphql-tools/schema": "^10.0.31",
         "@graphql-tools/utils": "^11.0.0",

--- a/packages/cli/src/auth-options.ts
+++ b/packages/cli/src/auth-options.ts
@@ -37,6 +37,12 @@ export const resolveServeAuthEnvironment = (
 ) => {
     const allowInsecureNoAuth = options.allowInsecureNoAuth || isTruthy(env.OCEAN_BRAIN_ALLOW_INSECURE_NO_AUTH);
 
+    if (allowInsecureNoAuth && env.OCEAN_BRAIN_PASSWORD) {
+        throw new Error(
+            'Conflicting auth config. OCEAN_BRAIN_ALLOW_INSECURE_NO_AUTH enables open mode while OCEAN_BRAIN_PASSWORD is also set.'
+        );
+    }
+
     if (!allowInsecureNoAuth && env.OCEAN_BRAIN_PASSWORD) {
         ensurePasswordModeRequirements(env);
     }

--- a/packages/cli/test/auth-options.test.ts
+++ b/packages/cli/test/auth-options.test.ts
@@ -22,15 +22,16 @@ test('resolveServeAuthEnvironment validates password mode requirements when pass
     );
 });
 
-test('resolveServeAuthEnvironment skips password requirements when insecure flag is enabled', () => {
-    const authEnv = resolveServeAuthEnvironment(
-        { allowInsecureNoAuth: true },
-        {
-            OCEAN_BRAIN_PASSWORD: 'secret'
-        }
+test('resolveServeAuthEnvironment fails closed when insecure flag and password env are both set', () => {
+    assert.throws(
+        () => resolveServeAuthEnvironment(
+            { allowInsecureNoAuth: true },
+            {
+                OCEAN_BRAIN_PASSWORD: 'secret'
+            }
+        ),
+        /Conflicting auth config/
     );
-
-    assert.equal(authEnv.OCEAN_BRAIN_ALLOW_INSECURE_NO_AUTH, 'true');
 });
 
 test('resolveServeAuthEnvironment validates explicit insecure flag from existing env', () => {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -14,7 +14,9 @@
         "type-check": "tsc --noEmit"
     },
     "dependencies": {
+        "@baejino/auth": "0.1.1",
         "@baejino/handy": "^0.2.3",
+        "@baejino/react-ui": "^0.2.0",
         "@blocknote/core": "^0.46.2",
         "@blocknote/mantine": "^0.46.2",
         "@blocknote/react": "^0.46.2",
@@ -25,12 +27,7 @@
         "@mantine/core": "^8.3.14",
         "@mantine/hooks": "^8.3.14",
         "@phosphor-icons/react": "^2.1.10",
-        "@radix-ui/react-dialog": "^1.1.15",
-        "@radix-ui/react-dropdown-menu": "^2.1.16",
-        "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-slot": "^1.2.4",
-        "@radix-ui/react-toggle-group": "^1.1.11",
-        "@radix-ui/react-tooltip": "^1.2.8",
         "@tanstack/react-query": "^5.90.21",
         "@tanstack/react-router": "^1.166.3",
         "axios": "^1.15.0",

--- a/packages/client/src/components/ui/Confirm/ConfirmContext.ts
+++ b/packages/client/src/components/ui/Confirm/ConfirmContext.ts
@@ -1,7 +1,0 @@
-import { createContext } from 'react';
-
-export interface ConfirmContextValue {
-    confirm: (message: string) => Promise<boolean>;
-}
-
-export const ConfirmContext = createContext<ConfirmContextValue | null>(null);

--- a/packages/client/src/components/ui/Confirm/ConfirmProvider.tsx
+++ b/packages/client/src/components/ui/Confirm/ConfirmProvider.tsx
@@ -1,56 +1,133 @@
-import { useCallback, useRef, useState } from 'react';
+import {
+    type AlertComponentProps,
+    ModalProvider as BaseModalProvider,
+    type ConfirmComponentProps,
+} from '@baejino/react-ui/modal';
+import * as AlertDialogPrimitive from '@baejino/react-ui/modal/alert-dialog';
+import classNames from 'classnames';
 
 import { Button } from '../Button';
-import { Modal } from '../Dialog/Modal';
+import {
+    dialogBodyVariants,
+    dialogContentVariants,
+    dialogDescriptionVariants,
+    dialogFooterVariants,
+    dialogTitleVariants,
+} from '../Dialog/variants';
 import { Text } from '../Text';
-import { ConfirmContext } from './ConfirmContext';
+
+const alertDialogOverlayClassName = classNames(
+    'fixed',
+    'inset-0',
+    'z-[1090]',
+    'bg-overlay',
+    'backdrop-blur-[2px]',
+    'data-[state=open]:animate-in',
+    'data-[state=closed]:animate-out',
+    'data-[state=closed]:fade-out-0',
+    'data-[state=open]:fade-in-0',
+);
+
+const AlertModal = ({ open, options, onClose }: AlertComponentProps) => {
+    return (
+        <AlertDialogPrimitive.Root
+            open={open}
+            onOpenChange={(nextOpen) => {
+                if (!nextOpen && options.dismissible) {
+                    onClose();
+                }
+            }}
+        >
+            <AlertDialogPrimitive.Portal>
+                <AlertDialogPrimitive.Overlay className={alertDialogOverlayClassName} />
+                <div className="pointer-events-none fixed inset-0 z-[1100] flex items-center justify-center p-4">
+                    <AlertDialogPrimitive.Content className={dialogContentVariants({ variant: 'confirm' })}>
+                        <div className={dialogBodyVariants({ variant: 'confirm' })}>
+                            <AlertDialogPrimitive.Title className={dialogTitleVariants({ variant: 'confirm' })}>
+                                {options.title}
+                            </AlertDialogPrimitive.Title>
+                            {options.description ? (
+                                <AlertDialogPrimitive.Description
+                                    className={dialogDescriptionVariants({ variant: 'confirm' })}
+                                >
+                                    {options.description}
+                                </AlertDialogPrimitive.Description>
+                            ) : null}
+                        </div>
+                        <div className={dialogFooterVariants({ variant: 'confirm' })}>
+                            <AlertDialogPrimitive.Action asChild>
+                                <Button size="sm" onClick={onClose}>
+                                    {options.confirmLabel}
+                                </Button>
+                            </AlertDialogPrimitive.Action>
+                        </div>
+                    </AlertDialogPrimitive.Content>
+                </div>
+            </AlertDialogPrimitive.Portal>
+        </AlertDialogPrimitive.Root>
+    );
+};
+
+const ConfirmModal = ({ open, options, onCancel, onConfirm }: ConfirmComponentProps) => {
+    return (
+        <AlertDialogPrimitive.Root
+            open={open}
+            onOpenChange={(nextOpen) => {
+                if (!nextOpen && options.dismissible) {
+                    onCancel();
+                }
+            }}
+        >
+            <AlertDialogPrimitive.Portal>
+                <AlertDialogPrimitive.Overlay className={alertDialogOverlayClassName} />
+                <div className="pointer-events-none fixed inset-0 z-[1100] flex items-center justify-center p-4">
+                    <AlertDialogPrimitive.Content className={dialogContentVariants({ variant: 'confirm' })}>
+                        <div className={dialogBodyVariants({ variant: 'confirm' })}>
+                            <AlertDialogPrimitive.Title className={dialogTitleVariants({ variant: 'confirm' })}>
+                                {options.title}
+                            </AlertDialogPrimitive.Title>
+                            {options.description ? (
+                                <AlertDialogPrimitive.Description
+                                    className={dialogDescriptionVariants({ variant: 'confirm' })}
+                                >
+                                    <Text as="span" variant="meta" tone="secondary">
+                                        {options.description}
+                                    </Text>
+                                </AlertDialogPrimitive.Description>
+                            ) : null}
+                        </div>
+                        <div className={dialogFooterVariants({ variant: 'confirm' })}>
+                            <AlertDialogPrimitive.Cancel asChild>
+                                <Button variant="ghost" size="sm" onClick={onCancel}>
+                                    {options.cancelLabel}
+                                </Button>
+                            </AlertDialogPrimitive.Cancel>
+                            <AlertDialogPrimitive.Action asChild>
+                                <Button
+                                    variant={options.tone === 'danger' ? 'danger' : 'primary'}
+                                    size="sm"
+                                    onClick={onConfirm}
+                                >
+                                    {options.confirmLabel}
+                                </Button>
+                            </AlertDialogPrimitive.Action>
+                        </div>
+                    </AlertDialogPrimitive.Content>
+                </div>
+            </AlertDialogPrimitive.Portal>
+        </AlertDialogPrimitive.Root>
+    );
+};
 
 export function ConfirmProvider({ children }: { children: React.ReactNode }) {
-    const [isOpen, setIsOpen] = useState(false);
-    const [message, setMessage] = useState('');
-    const resolveRef = useRef<((value: boolean) => void) | null>(null);
-
-    const confirm = useCallback((message: string): Promise<boolean> => {
-        setMessage(message);
-        setIsOpen(true);
-        return new Promise<boolean>((resolve) => {
-            resolveRef.current = resolve;
-        });
-    }, []);
-
-    const handleConfirm = () => {
-        resolveRef.current?.(true);
-        resolveRef.current = null;
-        setIsOpen(false);
-    };
-
-    const handleCancel = () => {
-        resolveRef.current?.(false);
-        resolveRef.current = null;
-        setIsOpen(false);
-    };
-
     return (
-        <ConfirmContext.Provider value={{ confirm }}>
+        <BaseModalProvider
+            components={{
+                Alert: AlertModal,
+                Confirm: ConfirmModal,
+            }}
+        >
             {children}
-            <Modal isOpen={isOpen} onClose={handleCancel} variant="confirm">
-                <Modal.Body>
-                    <Text as="p" variant="subheading" weight="semibold" tracking="tight">
-                        Confirm
-                    </Text>
-                    <Text as="p" variant="meta" tone="secondary">
-                        {message}
-                    </Text>
-                </Modal.Body>
-                <Modal.Footer>
-                    <Button variant="ghost" size="sm" onClick={handleCancel}>
-                        Cancel
-                    </Button>
-                    <Button variant="danger" size="sm" onClick={handleConfirm}>
-                        OK
-                    </Button>
-                </Modal.Footer>
-            </Modal>
-        </ConfirmContext.Provider>
+        </BaseModalProvider>
     );
 }

--- a/packages/client/src/components/ui/Confirm/useConfirm.ts
+++ b/packages/client/src/components/ui/Confirm/useConfirm.ts
@@ -1,11 +1,18 @@
-import { useContext } from 'react';
-
-import { ConfirmContext } from './ConfirmContext';
+import { useModal } from '@baejino/react-ui/modal';
+import { useCallback } from 'react';
 
 export function useConfirm() {
-    const context = useContext(ConfirmContext);
-    if (!context) {
-        throw new Error('useConfirm must be used within a ConfirmProvider');
-    }
-    return context.confirm;
+    const { confirm } = useModal();
+
+    return useCallback(
+        (message: string) =>
+            confirm({
+                title: 'Confirm',
+                description: message,
+                confirmLabel: 'OK',
+                cancelLabel: 'Cancel',
+                tone: 'danger',
+            }),
+        [confirm],
+    );
 }

--- a/packages/client/src/components/ui/Dialog/Dialog.tsx
+++ b/packages/client/src/components/ui/Dialog/Dialog.tsx
@@ -1,4 +1,4 @@
-import * as DialogPrimitive from '@radix-ui/react-dialog';
+import * as DialogPrimitive from '@baejino/react-ui/modal/dialog';
 import classNames from 'classnames';
 import { createContext, forwardRef, useContext } from 'react';
 

--- a/packages/client/src/components/ui/Dropdown/Dropdown.tsx
+++ b/packages/client/src/components/ui/Dropdown/Dropdown.tsx
@@ -1,4 +1,4 @@
-import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
+import * as DropdownMenuPrimitive from '@baejino/react-ui/dropdown-menu';
 import classNames from 'classnames';
 import { forwardRef } from 'react';
 

--- a/packages/client/src/components/ui/Select/Select.tsx
+++ b/packages/client/src/components/ui/Select/Select.tsx
@@ -1,4 +1,4 @@
-import * as SelectPrimitive from '@radix-ui/react-select';
+import * as SelectPrimitive from '@baejino/react-ui/select';
 import type { VariantProps } from 'class-variance-authority';
 import { cva } from 'class-variance-authority';
 import classNames from 'classnames';

--- a/packages/client/src/components/ui/Toast/ToastProvider.tsx
+++ b/packages/client/src/components/ui/Toast/ToastProvider.tsx
@@ -1,70 +1,27 @@
-import { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
+import { ToastProvider as BaseToastProvider, createToast } from '@baejino/react-ui/toast';
 
-interface Toast {
-    id: number;
-    message: string;
-}
-
-interface ToastContextValue {
-    toast: (message: string) => void;
-}
-
-const ToastContext = createContext<ToastContextValue | null>(null);
-
-let nextId = 0;
+const toast = createToast({ duration: 3000 });
 
 export function ToastProvider({ children }: { children: React.ReactNode }) {
-    const [toasts, setToasts] = useState<Toast[]>([]);
-    const timersRef = useRef<Map<number, ReturnType<typeof setTimeout>>>(new Map());
-
-    const toast = useCallback((message: string) => {
-        const id = nextId++;
-        setToasts((prev) => [
-            ...prev,
-            {
-                id,
-                message,
-            },
-        ]);
-
-        const timer = setTimeout(() => {
-            setToasts((prev) => prev.filter((t) => t.id !== id));
-            timersRef.current.delete(id);
-        }, 3000);
-
-        timersRef.current.set(id, timer);
-    }, []);
-
-    useEffect(() => {
-        const timers = timersRef.current;
-        return () => {
-            timers.forEach((timer) => clearTimeout(timer));
-        };
-    }, []);
-
     return (
-        <ToastContext.Provider value={{ toast }}>
+        <>
             {children}
-            {toasts.length > 0 && (
-                <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-[1200] flex flex-col gap-2 items-center">
-                    {toasts.map((t) => (
-                        <div
-                            key={t.id}
-                            className="surface-floating whitespace-nowrap px-5 py-3 text-sm font-medium text-fg-secondary animate-slide-in-from-bottom"
-                        >
-                            {t.message}
-                        </div>
-                    ))}
-                </div>
-            )}
-        </ToastContext.Provider>
+            <BaseToastProvider
+                position="bottom-center"
+                expand={false}
+                visibleToasts={3}
+                toastOptions={{
+                    duration: 3000,
+                    classNames: {
+                        toast: 'surface-floating whitespace-nowrap px-5 py-3 text-sm font-medium text-fg-secondary shadow-sm',
+                        title: 'text-sm font-medium text-fg-secondary',
+                    },
+                }}
+            />
+        </>
     );
 }
 
 export function useToast() {
-    const context = useContext(ToastContext);
-    if (!context) {
-        throw new Error('useToast must be used within a ToastProvider');
-    }
-    return context.toast;
+    return toast;
 }

--- a/packages/client/src/components/ui/ToggleGroup/ToggleGroup.tsx
+++ b/packages/client/src/components/ui/ToggleGroup/ToggleGroup.tsx
@@ -1,4 +1,4 @@
-import * as ToggleGroupPrimitive from '@radix-ui/react-toggle-group';
+import * as ToggleGroupPrimitive from '@baejino/react-ui/toggle-group';
 import type { VariantProps } from 'class-variance-authority';
 import classNames from 'classnames';
 import { createContext, forwardRef, useContext } from 'react';

--- a/packages/client/src/components/ui/Tooltip/Tooltip.tsx
+++ b/packages/client/src/components/ui/Tooltip/Tooltip.tsx
@@ -1,4 +1,4 @@
-import * as TooltipPrimitive from '@radix-ui/react-tooltip';
+import * as TooltipPrimitive from '@baejino/react-ui/tooltip';
 import classNames from 'classnames';
 import { forwardRef } from 'react';
 

--- a/packages/client/src/modules/auth-redirect.ts
+++ b/packages/client/src/modules/auth-redirect.ts
@@ -1,12 +1,8 @@
+import type { AuthSessionResponse } from '@baejino/auth';
 import axios from 'axios';
 
 const LOGIN_PATH = '/login';
 const AUTH_API_PATH_PREFIX = '/api/auth/';
-
-interface AuthSessionResponse {
-    authRequired?: boolean;
-    authenticated?: boolean;
-}
 
 type RedirectLocation = Pick<Location, 'assign' | 'hash' | 'pathname' | 'search'>;
 

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -38,7 +38,8 @@ export default defineConfig({
         host: '0.0.0.0',
         proxy: {
             '/api': { target: 'http://localhost:6683' },
-            '/auth': { target: 'http://localhost:6683' },
+            '/login': { target: 'http://localhost:6683' },
+            '/logout': { target: 'http://localhost:6683' },
             '/graphql': { target: 'http://localhost:6683' },
             '/assets/images': { target: 'http://localhost:6683' },
         },

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -15,6 +15,7 @@
         "type-check": "tsc --noEmit"
     },
     "dependencies": {
+        "@baejino/auth": "0.1.1",
         "@blocknote/server-util": "^0.46.2",
         "@graphql-tools/schema": "^10.0.31",
         "@graphql-tools/utils": "^11.0.0",

--- a/packages/server/src/features/auth/http/api.test.ts
+++ b/packages/server/src/features/auth/http/api.test.ts
@@ -2,7 +2,21 @@ import assert from 'node:assert/strict';
 import type { AddressInfo } from 'node:net';
 import test, { type TestContext } from 'node:test';
 import { createApp } from '~/app.js';
-import type { AuthConfig } from '~/modules/auth-mode.js';
+import { AUTH_SESSION_COOKIE_NAME, type AuthConfig } from '~/modules/auth-mode.js';
+
+const createPasswordAuthConfig = (): AuthConfig => ({
+    mode: 'password',
+    password: 'secret',
+    sessionSecret: 'session-secret',
+    cookieName: AUTH_SESSION_COOKIE_NAME,
+    source: 'password',
+});
+
+const createOpenAuthConfig = (): AuthConfig => ({
+    mode: 'open',
+    cookieName: AUTH_SESSION_COOKIE_NAME,
+    source: 'explicit-open',
+});
 
 const startServer = async (t: TestContext, authConfig: AuthConfig) => {
     const app = createApp(authConfig);
@@ -62,12 +76,7 @@ const jsonRequest = async (
 };
 
 test('password mode protects write paths until login and unlocks them after session auth', async (t) => {
-    const { baseUrl } = await startServer(t, {
-        mode: 'password',
-        password: 'secret',
-        sessionSecret: 'session-secret',
-        source: 'override',
-    });
+    const { baseUrl } = await startServer(t, createPasswordAuthConfig());
 
     const anonymousSession = await jsonRequest(baseUrl, '/api/auth/session', 'GET');
     assert.equal(anonymousSession.status, 200);
@@ -142,23 +151,20 @@ test('password mode protects write paths until login and unlocks them after sess
     assert.equal(postLogoutWrite.body.code, 'UNAUTHORIZED');
 });
 
-test('disabled mode keeps auth endpoints explicit and allows existing open write/query behavior', async (t) => {
-    const { baseUrl } = await startServer(t, {
-        mode: 'disabled',
-        source: 'override',
-    });
+test('open mode keeps auth endpoints explicit and allows existing open write/query behavior', async (t) => {
+    const { baseUrl } = await startServer(t, createOpenAuthConfig());
 
     const sessionStatus = await jsonRequest(baseUrl, '/api/auth/session', 'GET');
     assert.equal(sessionStatus.status, 200);
     assert.deepEqual(sessionStatus.body, {
-        mode: 'disabled',
+        mode: 'open',
         authRequired: false,
         authenticated: false,
     });
 
     const login = await jsonRequest(baseUrl, '/api/auth/login', 'POST', { password: 'secret' });
     assert.equal(login.status, 409);
-    assert.equal(login.body.code, 'AUTH_DISABLED');
+    assert.equal(login.body.code, 'AUTH_OPEN_MODE');
 
     const imageWrite = await jsonRequest(baseUrl, '/api/image', 'POST', {});
     assert.equal(imageWrite.status, 400);

--- a/packages/server/src/features/auth/http/api.ts
+++ b/packages/server/src/features/auth/http/api.ts
@@ -1,3 +1,4 @@
+import { buildAuthSessionResponse } from '@baejino/auth';
 import type { AuthConfig } from '~/modules/auth-mode.js';
 import { createAppError } from '~/modules/error-handler.js';
 import type { Controller } from '~/types/index.js';
@@ -31,13 +32,7 @@ export const createLogoutHandler = (authConfig: AuthConfig): Controller => {
             await destroySession(req);
         }
 
-        res.status(200)
-            .json({
-                mode: authConfig.mode,
-                authRequired: authConfig.mode === 'password',
-                authenticated: false,
-            })
-            .end();
+        res.status(200).json(buildAuthSessionResponse(authConfig, false)).end();
     };
 };
 

--- a/packages/server/src/features/auth/http/pages.test.ts
+++ b/packages/server/src/features/auth/http/pages.test.ts
@@ -2,7 +2,15 @@ import assert from 'node:assert/strict';
 import type { AddressInfo } from 'node:net';
 import test, { type TestContext } from 'node:test';
 import { createApp } from '~/app.js';
-import type { AuthConfig } from '~/modules/auth-mode.js';
+import { AUTH_SESSION_COOKIE_NAME, type AuthConfig } from '~/modules/auth-mode.js';
+
+const createPasswordAuthConfig = (): AuthConfig => ({
+    mode: 'password',
+    password: 'secret',
+    sessionSecret: 'session-secret',
+    cookieName: AUTH_SESSION_COOKIE_NAME,
+    source: 'password',
+});
 
 const startServer = async (t: TestContext, authConfig: AuthConfig) => {
     const app = createApp(authConfig);
@@ -42,12 +50,7 @@ const formRequest = async (baseUrl: string, path: string, body: Record<string, s
 };
 
 test('password mode blocks client routes until the server-side login form succeeds', async (t) => {
-    const { baseUrl } = await startServer(t, {
-        mode: 'password',
-        password: 'secret',
-        sessionSecret: 'session-secret',
-        source: 'override',
-    });
+    const { baseUrl } = await startServer(t, createPasswordAuthConfig());
 
     const blockedHome = await fetch(`${baseUrl}/`, { redirect: 'manual' });
 

--- a/packages/server/src/features/auth/service.test.ts
+++ b/packages/server/src/features/auth/service.test.ts
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { sanitizeRedirectPath } from './service.js';
+
+test('sanitizeRedirectPath keeps local app routes', () => {
+    assert.equal(sanitizeRedirectPath('/notes/123?tab=edit#title'), '/notes/123?tab=edit#title');
+});
+
+test('sanitizeRedirectPath keeps localhost absolute urls for local auth redirects', () => {
+    assert.equal(
+        sanitizeRedirectPath('http://127.0.0.1:5173/notes/123?tab=edit#title'),
+        'http://127.0.0.1:5173/notes/123?tab=edit#title',
+    );
+});
+
+test('sanitizeRedirectPath blocks login routes and foreign hosts', () => {
+    assert.equal(sanitizeRedirectPath('/login?next=%2Fnotes'), '/');
+    assert.equal(sanitizeRedirectPath('https://example.com/notes/123'), '/');
+});

--- a/packages/server/src/features/auth/service.ts
+++ b/packages/server/src/features/auth/service.ts
@@ -1,3 +1,5 @@
+import { buildAuthSessionResponse, sanitizeRedirectPath as sanitizeCommonRedirectPath } from '@baejino/auth';
+import { compareSharedSecret as compareCommonSharedSecret } from '@baejino/auth/crypto';
 import crypto from 'crypto';
 import type { Request } from 'express';
 import type { AuthConfig } from '~/modules/auth-mode.js';
@@ -15,26 +17,14 @@ export const comparePassword = async (password: string, storedHash: string) => {
     return hash === newHash;
 };
 
-export const compareSharedSecret = (expected: string, received: string) => {
-    const expectedBuffer = Buffer.from(expected, 'utf8');
-    const receivedBuffer = Buffer.from(received, 'utf8');
+export const compareSharedSecret = compareCommonSharedSecret;
 
-    if (expectedBuffer.length !== receivedBuffer.length) {
-        return false;
-    }
-
-    return crypto.timingSafeEqual(expectedBuffer, receivedBuffer);
-};
-
-export const buildSessionResponse = (authConfig: AuthConfig, req: Request) => ({
-    mode: authConfig.mode,
-    authRequired: authConfig.mode === 'password',
-    authenticated: authConfig.mode === 'password' ? Boolean(req.session?.authenticated) : false,
-});
+export const buildSessionResponse = (authConfig: AuthConfig, req: Request) =>
+    buildAuthSessionResponse(authConfig, Boolean(req.session?.authenticated));
 
 export const assertPasswordLoginAvailable = (authConfig: AuthConfig) => {
-    if (authConfig.mode !== 'password' || !authConfig.password) {
-        throw createAppError(409, 'AUTH_DISABLED', 'Login is unavailable while auth mode is disabled.');
+    if (authConfig.mode !== 'password') {
+        throw createAppError(409, 'AUTH_OPEN_MODE', 'Login is unavailable while auth mode is open.');
     }
 
     return authConfig.password;
@@ -70,43 +60,9 @@ export const destroySession = async (req: Request) => {
     });
 };
 
-export const sanitizeRedirectPath = (value: unknown) => {
-    if (typeof value !== 'string' || value.length === 0) {
-        return '/';
-    }
-
-    if (value.startsWith('/')) {
-        if (
-            value.startsWith('//') ||
-            value === '/login' ||
-            value.startsWith('/login?') ||
-            value === '/logout' ||
-            value.startsWith('/logout?')
-        ) {
-            return '/';
-        }
-
-        return value;
-    }
-
-    try {
-        const redirectUrl = new URL(value);
-        const hostname = redirectUrl.hostname.toLowerCase();
-
-        if (!['http:', 'https:'].includes(redirectUrl.protocol)) {
-            return '/';
-        }
-
-        if (!['localhost', '127.0.0.1', '::1', '[::1]'].includes(hostname)) {
-            return '/';
-        }
-
-        if (redirectUrl.pathname === '/login' || redirectUrl.pathname === '/logout') {
-            return '/';
-        }
-
-        return `${redirectUrl.origin}${redirectUrl.pathname}${redirectUrl.search}${redirectUrl.hash}`;
-    } catch {
-        return '/';
-    }
-};
+export const sanitizeRedirectPath = (value: unknown) =>
+    sanitizeCommonRedirectPath(value, {
+        fallbackPath: '/',
+        loginPath: '/login',
+        allowedAbsoluteHosts: ['localhost', '127.0.0.1', '::1'],
+    });

--- a/packages/server/src/features/mcp-admin/http/handlers.test.ts
+++ b/packages/server/src/features/mcp-admin/http/handlers.test.ts
@@ -2,8 +2,16 @@ import assert from 'node:assert/strict';
 import type { AddressInfo } from 'node:net';
 import test, { type TestContext } from 'node:test';
 import { createAppWithMcpAuth } from '~/app.js';
-import type { AuthConfig } from '~/modules/auth-mode.js';
+import { AUTH_SESSION_COOKIE_NAME, type AuthConfig } from '~/modules/auth-mode.js';
 import type { McpAdminService } from '../service.js';
+
+const createPasswordAuthConfig = (): AuthConfig => ({
+    mode: 'password',
+    password: 'secret',
+    sessionSecret: 'session-secret',
+    cookieName: AUTH_SESSION_COOKIE_NAME,
+    source: 'password',
+});
 
 const createStubMcpAdminService = (input: { enabled?: boolean; hasActiveToken?: boolean } = {}): McpAdminService => {
     let enabled = input.enabled ?? true;
@@ -92,12 +100,7 @@ const login = async (baseUrl: string) => {
 };
 
 test('GET /api/mcp-admin/status requires authenticated session in password mode', async (t) => {
-    const { baseUrl } = await startServer(t, {
-        mode: 'password',
-        password: 'secret',
-        sessionSecret: 'session-secret',
-        source: 'override',
-    });
+    const { baseUrl } = await startServer(t, createPasswordAuthConfig());
 
     const status = await jsonRequest(baseUrl, '/api/mcp-admin/status', 'GET');
     assert.equal(status.status, 401);
@@ -105,16 +108,7 @@ test('GET /api/mcp-admin/status requires authenticated session in password mode'
 });
 
 test('POST /api/mcp-admin/token/rotate returns plaintext token once for authenticated session', async (t) => {
-    const { baseUrl } = await startServer(
-        t,
-        {
-            mode: 'password',
-            password: 'secret',
-            sessionSecret: 'session-secret',
-            source: 'override',
-        },
-        createStubMcpAdminService(),
-    );
+    const { baseUrl } = await startServer(t, createPasswordAuthConfig(), createStubMcpAdminService());
 
     const cookie = await login(baseUrl);
 
@@ -126,16 +120,7 @@ test('POST /api/mcp-admin/token/rotate returns plaintext token once for authenti
 
 test('POST /api/mcp-admin/enabled toggles enabled state for authenticated session', async (t) => {
     const service = createStubMcpAdminService({ enabled: false });
-    const { baseUrl } = await startServer(
-        t,
-        {
-            mode: 'password',
-            password: 'secret',
-            sessionSecret: 'session-secret',
-            source: 'override',
-        },
-        service,
-    );
+    const { baseUrl } = await startServer(t, createPasswordAuthConfig(), service);
 
     const cookie = await login(baseUrl);
     const enabled = await jsonRequest(baseUrl, '/api/mcp-admin/enabled', 'POST', { enabled: true }, cookie);
@@ -146,16 +131,7 @@ test('POST /api/mcp-admin/enabled toggles enabled state for authenticated sessio
 
 test('POST /api/mcp-admin/token/revoke revokes active token for authenticated session', async (t) => {
     const service = createStubMcpAdminService({ enabled: true, hasActiveToken: true });
-    const { baseUrl } = await startServer(
-        t,
-        {
-            mode: 'password',
-            password: 'secret',
-            sessionSecret: 'session-secret',
-            source: 'override',
-        },
-        service,
-    );
+    const { baseUrl } = await startServer(t, createPasswordAuthConfig(), service);
 
     const cookie = await login(baseUrl);
     const revoked = await jsonRequest(baseUrl, '/api/mcp-admin/token/revoke', 'POST', {}, cookie);

--- a/packages/server/src/modules/auth-guard.ts
+++ b/packages/server/src/modules/auth-guard.ts
@@ -1,3 +1,4 @@
+import { buildUnauthorizedGraphqlPayload, buildUnauthorizedPayload } from '@baejino/auth';
 import type { NextFunction, Request, RequestHandler, Response } from 'express';
 import session from 'express-session';
 import type { ValidationRule } from 'graphql';
@@ -7,42 +8,30 @@ import type { AuthConfig } from './auth-mode.js';
 
 const JSON_HEADERS = { 'Content-Type': 'application/json' };
 
-const buildUnauthorizedPayload = () => ({
-    code: 'UNAUTHORIZED',
-    message: 'Authentication required',
-});
-
-const buildUnauthorizedGraphqlPayload = () => ({
-    errors: [
-        {
-            message: 'Authentication required',
-            extensions: { code: 'UNAUTHORIZED' },
-        },
-    ],
-});
-
 export const isAuthenticatedRequest = (req: Request) => Boolean(req.session?.authenticated);
 
 export const createSessionMiddleware = (authConfig: AuthConfig): RequestHandler => {
-    if (authConfig.mode !== 'password' || !authConfig.sessionSecret) {
+    if (authConfig.mode !== 'password') {
         return (_req, _res, next) => next();
     }
 
     return session({
         secret: authConfig.sessionSecret,
-        name: 'ocean-brain.sid',
+        name: authConfig.cookieName,
         resave: false,
         saveUninitialized: false,
         cookie: {
             httpOnly: true,
             sameSite: 'lax',
+            secure: process.env.NODE_ENV === 'production',
+            path: '/',
         },
     });
 };
 
 export const requireSessionForWrite = (authConfig: AuthConfig): RequestHandler => {
     return (req: Request, res: Response, next: NextFunction) => {
-        if (authConfig.mode === 'disabled' || isAuthenticatedRequest(req)) {
+        if (authConfig.mode === 'open' || isAuthenticatedRequest(req)) {
             next();
             return;
         }
@@ -53,7 +42,7 @@ export const requireSessionForWrite = (authConfig: AuthConfig): RequestHandler =
 
 export const requireSessionForGraphql = (authConfig: AuthConfig): RequestHandler => {
     return (req: Request, res: Response, next: NextFunction) => {
-        if (authConfig.mode === 'disabled' || isAuthenticatedRequest(req)) {
+        if (authConfig.mode === 'open' || isAuthenticatedRequest(req)) {
             next();
             return;
         }
@@ -70,10 +59,14 @@ export const createMutationAuthValidationRule = (): ValidationRule => {
                     return;
                 }
 
+                const unauthorizedError = buildUnauthorizedGraphqlPayload().errors[0];
+
                 context.reportError(
-                    new GraphQLError('Authentication required', {
+                    new GraphQLError(unauthorizedError.message, {
                         nodes: [node],
-                        extensions: { code: 'UNAUTHORIZED' },
+                        extensions: {
+                            code: unauthorizedError.extensions.code,
+                        },
                     }),
                 );
             },

--- a/packages/server/src/modules/auth-mode.ts
+++ b/packages/server/src/modules/auth-mode.ts
@@ -1,68 +1,32 @@
-export type AuthMode = 'password' | 'disabled';
+import { type AuthConfig, type AuthEnvironment, resolvePasswordAuthConfig } from '@baejino/auth';
 
-export interface AuthConfig {
-    mode: AuthMode;
-    password?: string;
-    sessionSecret?: string;
-    source: 'auto' | 'override';
-}
+export type { AuthConfig, AuthMode } from '@baejino/auth';
 
-export interface AuthModeEnvironment {
+export const AUTH_SESSION_COOKIE_NAME = 'ocean-brain.sid';
+
+export interface AuthModeEnvironment extends AuthEnvironment {
     [key: string]: string | undefined;
     OCEAN_BRAIN_ALLOW_INSECURE_NO_AUTH?: string;
     OCEAN_BRAIN_PASSWORD?: string;
     OCEAN_BRAIN_SESSION_SECRET?: string;
 }
 
-const isTruthy = (value?: string) => {
-    if (!value) {
-        return false;
-    }
-
-    return ['1', 'true', 'yes', 'on'].includes(value.trim().toLowerCase());
-};
-
-const ensurePasswordModeRequirements = (env: AuthModeEnvironment) => {
-    if (!env.OCEAN_BRAIN_PASSWORD) {
-        throw new Error('Missing OCEAN_BRAIN_PASSWORD. Set OCEAN_BRAIN_PASSWORD to enable password auth mode.');
-    }
-
-    if (!env.OCEAN_BRAIN_SESSION_SECRET) {
-        throw new Error(
-            'Missing OCEAN_BRAIN_SESSION_SECRET. Set OCEAN_BRAIN_SESSION_SECRET when password auth mode is enabled.',
-        );
-    }
-};
-
-export const resolveAuthConfig = (env: AuthModeEnvironment): AuthConfig => {
-    const allowInsecureNoAuth = isTruthy(env.OCEAN_BRAIN_ALLOW_INSECURE_NO_AUTH);
-
-    if (allowInsecureNoAuth) {
-        return {
-            mode: 'disabled',
-            source: 'auto',
-        };
-    }
-
-    if (env.OCEAN_BRAIN_PASSWORD) {
-        ensurePasswordModeRequirements(env);
-
-        return {
-            mode: 'password',
-            password: env.OCEAN_BRAIN_PASSWORD,
-            sessionSecret: env.OCEAN_BRAIN_SESSION_SECRET,
-            source: 'auto',
-        };
-    }
-
-    throw new Error(
-        'Unable to resolve auth mode. Set OCEAN_BRAIN_PASSWORD and OCEAN_BRAIN_SESSION_SECRET for password mode, or set OCEAN_BRAIN_ALLOW_INSECURE_NO_AUTH=true for disabled mode.',
-    );
-};
+export const resolveAuthConfig = (env: AuthModeEnvironment): AuthConfig =>
+    resolvePasswordAuthConfig({
+        env,
+        passwordEnv: 'OCEAN_BRAIN_PASSWORD',
+        sessionSecretEnv: 'OCEAN_BRAIN_SESSION_SECRET',
+        allowOpenEnv: 'OCEAN_BRAIN_ALLOW_INSECURE_NO_AUTH',
+        requireExplicitOpen: true,
+        allowPasswordAsSessionSecret: false,
+        cookieName: AUTH_SESSION_COOKIE_NAME,
+    });
 
 export const logAuthConfig = (authConfig: AuthConfig) => {
-    if (authConfig.mode === 'disabled') {
-        process.stderr.write('[auth] Running in disabled mode. Authentication is not required for write access.\n');
+    if (authConfig.mode === 'open') {
+        process.stderr.write(
+            '[auth] Running in explicit open mode. Authentication is not required for write access.\n',
+        );
         return;
     }
 

--- a/packages/server/test/auth-mode.test.ts
+++ b/packages/server/test/auth-mode.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { resolveAuthConfig } from '../src/modules/auth-mode.js';
+import { AUTH_SESSION_COOKIE_NAME, resolveAuthConfig } from '../src/modules/auth-mode.js';
 
 test('resolveAuthConfig returns password mode when password env is present', () => {
     const authConfig = resolveAuthConfig({
@@ -10,24 +10,32 @@ test('resolveAuthConfig returns password mode when password env is present', () 
     });
 
     assert.equal(authConfig.mode, 'password');
-    assert.equal(authConfig.source, 'auto');
+    assert.equal(authConfig.source, 'password');
+    assert.equal(authConfig.cookieName, AUTH_SESSION_COOKIE_NAME);
 });
 
-test('resolveAuthConfig returns disabled mode when insecure flag is enabled', () => {
+test('resolveAuthConfig returns open mode when insecure flag is enabled', () => {
     const authConfig = resolveAuthConfig({ OCEAN_BRAIN_ALLOW_INSECURE_NO_AUTH: 'true' });
 
-    assert.equal(authConfig.mode, 'disabled');
+    assert.deepEqual(authConfig, {
+        mode: 'open',
+        source: 'explicit-open',
+        cookieName: AUTH_SESSION_COOKIE_NAME,
+    });
 });
 
 test('resolveAuthConfig throws when password mode is missing session secret', () => {
     assert.throws(() => resolveAuthConfig({ OCEAN_BRAIN_PASSWORD: 'secret' }), /OCEAN_BRAIN_SESSION_SECRET/);
 });
 
-test('resolveAuthConfig prioritizes insecure flag when both insecure flag and password env are present', () => {
-    const authConfig = resolveAuthConfig({
-        OCEAN_BRAIN_ALLOW_INSECURE_NO_AUTH: 'true',
-        OCEAN_BRAIN_PASSWORD: 'secret',
-    });
-
-    assert.equal(authConfig.mode, 'disabled');
+test('resolveAuthConfig fails closed when both insecure flag and password env are present', () => {
+    assert.throws(
+        () =>
+            resolveAuthConfig({
+                OCEAN_BRAIN_ALLOW_INSECURE_NO_AUTH: 'true',
+                OCEAN_BRAIN_PASSWORD: 'secret',
+                OCEAN_BRAIN_SESSION_SECRET: 'session-secret',
+            }),
+        /Conflicting auth config/,
+    );
 });

--- a/packages/server/test/mcp-auth.test.ts
+++ b/packages/server/test/mcp-auth.test.ts
@@ -3,7 +3,21 @@ import type { AddressInfo } from 'node:net';
 import test, { type TestContext } from 'node:test';
 import { createAppWithMcpAuth } from '../src/app.js';
 import type { McpAdminService } from '../src/features/mcp-admin/service.js';
-import type { AuthConfig } from '../src/modules/auth-mode.js';
+import { AUTH_SESSION_COOKIE_NAME, type AuthConfig } from '../src/modules/auth-mode.js';
+
+const createPasswordAuthConfig = (): AuthConfig => ({
+    mode: 'password',
+    password: 'secret',
+    sessionSecret: 'session-secret',
+    cookieName: AUTH_SESSION_COOKIE_NAME,
+    source: 'password',
+});
+
+const createOpenAuthConfig = (): AuthConfig => ({
+    mode: 'open',
+    cookieName: AUTH_SESSION_COOKIE_NAME,
+    source: 'explicit-open',
+});
 
 const startServer = async (t: TestContext, authConfig: AuthConfig, mcpAdminAuth: McpAdminService) => {
     const app = createAppWithMcpAuth(authConfig, mcpAdminAuth);
@@ -157,12 +171,7 @@ const createMcpAdminAuth = (options: {
 test('password mode requires a valid bearer token on the MCP graphql endpoint', async (t) => {
     const { baseUrl } = await startServer(
         t,
-        {
-            mode: 'password',
-            password: 'secret',
-            sessionSecret: 'session-secret',
-            source: 'override',
-        },
+        createPasswordAuthConfig(),
         createMcpAdminAuth({ enabled: true, expectedToken: 'mcp-secret' }),
     );
 
@@ -182,12 +191,7 @@ test('password mode requires a valid bearer token on the MCP graphql endpoint', 
 test('password mode requires a session on the server events endpoint', async (t) => {
     const { baseUrl } = await startServer(
         t,
-        {
-            mode: 'password',
-            password: 'secret',
-            sessionSecret: 'session-secret',
-            source: 'override',
-        },
+        createPasswordAuthConfig(),
         createMcpAdminAuth({ enabled: true, expectedToken: 'mcp-secret' }),
     );
 
@@ -200,13 +204,10 @@ test('password mode requires a session on the server events endpoint', async (t)
     });
 });
 
-test('disabled mode exposes the server events endpoint as an event stream', async (t) => {
+test('open mode exposes the server events endpoint as an event stream', async (t) => {
     const { baseUrl } = await startServer(
         t,
-        {
-            mode: 'disabled',
-            source: 'override',
-        },
+        createOpenAuthConfig(),
         createMcpAdminAuth({ enabled: true, expectedToken: 'mcp-secret' }),
     );
 
@@ -220,12 +221,7 @@ test('disabled mode exposes the server events endpoint as an event stream', asyn
 test('password mode keeps the MCP graphql endpoint read-only even with a valid bearer token', async (t) => {
     const { baseUrl } = await startServer(
         t,
-        {
-            mode: 'password',
-            password: 'secret',
-            sessionSecret: 'session-secret',
-            source: 'override',
-        },
+        createPasswordAuthConfig(),
         createMcpAdminAuth({ enabled: true, expectedToken: 'mcp-secret' }),
     );
 
@@ -237,10 +233,7 @@ test('password mode keeps the MCP graphql endpoint read-only even with a valid b
 test('mcp disabled state blocks MCP graphql access even with a valid token', async (t) => {
     const { baseUrl } = await startServer(
         t,
-        {
-            mode: 'disabled',
-            source: 'override',
-        },
+        createOpenAuthConfig(),
         createMcpAdminAuth({ enabled: false, expectedToken: 'mcp-secret' }),
     );
 
@@ -252,10 +245,7 @@ test('mcp disabled state blocks MCP graphql access even with a valid token', asy
 test('enabled state still requires a valid bearer token on the MCP note delete endpoint', async (t) => {
     const { baseUrl } = await startServer(
         t,
-        {
-            mode: 'disabled',
-            source: 'override',
-        },
+        createOpenAuthConfig(),
         createMcpAdminAuth({ enabled: true, expectedToken: 'mcp-secret' }),
     );
 
@@ -275,10 +265,7 @@ test('enabled state still requires a valid bearer token on the MCP note delete e
 test('enabled state still requires a valid bearer token on the MCP note create endpoint', async (t) => {
     const { baseUrl } = await startServer(
         t,
-        {
-            mode: 'disabled',
-            source: 'override',
-        },
+        createOpenAuthConfig(),
         createMcpAdminAuth({ enabled: true, expectedToken: 'mcp-secret' }),
     );
 
@@ -298,10 +285,7 @@ test('enabled state still requires a valid bearer token on the MCP note create e
 test('enabled state still requires a valid bearer token on the MCP note update endpoint', async (t) => {
     const { baseUrl } = await startServer(
         t,
-        {
-            mode: 'disabled',
-            source: 'override',
-        },
+        createOpenAuthConfig(),
         createMcpAdminAuth({ enabled: true, expectedToken: 'mcp-secret' }),
     );
 
@@ -321,10 +305,7 @@ test('enabled state still requires a valid bearer token on the MCP note update e
 test('enabled state still requires a valid bearer token on the MCP tag create endpoint', async (t) => {
     const { baseUrl } = await startServer(
         t,
-        {
-            mode: 'disabled',
-            source: 'override',
-        },
+        createOpenAuthConfig(),
         createMcpAdminAuth({ enabled: true, expectedToken: 'mcp-secret' }),
     );
 
@@ -344,12 +325,7 @@ test('enabled state still requires a valid bearer token on the MCP tag create en
 test('password mode returns configuration error on the MCP note delete endpoint when no bearer token is configured', async (t) => {
     const { baseUrl } = await startServer(
         t,
-        {
-            mode: 'password',
-            password: 'secret',
-            sessionSecret: 'session-secret',
-            source: 'override',
-        },
+        createPasswordAuthConfig(),
         createMcpAdminAuth({ enabled: true, configured: false }),
     );
 
@@ -361,12 +337,7 @@ test('password mode returns configuration error on the MCP note delete endpoint 
 test('password mode returns configuration error on the MCP note create endpoint when no bearer token is configured', async (t) => {
     const { baseUrl } = await startServer(
         t,
-        {
-            mode: 'password',
-            password: 'secret',
-            sessionSecret: 'session-secret',
-            source: 'override',
-        },
+        createPasswordAuthConfig(),
         createMcpAdminAuth({ enabled: true, configured: false }),
     );
 
@@ -378,12 +349,7 @@ test('password mode returns configuration error on the MCP note create endpoint 
 test('password mode returns configuration error on the MCP note update endpoint when no bearer token is configured', async (t) => {
     const { baseUrl } = await startServer(
         t,
-        {
-            mode: 'password',
-            password: 'secret',
-            sessionSecret: 'session-secret',
-            source: 'override',
-        },
+        createPasswordAuthConfig(),
         createMcpAdminAuth({ enabled: true, configured: false }),
     );
 
@@ -395,12 +361,7 @@ test('password mode returns configuration error on the MCP note update endpoint 
 test('password mode returns configuration error on the MCP tag create endpoint when no bearer token is configured', async (t) => {
     const { baseUrl } = await startServer(
         t,
-        {
-            mode: 'password',
-            password: 'secret',
-            sessionSecret: 'session-secret',
-            source: 'override',
-        },
+        createPasswordAuthConfig(),
         createMcpAdminAuth({ enabled: true, configured: false }),
     );
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,9 @@ importers:
 
   packages/cli:
     dependencies:
+      '@baejino/auth':
+        specifier: 0.1.1
+        version: 0.1.1
       '@blocknote/server-util':
         specifier: ^0.46.2
         version: 0.46.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.6)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -55,9 +58,15 @@ importers:
 
   packages/client:
     dependencies:
+      '@baejino/auth':
+        specifier: 0.1.1
+        version: 0.1.1
       '@baejino/handy':
         specifier: ^0.2.3
         version: 0.2.3
+      '@baejino/react-ui':
+        specifier: ^0.2.0
+        version: 0.2.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@blocknote/core':
         specifier: ^0.46.2
         version: 0.46.2(@types/hast@3.0.4)
@@ -88,24 +97,9 @@ importers:
       '@phosphor-icons/react':
         specifier: ^2.1.10
         version: 2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@radix-ui/react-dialog':
-        specifier: ^1.1.15
-        version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@radix-ui/react-dropdown-menu':
-        specifier: ^2.1.16
-        version: 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@radix-ui/react-select':
-        specifier: ^2.2.6
-        version: 2.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-slot':
         specifier: ^1.2.4
         version: 1.2.4(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-toggle-group':
-        specifier: ^1.1.11
-        version: 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@radix-ui/react-tooltip':
-        specifier: ^1.2.8
-        version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@tanstack/react-query':
         specifier: ^5.90.21
         version: 5.90.21(react@19.2.4)
@@ -200,6 +194,9 @@ importers:
 
   packages/server:
     dependencies:
+      '@baejino/auth':
+        specifier: 0.1.1
+        version: 0.1.1
       '@blocknote/server-util':
         specifier: ^0.46.2
         version: 0.46.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.6)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -782,8 +779,17 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
+  '@baejino/auth@0.1.1':
+    resolution: {integrity: sha512-2Z3AcM3JFsL4DKYu/ajv0+6zL1D7q18axaBWfWRg6eK/JYE4p6oMUmt7k6RwwiqbB2bO0doyr0anmRQ22q+Gpg==}
+
   '@baejino/handy@0.2.3':
     resolution: {integrity: sha512-znE97aBZ4BaZPf7/oqDtpA7aWO1zXX9LGtfd80wSl7jUnii7rHddQt7Kx5tPbXK47DKxkbQLXe5UGNiZHRMlAg==}
+
+  '@baejino/react-ui@0.2.0':
+    resolution: {integrity: sha512-NHWgMhHcXI8IQARUyt2KnQ8OuMkHxGU6KWB0nBrrkDH9tWxCmc+5+Qav6Bnubz3SCdZy5inTJFN74he06dB7Wg==}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
 
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
@@ -1505,6 +1511,19 @@ packages:
 
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
+
+  '@radix-ui/react-alert-dialog@1.1.15':
+    resolution: {integrity: sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
 
   '@radix-ui/react-arrow@1.1.7':
     resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
@@ -4722,6 +4741,12 @@ packages:
     resolution: {integrity: sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==}
     engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
 
+  sonner@2.0.7:
+    resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -5985,7 +6010,24 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@baejino/auth@0.1.1': {}
+
   '@baejino/handy@0.2.3': {}
+
+  '@baejino/react-ui@0.2.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-alert-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-dropdown-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-select': 2.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-toggle-group': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-tooltip': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      sonner: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
 
   '@bcoe/v8-coverage@1.0.2': {}
 
@@ -6641,6 +6683,20 @@ snapshots:
   '@radix-ui/number@1.1.1': {}
 
   '@radix-ui/primitive@1.1.3': {}
+
+  '@radix-ui/react-alert-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -10181,6 +10237,11 @@ snapshots:
       ip-address: 10.1.0
       smart-buffer: 4.2.0
     optional: true
+
+  sonner@2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   source-map-js@1.2.1: {}
 


### PR DESCRIPTION
## :dart: Goal
- Move Ocean Brain auth adapter code onto the shared @baejino/auth contracts while preserving server-owned /login behavior.
- Replace local Radix/modal/toast wiring with @baejino/react-ui adapters so the app consumes the shared UI runtime.

## :hammer_and_wrench: Core Changes
- Uses @baejino/auth for auth config resolution, session responses, unauthorized payloads, shared secret comparison, and redirect sanitization.
- Keeps human auth on canonical /login and proxies /login plus /logout through Vite dev server so the server HTML login page owns password mode.
- Migrates dialog, dropdown, select, toggle group, tooltip, confirm, and toast wrappers to @baejino/react-ui.
- Keeps @baejino/auth in the CLI package because the serve command imports the bundled server runtime; mcp continues to use only MCP bearer-token handling.

## :brain: Key Decisions
- CLI auth validation is only applied to serve. The mcp command still only resolves MCP token options and starts the MCP server.
- Open mode now follows the shared auth package naming and fails closed when insecure-open and password envs conflict.
- Release impact: packages/cli/package.json changed for a runtime dependency. Expected release version: next planned CLI release, no version bump in this PR. Tag plan: no tag from this PR; tag during the release PR.

## :test_tube: Verification Guide
### How to verify
1. pnpm check:encoding
2. pnpm lint
3. pnpm type-check
4. pnpm test:ci
5. pnpm build
6. pnpm --filter ocean-brain build

### Expected result
- All commands pass.
- CLI_SMOKE is configured to run only for chore/release-v* branches or workflow_dispatch; for this non-release PR, local CLI build passed and PR CI should skip npx smoke.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)