### PR TITLE
✨ Add note export downloads

### DIFF
--- a/packages/client/src/apis/note.api.ts
+++ b/packages/client/src/apis/note.api.ts
@@ -186,7 +186,7 @@ export function fetchNotesByTagNames({ tagNames, mode = 'and', limit = 25, offse
 export function fetchNote(id: string) {
     return graphQuery<
         {
-            note: Pick<Note, 'title' | 'content' | 'pinned' | 'layout' | 'updatedAt'>;
+            note: Pick<Note, 'title' | 'content' | 'pinned' | 'layout' | 'createdAt' | 'updatedAt'>;
         },
         { id: string }
     >(
@@ -196,6 +196,7 @@ export function fetchNote(id: string) {
                 pinned
                 layout
                 content
+                createdAt
                 updatedAt
             }
         }`,

--- a/packages/client/src/components/shared/Editor/Editor.tsx
+++ b/packages/client/src/components/shared/Editor/Editor.tsx
@@ -3,6 +3,11 @@ import { useCreateBlockNote } from '@blocknote/react';
 import { forwardRef, useImperativeHandle } from 'react';
 import { uploadImage } from '~/apis/image.api';
 import schema, { CommandView, ReferenceView, TagView } from '~/components/schema';
+import {
+    type MarkdownBlock,
+    prepareBlocksForMarkdown,
+    restoreTagPlaceholdersInMarkdown,
+} from '~/modules/blocknote-markdown';
 import { fileToBase64 } from '~/modules/file';
 import { useTheme } from '~/store/theme';
 
@@ -15,6 +20,8 @@ interface EditorProps {
 
 export interface EditorRef {
     getContent: () => string;
+    getMarkdown: () => string;
+    getHtml: () => string;
 }
 
 const Editor = forwardRef<EditorRef, EditorProps>(({ content, currentNoteId, editable, onChange }, ref) => {
@@ -33,6 +40,17 @@ const Editor = forwardRef<EditorRef, EditorProps>(({ content, currentNoteId, edi
         return {
             getContent: () => {
                 return JSON.stringify(editor.document);
+            },
+            getMarkdown: () => {
+                const prepared = prepareBlocksForMarkdown(editor.document as unknown as MarkdownBlock[]);
+                const markdown = editor.blocksToMarkdownLossy(
+                    prepared.blocks as Parameters<typeof editor.blocksToMarkdownLossy>[0],
+                );
+
+                return restoreTagPlaceholdersInMarkdown(markdown, prepared.placeholderToTag);
+            },
+            getHtml: () => {
+                return editor.blocksToHTMLLossy(editor.document);
             },
         };
     });

--- a/packages/client/src/modules/blocknote-markdown.spec.ts
+++ b/packages/client/src/modules/blocknote-markdown.spec.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { type MarkdownBlock, prepareBlocksForMarkdown, restoreTagPlaceholdersInMarkdown } from './blocknote-markdown';
+
+describe('blocknote markdown helpers', () => {
+    it('serializes custom references and tags into explicit markdown-friendly text', () => {
+        const blocks: MarkdownBlock[] = [
+            {
+                type: 'paragraph',
+                content: [
+                    { type: 'tag', props: { tag: '@project' } },
+                    { type: 'text', text: ' ', styles: {} },
+                    { type: 'reference', props: { title: 'Reference Note' } },
+                ],
+                children: [],
+            },
+        ];
+
+        const prepared = prepareBlocksForMarkdown(blocks);
+
+        expect(prepared.blocks[0].content).toEqual([
+            { type: 'text', text: 'OCEAN_BRAIN_TAG_0_TOKEN', styles: {} },
+            { type: 'text', text: ' ', styles: {} },
+            { type: 'text', text: '[[Reference Note]]', styles: {} },
+        ]);
+        expect(
+            restoreTagPlaceholdersInMarkdown('OCEAN_BRAIN_TAG_0_TOKEN [[Reference Note]]', prepared.placeholderToTag),
+        ).toBe('[@project] [[Reference Note]]');
+    });
+
+    it('strips unsupported table of contents blocks', () => {
+        const prepared = prepareBlocksForMarkdown([
+            { type: 'tableOfContents', content: [], children: [] },
+            { type: 'paragraph', content: [{ type: 'text', text: 'Body', styles: {} }], children: [] },
+        ]);
+
+        expect(prepared.blocks).toHaveLength(1);
+        expect(prepared.blocks[0].type).toBe('paragraph');
+    });
+
+    it('serializes custom inline content inside table cells', () => {
+        const prepared = prepareBlocksForMarkdown([
+            {
+                type: 'table',
+                content: {
+                    type: 'tableContent',
+                    rows: [
+                        {
+                            cells: [
+                                {
+                                    content: [
+                                        { type: 'tag', props: { tag: '#topic' } },
+                                        { type: 'reference', props: { title: 'Table Note' } },
+                                    ],
+                                },
+                            ],
+                        },
+                    ],
+                },
+                children: [],
+            },
+        ]);
+
+        expect(prepared.blocks[0].content).toMatchObject({
+            rows: [
+                {
+                    cells: [
+                        {
+                            content: [
+                                { type: 'text', text: 'OCEAN_BRAIN_TAG_0_TOKEN', styles: {} },
+                                { type: 'text', text: '[[Table Note]]', styles: {} },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+});

--- a/packages/client/src/modules/blocknote-markdown.ts
+++ b/packages/client/src/modules/blocknote-markdown.ts
@@ -1,0 +1,121 @@
+interface MarkdownInlineContent {
+    type: string;
+    props?: Record<string, unknown>;
+    text?: string;
+    styles?: Record<string, unknown>;
+    [key: string]: unknown;
+}
+
+interface MarkdownTableCell {
+    content?: MarkdownInlineContent[];
+    [key: string]: unknown;
+}
+
+interface MarkdownTableRow {
+    cells?: MarkdownTableCell[];
+    [key: string]: unknown;
+}
+
+interface MarkdownTableContent {
+    type: 'tableContent';
+    rows?: MarkdownTableRow[];
+    [key: string]: unknown;
+}
+
+export interface MarkdownBlock {
+    type: string;
+    content?: MarkdownInlineContent[] | MarkdownTableContent;
+    children?: MarkdownBlock[];
+    [key: string]: unknown;
+}
+
+const UNSUPPORTED_MARKDOWN_BLOCK_TYPES = new Set(['tableOfContents']);
+const TAG_PLACEHOLDER_PREFIX = 'OCEAN_BRAIN_TAG_';
+const TAG_PLACEHOLDER_SUFFIX = '_TOKEN';
+
+const createTagPlaceholder = (index: number) => `${TAG_PLACEHOLDER_PREFIX}${index}${TAG_PLACEHOLDER_SUFFIX}`;
+
+const isTableContent = (content: MarkdownBlock['content']): content is MarkdownTableContent => {
+    return !Array.isArray(content) && content?.type === 'tableContent';
+};
+
+const mapBlockContent = (
+    content: MarkdownBlock['content'],
+    mapInline: (inline: MarkdownInlineContent) => MarkdownInlineContent,
+): MarkdownBlock['content'] => {
+    if (Array.isArray(content)) {
+        return content.map(mapInline);
+    }
+
+    if (!isTableContent(content)) {
+        return content;
+    }
+
+    return {
+        ...content,
+        rows: content.rows?.map((row) => ({
+            ...row,
+            cells: row.cells?.map((cell) => ({
+                ...cell,
+                content: cell.content?.map(mapInline),
+            })),
+        })),
+    };
+};
+
+const mapBlocks = (
+    blocks: MarkdownBlock[],
+    mapContent: (content: MarkdownBlock['content']) => MarkdownBlock['content'],
+): MarkdownBlock[] => {
+    return blocks
+        .filter((block) => !UNSUPPORTED_MARKDOWN_BLOCK_TYPES.has(block.type))
+        .map((block) => ({
+            ...block,
+            content: mapContent(block.content),
+            children: block.children?.length ? mapBlocks(block.children, mapContent) : [],
+        }));
+};
+
+export function prepareBlocksForMarkdown(blocks: MarkdownBlock[]) {
+    const placeholderToTag = new Map<string, string>();
+    let nextPlaceholderIndex = 0;
+
+    const markdownBlocks = mapBlocks(blocks, (content) =>
+        mapBlockContent(content, (inline) => {
+            if (inline.type === 'reference') {
+                return {
+                    type: 'text',
+                    text: `[[${inline.props?.title || inline.props?.id || ''}]]`,
+                    styles: {},
+                };
+            }
+
+            if (inline.type === 'tag') {
+                const tag = (inline.props?.tag as string) || '';
+                const placeholder = createTagPlaceholder(nextPlaceholderIndex);
+                nextPlaceholderIndex += 1;
+                placeholderToTag.set(placeholder, tag);
+
+                return {
+                    type: 'text',
+                    text: placeholder,
+                    styles: {},
+                };
+            }
+
+            return inline;
+        }),
+    );
+
+    return { blocks: markdownBlocks, placeholderToTag };
+}
+
+export function restoreTagPlaceholdersInMarkdown(markdown: string, placeholderToTag: Map<string, string>) {
+    let restoredMarkdown = markdown;
+
+    for (const [placeholder, tag] of placeholderToTag.entries()) {
+        restoredMarkdown = restoredMarkdown.split(placeholder).join(`[${tag}]`);
+    }
+
+    return restoredMarkdown;
+}

--- a/packages/client/src/modules/note-export.spec.ts
+++ b/packages/client/src/modules/note-export.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { createHtmlExport, createMarkdownExport, getNoteExportFilename } from './note-export';
+
+describe('note-export', () => {
+    it('creates a safe markdown filename from a note title', () => {
+        expect(getNoteExportFilename('VSCode에서 탈출하기?', 'md')).toBe('vscode에서-탈출하기.md');
+    });
+
+    it('adds frontmatter when markdown metadata is requested', () => {
+        const markdown = createMarkdownExport(
+            'Body',
+            {
+                id: '123',
+                title: 'Hello: World',
+                createdAt: '1778198400000',
+                updatedAt: '1778198400000',
+            },
+            true,
+        );
+
+        expect(markdown).toContain('---\ntitle: "Hello: World"');
+        expect(markdown).toContain('note_id: 123');
+        expect(markdown).toContain('source: ocean-brain\n---\n\nBody');
+    });
+
+    it('wraps html in a complete document when standalone mode is requested', () => {
+        const html = createHtmlExport('<p>Body</p>', { id: '123', title: 'Hello <World>' }, { mode: 'standalone' });
+
+        expect(html).toContain('<!doctype html>');
+        expect(html).toContain('<title>Hello &lt;World&gt;</title>');
+        expect(html).toContain('<p>Body</p>');
+    });
+});

--- a/packages/client/src/modules/note-export.ts
+++ b/packages/client/src/modules/note-export.ts
@@ -1,0 +1,125 @@
+interface NoteExportMetadata {
+    id: string;
+    title: string;
+    createdAt?: string;
+    updatedAt?: string;
+}
+
+export type HtmlExportMode = 'fragment' | 'standalone';
+
+const YAML_SPECIAL_CHAR_PATTERN = /[:{}[\],&*#?|<>=!%@`-]/;
+
+const normalizeTitleForFilename = (title: string) => {
+    const normalized = title
+        .trim()
+        .toLowerCase()
+        .replace(/\s+/g, '-')
+        .replace(/[\\/:*?"<>|]/g, '-')
+        .replace(/-+/g, '-')
+        .replace(/^-|-$/g, '');
+
+    return normalized || 'untitled-note';
+};
+
+const escapeHtml = (value: string) =>
+    value
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+
+const formatYamlString = (value: string) => {
+    if (!value) {
+        return '""';
+    }
+
+    if (YAML_SPECIAL_CHAR_PATTERN.test(value) || /^\s|\s$/.test(value)) {
+        return JSON.stringify(value);
+    }
+
+    return value;
+};
+
+const formatTimestamp = (timestamp?: string) => {
+    if (!timestamp) {
+        return undefined;
+    }
+
+    const numericTimestamp = Number(timestamp);
+
+    if (!Number.isFinite(numericTimestamp)) {
+        return timestamp;
+    }
+
+    return new Date(numericTimestamp).toISOString();
+};
+
+export const getNoteExportFilename = (title: string, extension: 'md' | 'html') => {
+    return `${normalizeTitleForFilename(title)}.${extension}`;
+};
+
+export const createMarkdownFrontmatter = ({ id, title, createdAt, updatedAt }: NoteExportMetadata) => {
+    const lines = ['---', `title: ${formatYamlString(title)}`, `note_id: ${formatYamlString(id)}`];
+    const formattedCreatedAt = formatTimestamp(createdAt);
+    const formattedUpdatedAt = formatTimestamp(updatedAt);
+
+    if (formattedCreatedAt) {
+        lines.push(`created_at: ${formatYamlString(formattedCreatedAt)}`);
+    }
+
+    if (formattedUpdatedAt) {
+        lines.push(`updated_at: ${formatYamlString(formattedUpdatedAt)}`);
+    }
+
+    lines.push('source: ocean-brain', '---');
+
+    return lines.join('\n');
+};
+
+export const createMarkdownExport = (markdown: string, metadata: NoteExportMetadata, includeMetadata = false) => {
+    if (!includeMetadata) {
+        return markdown;
+    }
+
+    return `${createMarkdownFrontmatter(metadata)}\n\n${markdown}`;
+};
+
+export const createHtmlExport = (
+    html: string,
+    metadata: NoteExportMetadata,
+    { includeMetadata = false, mode = 'fragment' }: { includeMetadata?: boolean; mode?: HtmlExportMode } = {},
+) => {
+    const metadataComment = includeMetadata
+        ? `<!--\nsource: ocean-brain\nnote_id: ${metadata.id}\ntitle: ${metadata.title}\ncreated_at: ${formatTimestamp(metadata.createdAt) ?? ''}\nupdated_at: ${formatTimestamp(metadata.updatedAt) ?? ''}\n-->\n`
+        : '';
+
+    if (mode === 'fragment') {
+        return `${metadataComment}${html}`;
+    }
+
+    return `<!doctype html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>${escapeHtml(metadata.title)}</title>
+</head>
+<body>
+${metadataComment}${html}
+</body>
+</html>`;
+};
+
+export const downloadTextFile = (content: string, filename: string, type: string) => {
+    const blob = new Blob([content], { type });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+
+    anchor.href = url;
+    anchor.download = filename;
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+    URL.revokeObjectURL(url);
+};

--- a/packages/client/src/pages/Note.tsx
+++ b/packages/client/src/pages/Note.tsx
@@ -9,13 +9,30 @@ import { BackReferences } from '~/components/entities';
 import * as Icon from '~/components/icon';
 import { LayoutModal, RestoreSnapshotModal } from '~/components/note';
 import { ReminderPanel } from '~/components/reminder';
-import { AuxiliaryPanelHeader, Button, Callout, Dropdown, PageLayout, Skeleton } from '~/components/shared';
+import {
+    AuxiliaryPanelHeader,
+    Button,
+    Callout,
+    Dropdown,
+    Modal,
+    ModalActionRow,
+    PageLayout,
+    SelectionOptionCard,
+    Skeleton,
+} from '~/components/shared';
 import type { EditorRef } from '~/components/shared/Editor';
 import Editor from '~/components/shared/Editor';
-import { MoreButton, Text, useToast } from '~/components/ui';
+import { Checkbox, MoreButton, Text, useToast } from '~/components/ui';
 import useNoteMutate from '~/hooks/resource/useNoteMutate';
 import useDebounce from '~/hooks/useDebounce';
 import type { NoteLayout } from '~/models/note.model';
+import {
+    createHtmlExport,
+    createMarkdownExport,
+    downloadTextFile,
+    getNoteExportFilename,
+    type HtmlExportMode,
+} from '~/modules/note-export';
 import { queryKeys } from '~/modules/query-key-factory';
 import { subscribeServerEvent } from '~/modules/server-events';
 import { NOTE_ROUTE, SETTINGS_TRASH_ROUTE } from '~/modules/url';
@@ -81,6 +98,10 @@ function NoteContent({ id }: NoteContentProps) {
     const [layout, setLayout] = useState<NoteLayout>(note.layout || 'wide');
     const [isLayoutModalOpen, setIsLayoutModalOpen] = useState(false);
     const [isRestoreModalOpen, setIsRestoreModalOpen] = useState(false);
+    const [isExportModalOpen, setIsExportModalOpen] = useState(false);
+    const [exportFormat, setExportFormat] = useState<'markdown' | 'html'>('markdown');
+    const [includeMetadata, setIncludeMetadata] = useState(false);
+    const [htmlExportMode, setHtmlExportMode] = useState<HtmlExportMode>('fragment');
     const [externalNoteChange, setExternalNoteChange] = useState<ExternalNoteChange | null>(null);
     const [isMountedEvent, mountEvent] = useDebounce(1000);
 
@@ -180,6 +201,84 @@ function NoteContent({ id }: NoteContentProps) {
         toast('Layout has been updated.');
     };
 
+    const getExportMetadata = () => ({
+        id,
+        title,
+        createdAt: note.createdAt,
+        updatedAt: note.updatedAt,
+    });
+
+    const handleCopyMarkdown = async () => {
+        const markdown = editorRef.current?.getMarkdown();
+
+        if (markdown === undefined) {
+            toast('Markdown is not ready yet.');
+            return;
+        }
+
+        try {
+            await navigator.clipboard.writeText(markdown);
+            toast('Copied note as Markdown.');
+        } catch {
+            toast('Failed to copy Markdown.');
+        }
+    };
+
+    const handleDownloadMarkdown = () => {
+        const markdown = editorRef.current?.getMarkdown();
+
+        if (markdown === undefined) {
+            toast('Markdown is not ready yet.');
+            return;
+        }
+
+        try {
+            downloadTextFile(markdown, getNoteExportFilename(title, 'md'), 'text/markdown;charset=utf-8');
+            toast('Downloaded note as Markdown.');
+        } catch {
+            toast('Failed to download Markdown.');
+        }
+    };
+
+    const handleDownloadOtherFormat = () => {
+        const metadata = getExportMetadata();
+
+        try {
+            if (exportFormat === 'markdown') {
+                const markdown = editorRef.current?.getMarkdown();
+
+                if (markdown === undefined) {
+                    toast('Markdown is not ready yet.');
+                    return;
+                }
+
+                downloadTextFile(
+                    createMarkdownExport(markdown, metadata, includeMetadata),
+                    getNoteExportFilename(title, 'md'),
+                    'text/markdown;charset=utf-8',
+                );
+            } else {
+                const html = editorRef.current?.getHtml();
+
+                if (html === undefined) {
+                    toast('HTML is not ready yet.');
+                    return;
+                }
+
+                downloadTextFile(
+                    createHtmlExport(html, metadata, { includeMetadata, mode: htmlExportMode }),
+                    getNoteExportFilename(title, 'html'),
+                    'text/html;charset=utf-8',
+                );
+            }
+
+            setIsExportModalOpen(false);
+            toast('Downloaded note.');
+        } catch {
+            toast('Failed to download note.');
+        }
+    };
+
     const handleReloadExternalChange = async () => {
         const response = await noteQuery.refetch();
 
@@ -224,6 +323,19 @@ function NoteContent({ id }: NoteContentProps) {
                                 <Dropdown
                                     button={<MoreButton label="Note actions" size="lg" />}
                                     items={[
+                                        {
+                                            name: 'Copy Markdown',
+                                            onClick: handleCopyMarkdown,
+                                        },
+                                        {
+                                            name: 'Download Markdown',
+                                            onClick: handleDownloadMarkdown,
+                                        },
+                                        {
+                                            name: 'Download in another format',
+                                            onClick: () => setIsExportModalOpen(true),
+                                        },
+                                        { type: 'separator', key: 'export-separator' },
                                         {
                                             name: isPinned ? 'Unpin' : 'Pin',
                                             onClick: () =>
@@ -412,6 +524,82 @@ function NoteContent({ id }: NoteContentProps) {
                     onSave={handleLayoutSave}
                     currentLayout={layout}
                 />
+                <Modal isOpen={isExportModalOpen} onClose={() => setIsExportModalOpen(false)} variant="compact">
+                    <Modal.Header title="Download in another format" onClose={() => setIsExportModalOpen(false)} />
+                    <Modal.Body>
+                        <div className="flex flex-col gap-4">
+                            <div className="flex flex-col gap-2">
+                                <Text as="div" variant="body" weight="semibold" tone="secondary">
+                                    Format
+                                </Text>
+                                <div className="grid gap-2 sm:grid-cols-2">
+                                    <SelectionOptionCard
+                                        title="Markdown"
+                                        description="Good for GitHub, static blogs, and other note apps."
+                                        selected={exportFormat === 'markdown'}
+                                        onClick={() => setExportFormat('markdown')}
+                                    />
+                                    <SelectionOptionCard
+                                        title="HTML"
+                                        description="Good for web documents or CMS editors."
+                                        selected={exportFormat === 'html'}
+                                        onClick={() => setExportFormat('html')}
+                                    />
+                                </div>
+                            </div>
+
+                            <div className="flex items-start gap-3 rounded-[14px] border border-border-subtle bg-subtle/60 p-3">
+                                <Checkbox
+                                    size="sm"
+                                    checked={includeMetadata}
+                                    onChange={(event) => setIncludeMetadata(event.target.checked)}
+                                    className="mt-0.5"
+                                    aria-label="Include metadata"
+                                />
+                                <div className="flex flex-col gap-1">
+                                    <Text as="span" variant="body" weight="semibold">
+                                        Include metadata
+                                    </Text>
+                                    <Text as="span" variant="label" tone="tertiary">
+                                        Add the title, note id, timestamps, and Ocean Brain source information.
+                                    </Text>
+                                </div>
+                            </div>
+
+                            {exportFormat === 'html' && (
+                                <div className="flex flex-col gap-2">
+                                    <Text as="div" variant="body" weight="semibold" tone="secondary">
+                                        HTML style
+                                    </Text>
+                                    <div className="grid gap-2 sm:grid-cols-2">
+                                        <SelectionOptionCard
+                                            title="Content only"
+                                            description="Save only the note body HTML."
+                                            selected={htmlExportMode === 'fragment'}
+                                            onClick={() => setHtmlExportMode('fragment')}
+                                        />
+                                        <SelectionOptionCard
+                                            title="Full HTML document"
+                                            description="Save a complete HTML file that opens in a browser."
+                                            selected={htmlExportMode === 'standalone'}
+                                            onClick={() => setHtmlExportMode('standalone')}
+                                        />
+                                    </div>
+                                </div>
+                            )}
+                        </div>
+                    </Modal.Body>
+                    <Modal.Footer>
+                        <ModalActionRow>
+                            <Button variant="ghost" size="sm" onClick={() => setIsExportModalOpen(false)}>
+                                Cancel
+                            </Button>
+                            <Button variant="primary" size="sm" onClick={handleDownloadOtherFormat}>
+                                Download
+                            </Button>
+                        </ModalActionRow>
+                    </Modal.Footer>
+                </Modal>
                 <RestoreSnapshotModal
                     isOpen={isRestoreModalOpen}
                     noteId={id}


### PR DESCRIPTION
## :dart: Goal
Add note export actions so users can copy or download the current note as Markdown and download alternate export formats.

## :hammer_and_wrench: Core Changes
- Added BlockNote export helpers that convert custom reference/tag inline content into Markdown-friendly `[[Note]]` and `[@tag]` text.
- Added note export utilities for Markdown frontmatter, HTML fragment/standalone output, safe filenames, and browser text-file downloads.
- Added note action menu items for copying Markdown, downloading Markdown, and opening an export format modal.
- Included created/updated metadata in exports by fetching `createdAt` on note detail queries.

## :brain: Key Decisions
- Kept the quick Markdown download metadata-free for a fast one-click export path.
- Added metadata as an explicit option in the alternate export modal.
- Removed unsupported BlockNote table-of-contents blocks from Markdown export to avoid lossy serializer issues.

## :test_tube: Verification Guide
- `pnpm --filter client lint` → passes with no fixes applied.
- `pnpm --filter client type-check` → passes.
- `pnpm --filter client test -- blocknote-markdown note-export --run` → passes, 42 files / 112 tests.
- `pnpm --filter client build` → passes; Vite reports existing large chunk warnings after successful build.

## :white_check_mark: Checklist
- [x] Local validation for the changed client scope is complete.
- [x] Tests were added for Markdown conversion and export formatting helpers.
- [x] PR title follows `<emoji> <subject>` and the subject starts with an English verb.
- [x] No release-impacting files were changed.
