### PR TITLE
🔖 Bump version to 0.4.1

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ocean-brain",
-    "version": "0.4.0",
+    "version": "0.4.1",
     "type": "module",
     "repository": {
         "type": "git",


### PR DESCRIPTION
## :dart: Goal
Prepare the next patch release for Ocean Brain CLI and bundled app artifacts.

## :hammer_and_wrench: Core Changes
- Bump `packages/cli/package.json` from `0.4.0` to `0.4.1`.
- Expected release version: `0.4.1`.
- Tag plan: `v0.4.1` after this PR is merged into `main`.

## :brain: Key Decisions
- Use a patch release because the changes since `v0.4.0` are feature/fix-level improvements that do not require migration steps.
- Keep the version bump isolated in a dedicated release PR per release strategy.

## :test_tube: Verification Guide
- `CLI_SMOKE` must pass on this `chore/release-v0.4.1` PR before merge.
- After merge, trigger the release explicitly with `git tag v0.4.1 && git push origin v0.4.1` from updated `main`.

## :white_check_mark: Checklist
- [x] Version bump is isolated to `packages/cli/package.json`.
- [x] Expected version is documented: `0.4.1`.
- [x] Tag plan is documented: `v0.4.1`.
- [ ] `CLI_SMOKE` passed on this release PR.
