### PR TITLE
🛠 Fix CLI smoke auth mode expectation

### DIFF
--- a/scripts/ci/smoke-cli-npx.mjs
+++ b/scripts/ci/smoke-cli-npx.mjs
@@ -253,7 +253,7 @@ async function runScenario(scenario) {
         await waitForReady(child, readyTimeoutMs);
         if (scenario.expectation === 'graphql-open') {
             await assertAuthSession({
-                mode: 'disabled',
+                mode: 'open',
                 authRequired: false,
                 authenticated: false
             });

--- a/scripts/ci/smoke-cli-npx.mjs
+++ b/scripts/ci/smoke-cli-npx.mjs
@@ -217,16 +217,16 @@ async function stopProcess(child) {
     }
 }
 
-export async function expectAuthFailure(child, getStderr) {
+export async function expectAuthFailure(child, getStderr, timeoutMs = 15000) {
     if (child.exitCode === null && child.signalCode === null) {
         await Promise.race([
             new Promise(resolve => child.once('exit', resolve)),
-            sleep(15000)
+            sleep(timeoutMs)
         ]);
     }
 
     if (child.exitCode === null && child.signalCode === null) {
-        throw new Error('CLI process did not fail within 15000ms for missing-auth scenario');
+        throw new Error(`CLI process did not fail within ${timeoutMs}ms for missing-auth scenario`);
     }
 
     const stderrBuffer = getStderr();
@@ -245,7 +245,7 @@ async function runScenario(scenario) {
 
     try {
         if (scenario.name === 'missing-auth') {
-            await expectAuthFailure(child, getStderr);
+            await expectAuthFailure(child, getStderr, readyTimeoutMs);
             console.log(`CLI smoke scenario passed: ${scenario.name}`);
             return;
         }


### PR DESCRIPTION
## :dart: Goal
Fix the CLI smoke workflow expectations after the auth route standardization.

## :hammer_and_wrench: Core Changes
- Expect open-mode auth sessions to report `mode: open` instead of the old disabled-mode label.
- Reuse the platform-specific ready timeout for the missing-auth scenario so Windows has enough time to reach the expected auth failure.

## :brain: Key Decisions
- Keep this CI fix separate from the release version bump so the release PR can stay version-only.

## :test_tube: Verification Guide
- `node --test scripts/ci/smoke-cli-npx.test.mjs` → passes.
- `pnpm lint` → passes.
- PR CI should pass before merge.

## :white_check_mark: Checklist
- [x] Local validation is complete.
- [x] CI smoke behavior is updated for current auth mode naming.
- [x] No release version files were changed.
