### PR TITLE
🛠 Clarify release accessibility safeguards

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ Open `http://localhost:6683` after startup.
 
 ### Docker
 
+The examples below use Docker's default floating tag (`latest`) for quick trials.
+For production, pin an exact image tag such as `baealex/ocean-brain:<version>`.
+
 No auth (local/trusted only):
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: "2.1"
 
 services:
   app:
+    # Quick-start sample uses latest. Pin baealex/ocean-brain:<exact-version> for production.
     image: baealex/ocean-brain:latest
     # build:
     #   context: .

--- a/docs/process/DEPLOYMENT_RELEASE_STRATEGY.md
+++ b/docs/process/DEPLOYMENT_RELEASE_STRATEGY.md
@@ -72,6 +72,7 @@ git push origin v0.3.1
 ## 6. Manual Release Runbook
 1. Verify release package
 - Required: latest `CLI_SMOKE` workflow is green for the release target PR or commit.
+- Required before tagging: confirm the release commit on `main` has already passed the required PR CI (`lint`, `type-check`, `build`). The tag-triggered `RELEASE` workflow publishes artifacts; it is not a replacement for main-branch quality validation.
 
 2. Collect unreleased changes before version bump
 - Commit list:

--- a/packages/client/src/styles/main.scss
+++ b/packages/client/src/styles/main.scss
@@ -48,8 +48,8 @@ body {
     overflow-wrap: anywhere;
 }
 
-div:focus {
-    outline: none !important;
+div:focus:not(:focus-visible) {
+    outline: none;
 }
 
 .window-modal__container {


### PR DESCRIPTION
## :dart: Goal
- Clarify that Docker quick-start examples use `latest` only for trials and production should pin an exact image tag.
- Preserve keyboard focus visibility by avoiding a blanket `div:focus` outline removal.

## :hammer_and_wrench: Core Changes
- Added Docker tag guidance to `README.md` and `docker-compose.yml`.
- Updated the release runbook to require PR CI validation before release tagging.
- Changed the global `div:focus` style to keep outlines for `:focus-visible` interactions.

## :brain: Key Decisions
- Kept the compose sample on `latest` for quick starts while documenting exact tag pinning for production.
- Did not create or push a release tag, and did not run the `RELEASE` workflow.
- Release-impact metadata: expected release version is not assigned in this PR; tag plan is none; `CLI_SMOKE` was not run because this PR does not trigger a release workflow.

## :test_tube: Verification Guide
### How to verify
1. `pnpm --filter @ocean-brain/client type-check`
2. `pnpm --filter @ocean-brain/client lint`

### Expected result
- `pnpm --filter @ocean-brain/client type-check` passed.
- `pnpm --filter @ocean-brain/client lint` passed: `Checked 249 files in 81ms. No fixes applied.`

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [ ] Tests completed — Not run; requested validation scope was client lint and type-check.
- [x] Documentation updated (if needed)
