### PR TITLE
🐛 Fix reference parsing reliability

### DIFF
--- a/packages/server/src/features/note/graphql/note.query.resolver.test.ts
+++ b/packages/server/src/features/note/graphql/note.query.resolver.test.ts
@@ -1,7 +1,11 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { createAllNotesQueryResolver } from './note.query.resolver.js';
+import {
+    createAllNotesQueryResolver,
+    createBackReferencesQueryResolver,
+    createNoteGraphQueryResolver,
+} from './note.query.resolver.js';
 
 test('allNotes resolver uses stored searchable text with DB pagination when no stale notes exist', async () => {
     const findCalls: unknown[] = [];
@@ -225,4 +229,125 @@ test('allNotes resolver leaves unfiltered queries on the fast default path', asy
     });
     assert.equal(result.totalCount, 3);
     assert.deepEqual(result.notes, []);
+});
+
+test('backReferences resolver finds structurally valid references in formatted note JSON', async () => {
+    const resolver = createBackReferencesQueryResolver({
+        findCandidateNotes: async (noteId) => {
+            assert.equal(noteId, 7);
+
+            return [
+                {
+                    id: 8,
+                    title: 'Source note',
+                    content: JSON.stringify(
+                        [
+                            {
+                                id: 'paragraph-1',
+                                type: 'paragraph',
+                                props: {},
+                                content: [
+                                    {
+                                        type: 'reference',
+                                        props: {
+                                            id: '7',
+                                            title: 'Target note',
+                                        },
+                                    },
+                                ],
+                                children: [],
+                            },
+                        ],
+                        null,
+                        2,
+                    ),
+                    searchableText: '',
+                    searchableTextVersion: 1,
+                    createdAt: new Date('2026-04-01T00:00:00.000Z'),
+                    updatedAt: new Date('2026-04-02T00:00:00.000Z'),
+                    pinned: false,
+                    order: 0,
+                    layout: 'wide',
+                },
+                {
+                    id: 9,
+                    title: 'Non-reference note',
+                    content: JSON.stringify([
+                        {
+                            id: 'paragraph-1',
+                            type: 'paragraph',
+                            props: {},
+                            content: [
+                                {
+                                    type: 'text',
+                                    text: 'The word reference alone is not a link.',
+                                    styles: {},
+                                },
+                            ],
+                            children: [],
+                        },
+                    ]),
+                    searchableText: '',
+                    searchableTextVersion: 1,
+                    createdAt: new Date('2026-04-01T00:00:00.000Z'),
+                    updatedAt: new Date('2026-04-03T00:00:00.000Z'),
+                    pinned: false,
+                    order: 0,
+                    layout: 'wide',
+                },
+            ] as never;
+        },
+    });
+
+    const result = await resolver(null, { id: '7' });
+
+    assert.deepEqual(
+        result.map((note) => note.id),
+        [8],
+    );
+});
+
+test('noteGraph resolver uses the shared structural reference parser', async () => {
+    const resolver = createNoteGraphQueryResolver({
+        findNotes: async () => [
+            {
+                id: 1,
+                title: 'Source',
+                content: JSON.stringify(
+                    [
+                        {
+                            id: 'paragraph-1',
+                            type: 'paragraph',
+                            props: {},
+                            content: [
+                                {
+                                    type: 'reference',
+                                    props: {
+                                        id: '2',
+                                        title: 'Target',
+                                    },
+                                },
+                            ],
+                            children: [],
+                        },
+                    ],
+                    null,
+                    2,
+                ),
+            },
+            {
+                id: 2,
+                title: 'Target',
+                content: JSON.stringify([]),
+            },
+        ],
+    });
+
+    assert.deepEqual(await resolver(), {
+        nodes: [
+            { id: '1', title: 'Source', connections: 1 },
+            { id: '2', title: 'Target', connections: 1 },
+        ],
+        links: [{ source: '1', target: '2' }],
+    });
 });

--- a/packages/server/src/features/note/graphql/note.query.resolver.ts
+++ b/packages/server/src/features/note/graphql/note.query.resolver.ts
@@ -4,7 +4,7 @@ import {
     buildNoteGraph,
     contentReferencesNote,
     extractReferenceBlocksFromContent,
-    NOTE_REFERENCE_CONTENT_PREFILTER,
+    normalizeReferenceId,
     syncReferenceTitlesInContent,
 } from '~/features/note/services/content-blocks.js';
 import {
@@ -245,6 +245,51 @@ export const createAllNotesQueryResolver = (
 
 type NoteQueryResolvers = NonNullable<IResolvers['Query']>;
 
+interface BackReferencesQueryResolverDeps {
+    findCandidateNotes: (noteId: number) => Promise<Note[]>;
+}
+
+export const createBackReferencesQueryResolver = (
+    deps: BackReferencesQueryResolverDeps = {
+        findCandidateNotes: (noteId) =>
+            models.note.findMany({
+                orderBy: [{ pinned: 'desc' }, { updatedAt: 'desc' }],
+                where: {
+                    NOT: { id: noteId },
+                },
+            }),
+    },
+) => {
+    return async (_: unknown, { id }: { id: string }) => {
+        const notes = await deps.findCandidateNotes(Number(id));
+
+        return notes.filter((note) => contentReferencesNote(note.content, id));
+    };
+};
+
+interface NoteGraphQueryResolverDeps {
+    findNotes: () => Promise<Array<Pick<Note, 'id' | 'title' | 'content'>>>;
+}
+
+export const createNoteGraphQueryResolver = (
+    deps: NoteGraphQueryResolverDeps = {
+        findNotes: () =>
+            models.note.findMany({
+                select: {
+                    id: true,
+                    title: true,
+                    content: true,
+                },
+            }),
+    },
+) => {
+    return async () => {
+        const notes = await deps.findNotes();
+
+        return buildNoteGraph(notes);
+    };
+};
+
 export const noteQueryResolvers: NoteQueryResolvers = {
     allNotes: createAllNotesQueryResolver(),
     notesInDateRange: async (
@@ -347,17 +392,7 @@ export const noteQueryResolvers: NoteQueryResolvers = {
             orderBy: { updatedAt: 'desc' },
             where: { content: { contains: src } },
         }),
-    backReferences: async (_, { id }: { id: string }) => {
-        const notes = await models.note.findMany({
-            orderBy: [{ pinned: 'desc' }, { updatedAt: 'desc' }],
-            where: {
-                content: { contains: NOTE_REFERENCE_CONTENT_PREFILTER },
-                NOT: { id: Number(id) },
-            },
-        });
-
-        return notes.filter((note) => contentReferencesNote(note.content, id));
-    },
+    backReferences: createBackReferencesQueryResolver(),
     note: async (_, { id }: { id: string }) => {
         const note = await models.note.findUnique({ where: { id: Number(id) } });
 
@@ -376,7 +411,13 @@ export const noteQueryResolvers: NoteQueryResolvers = {
         }
 
         const referenceIds = Array.from(
-            new Set(blocks.map((block) => Number(block.props?.id)).filter(Number.isFinite)),
+            new Set(
+                blocks
+                    .map((block) => normalizeReferenceId(block.props?.id))
+                    .filter((referenceId): referenceId is string => referenceId !== null)
+                    .map(Number)
+                    .filter(Number.isFinite),
+            ),
         );
         const references = await models.note.findMany({ where: { id: { in: referenceIds } } });
         const titlesById = new Map(
@@ -470,15 +511,5 @@ export const noteQueryResolvers: NoteQueryResolvers = {
             offset: Number(pagination.offset),
         });
     },
-    noteGraph: async () => {
-        const notes = await models.note.findMany({
-            select: {
-                id: true,
-                title: true,
-                content: true,
-            },
-        });
-
-        return buildNoteGraph(notes);
-    },
+    noteGraph: createNoteGraphQueryResolver(),
 };

--- a/packages/server/src/features/note/services/cleanup.ts
+++ b/packages/server/src/features/note/services/cleanup.ts
@@ -1,5 +1,5 @@
 import models from '~/models.js';
-import { contentReferencesNote, NOTE_REFERENCE_CONTENT_PREFILTER } from './content-blocks.js';
+import { contentReferencesNote } from './content-blocks.js';
 import { trashNoteById as moveNoteToTrashById } from './trash.js';
 
 export interface NoteCleanupBackReference {
@@ -275,7 +275,6 @@ const noteCleanupService = createNoteCleanupService({
                     content: true,
                 },
                 where: {
-                    content: { contains: NOTE_REFERENCE_CONTENT_PREFILTER },
                     NOT: { id: noteId },
                 },
                 orderBy: [{ pinned: 'desc' }, { updatedAt: 'desc' }],

--- a/packages/server/src/features/note/services/content-blocks.test.ts
+++ b/packages/server/src/features/note/services/content-blocks.test.ts
@@ -57,6 +57,78 @@ test('extractReferenceBlocksFromContent reads nested inline references', () => {
     assert.equal(contentReferencesNote(content, 43), true);
 });
 
+test('contentReferencesNote compares normalized reference ids', () => {
+    const content = JSON.stringify([
+        {
+            id: 'paragraph-1',
+            type: 'paragraph',
+            props: {},
+            content: [
+                {
+                    type: 'reference',
+                    props: {
+                        title: 'Linked note',
+                        id: ' 42 ',
+                    },
+                },
+            ],
+            children: [],
+        },
+    ]);
+
+    assert.equal(contentReferencesNote(content, 42), true);
+    assert.equal(contentReferencesNote(content, '42'), true);
+});
+
+test('extractReferenceBlocksFromContent reads references inside deeply nested list items', () => {
+    const content = JSON.stringify([
+        {
+            id: 'list-1',
+            type: 'bulletListItem',
+            props: {},
+            content: [{ type: 'text', text: 'Level 1', styles: {} }],
+            children: [
+                {
+                    id: 'list-2',
+                    type: 'bulletListItem',
+                    props: {},
+                    content: [{ type: 'text', text: 'Level 2', styles: {} }],
+                    children: [
+                        {
+                            id: 'list-3',
+                            type: 'bulletListItem',
+                            props: {},
+                            content: [
+                                {
+                                    type: 'text',
+                                    text: 'Level 3 ',
+                                    styles: {},
+                                },
+                                {
+                                    type: 'reference',
+                                    props: {
+                                        id: '99',
+                                        title: 'Deep reference',
+                                    },
+                                },
+                            ],
+                            children: [],
+                        },
+                    ],
+                },
+            ],
+        },
+    ]);
+
+    const references = extractReferenceBlocksFromContent(content);
+
+    assert.deepEqual(
+        references.map((reference) => reference.props?.id),
+        ['99'],
+    );
+    assert.equal(contentReferencesNote(content, 99), true);
+});
+
 test('extractReferenceBlocksFromContent reads references inside table cells', () => {
     const content = JSON.stringify([
         {
@@ -94,6 +166,31 @@ test('syncReferenceTitlesInContent updates reference props structurally', () => 
                     props: {
                         title: 'Old title',
                         id: '7',
+                    },
+                },
+            ],
+            children: [],
+        },
+    ]);
+
+    const syncedContent = syncReferenceTitlesInContent(content, new Map([['7', 'Current title']]));
+
+    assert.ok(syncedContent);
+    assert.equal(JSON.parse(syncedContent)[0].content[0].props.title, 'Current title');
+});
+
+test('syncReferenceTitlesInContent matches normalized reference ids', () => {
+    const content = JSON.stringify([
+        {
+            id: 'paragraph-1',
+            type: 'paragraph',
+            props: {},
+            content: [
+                {
+                    type: 'reference',
+                    props: {
+                        title: 'Old title',
+                        id: ' 7 ',
                     },
                 },
             ],

--- a/packages/server/src/features/note/services/content-blocks.ts
+++ b/packages/server/src/features/note/services/content-blocks.ts
@@ -24,10 +24,22 @@ export interface NoteGraphResult {
     links: Array<{ source: string; target: string }>;
 }
 
-export const NOTE_REFERENCE_CONTENT_PREFILTER = '"type":"reference"';
-
 export const parseNoteContent = (content: string): unknown[] | null => {
     return parseBlockNoteContent(content);
+};
+
+export const normalizeReferenceId = (id: unknown) => {
+    if (typeof id === 'number') {
+        return Number.isFinite(id) ? String(id) : null;
+    }
+
+    if (typeof id !== 'string') {
+        return null;
+    }
+
+    const normalizedId = id.trim();
+
+    return normalizedId.length > 0 ? normalizedId : null;
 };
 
 export const extractBlocksByType = <T>(type: string, dataArray: unknown): BlockNote<T>[] => {
@@ -44,7 +56,7 @@ export const extractBlocksByType = <T>(type: string, dataArray: unknown): BlockN
 
 export const extractReferenceBlocks = (dataArray: unknown) => {
     return extractBlocksByType<ReferenceProps>('reference', dataArray).filter((block) => {
-        return block.props?.id !== undefined && block.props.id !== null && String(block.props.id).trim() !== '';
+        return normalizeReferenceId(block.props?.id) !== null;
     });
 };
 
@@ -54,8 +66,15 @@ export const extractReferenceBlocksFromContent = (content: string) => {
 };
 
 export const contentReferencesNote = (content: string, noteId: string | number) => {
-    const targetId = String(noteId);
-    return extractReferenceBlocksFromContent(content).some((block) => String(block.props?.id) === targetId);
+    const targetId = normalizeReferenceId(noteId);
+
+    if (!targetId) {
+        return false;
+    }
+
+    return extractReferenceBlocksFromContent(content).some(
+        (block) => normalizeReferenceId(block.props?.id) === targetId,
+    );
 };
 
 export const syncReferenceTitlesInContent = (content: string, titlesById: Map<string, string>) => {
@@ -69,13 +88,13 @@ export const syncReferenceTitlesInContent = (content: string, titlesById: Map<st
 
     for (const block of extractReferenceBlocks(parsed)) {
         const props = block.props;
-        const id = props?.id;
+        const id = normalizeReferenceId(props?.id);
 
-        if (!props || id === undefined || id === null) {
+        if (!props || id === null) {
             continue;
         }
 
-        const title = titlesById.get(String(id));
+        const title = titlesById.get(id);
 
         if (title !== undefined && props.title !== title) {
             block.props = {
@@ -99,7 +118,7 @@ export const buildNoteGraph = (notes: NoteGraphInput[]): NoteGraphResult => {
         const sourceId = String(note.id);
 
         for (const block of extractReferenceBlocksFromContent(note.content)) {
-            const targetId = block.props?.id ? String(block.props.id) : '';
+            const targetId = normalizeReferenceId(block.props?.id);
 
             if (!targetId || sourceId === targetId || !existingNoteIds.has(targetId)) {
                 continue;


### PR DESCRIPTION
## :dart: Goal
- Make note references and backlinks reliable regardless of JSON formatting or nested BlockNote structure.
- Prevent formatted note content from being skipped by brittle string prefilters.

## :hammer_and_wrench: Core Changes
- Parse note content structurally for backlink cleanup, backlink queries, and graph generation.
- Normalize reference ids before comparing or syncing titles.
- Add server tests for formatted JSON, false positives, normalized ids, graph parsing, and deeply nested list references.

## :brain: Key Decisions
- Removed the `"type":"reference"` string prefilter because it misses pretty-printed JSON and can disagree with the real BlockNote structure.
- Kept parsing centralized in the shared content block utilities so backlinks, cleanup, and graph behavior use the same rules.
- Accepted scanning candidate notes for now because correctness is more important than a fragile DB substring shortcut at the current note scale.

## :test_tube: Verification Guide
### How to verify
1. `pnpm --filter @ocean-brain/server lint`
2. `pnpm --filter @ocean-brain/server type-check`
3. `pnpm --filter @ocean-brain/server test:ci`
4. `pnpm --filter @ocean-brain/server build`

### Expected result
- Server lint, type-check, tests, and build complete successfully.
- Backlinks and note graph include references stored in formatted or nested BlockNote JSON.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (not needed)
