### PR TITLE
🐛 Improve note save reliability

### DIFF
--- a/packages/client/src/hooks/useNoteSaveController.spec.tsx
+++ b/packages/client/src/hooks/useNoteSaveController.spec.tsx
@@ -25,6 +25,15 @@ const createWrapper = (queryClient = createQueryClient()) => {
     );
 };
 
+const createDeferred = <T,>() => {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((nextResolve) => {
+        resolve = nextResolve;
+    });
+
+    return { promise, resolve };
+};
+
 describe('useNoteSaveController', () => {
     beforeEach(() => {
         vi.clearAllMocks();
@@ -288,5 +297,109 @@ describe('useNoteSaveController', () => {
         });
 
         expect(result.current.buildDraft('Next draft').baseUpdatedAt).toBe('1770000000000');
+    });
+
+    it('returns after an in-flight save flushes the newer queued draft', async () => {
+        const firstSave = createDeferred<Awaited<ReturnType<typeof updateNote>>>();
+        const secondSave = createDeferred<Awaited<ReturnType<typeof updateNote>>>();
+        vi.mocked(updateNote).mockReturnValueOnce(firstSave.promise).mockReturnValueOnce(secondSave.promise);
+        let content = 'content-a';
+        const { result } = renderHook(
+            () =>
+                useNoteSaveController({
+                    noteId: '7',
+                    initialContent: 'initial',
+                    initialUpdatedAt: '1770000000000',
+                    editSessionIdRef: { current: 'session-1' },
+                    getContent: () => content,
+                    onSaved: vi.fn(),
+                    onConflict: vi.fn(),
+                    onError: vi.fn(),
+                }),
+            { wrapper: createWrapper() },
+        );
+
+        await act(async () => {
+            result.current.queueSave(result.current.buildDraft('Draft A'), { immediate: true });
+        });
+
+        act(() => {
+            content = 'content-b';
+            result.current.queueSave(result.current.buildDraft('Draft B'));
+        });
+
+        let flushResult: Awaited<ReturnType<typeof result.current.flushPendingSave>> | undefined;
+        const flushPromise = result.current.flushPendingSave().then((result) => {
+            flushResult = result;
+        });
+
+        await act(async () => {
+            firstSave.resolve({
+                type: 'success',
+                updateNote: {
+                    id: '7',
+                    title: 'Draft A',
+                    updatedAt: '1770000001000',
+                },
+            } as never);
+            await firstSave.promise;
+        });
+
+        await waitFor(() => expect(updateNote).toHaveBeenCalledTimes(2));
+
+        await act(async () => {
+            secondSave.resolve({
+                type: 'success',
+                updateNote: {
+                    id: '7',
+                    title: 'Draft B',
+                    updatedAt: '1770000002000',
+                },
+            } as never);
+            await secondSave.promise;
+            await flushPromise;
+        });
+
+        expect(flushResult).toBe('saved');
+        expect(updateNote).toHaveBeenLastCalledWith({
+            id: '7',
+            title: 'Draft B',
+            content: 'content-b',
+            editSessionId: 'session-1',
+            expectedUpdatedAt: '1770000001000',
+        });
+    });
+
+    it('keeps the draft recoverable when the save request rejects', async () => {
+        const onError = vi.fn();
+        vi.mocked(updateNote).mockRejectedValue(new Error('offline'));
+        const { result } = renderHook(
+            () =>
+                useNoteSaveController({
+                    noteId: '7',
+                    initialContent: 'initial',
+                    initialUpdatedAt: '1770000000000',
+                    editSessionIdRef: { current: 'session-1' },
+                    getContent: () => 'content',
+                    onSaved: vi.fn(),
+                    onConflict: vi.fn(),
+                    onError,
+                }),
+            { wrapper: createWrapper() },
+        );
+
+        let flushResult: Awaited<ReturnType<typeof result.current.flushPendingSave>> | undefined;
+
+        await act(async () => {
+            result.current.queueSave(result.current.buildDraft('Rejected draft'));
+            flushResult = await result.current.flushPendingSave();
+        });
+
+        const storedDraft = JSON.parse(window.localStorage.getItem(getDraftStorageKey('7')) ?? '{}') as NoteSaveDraft;
+
+        expect(flushResult).toBe('error');
+        expect(result.current.saveStatus).toBe('error');
+        expect(onError).toHaveBeenCalledWith('Failed to save note.');
+        expect(storedDraft.title).toBe('Rejected draft');
     });
 });

--- a/packages/client/src/hooks/useNoteSaveController.ts
+++ b/packages/client/src/hooks/useNoteSaveController.ts
@@ -16,6 +16,7 @@ const NOTE_AUTOSAVE_DELAY_MS = 1000;
 const NOTE_UPDATE_CONFLICT_CODE = 'NOTE_UPDATE_CONFLICT';
 
 export type NoteSaveStatus = 'saved' | 'pending' | 'saving' | 'error' | 'conflict';
+export type NoteSaveFlushResult = 'idle' | 'saved' | 'error' | 'conflict';
 
 interface UseNoteSaveControllerParams {
     noteId: string;
@@ -48,6 +49,7 @@ export function useNoteSaveController({
     const saveTimerRef = useRef<number | null>(null);
     const pendingDraftRef = useRef<NoteSaveDraft | null>(null);
     const inFlightSaveRef = useRef(false);
+    const inFlightSavePromiseRef = useRef<Promise<NoteSaveFlushResult> | null>(null);
     const flushAfterInFlightRef = useRef(false);
     const serverUpdatedAtRef = useRef(initialUpdatedAt);
     const isSaveConflictRef = useRef(false);
@@ -106,13 +108,14 @@ export function useNoteSaveController({
         async ({ ignoreConflict = false, silent = false }: { ignoreConflict?: boolean; silent?: boolean } = {}) => {
             if (inFlightSaveRef.current) {
                 flushAfterInFlightRef.current = true;
-                return;
+                return inFlightSavePromiseRef.current ?? 'idle';
             }
 
             const draft = pendingDraftRef.current;
 
             if (!draft) {
-                return;
+                flushAfterInFlightRef.current = false;
+                return 'idle';
             }
 
             pendingDraftRef.current = null;
@@ -124,118 +127,142 @@ export function useNoteSaveController({
                 setMountedSaveStatus('saving');
             }
 
-            const response = await updateNote({
-                id: noteId,
-                title: draft.title,
-                content: draft.content,
-                ...(draft.layout ? { layout: draft.layout } : {}),
-                editSessionId: editSessionIdRef.current,
-                ...(ignoreConflict ? { force: true } : { expectedUpdatedAt: draft.baseUpdatedAt }),
-            });
+            const savePromise = (async (): Promise<NoteSaveFlushResult> => {
+                let response: Awaited<ReturnType<typeof updateNote>>;
 
-            inFlightSaveRef.current = false;
-
-            if (response.type === 'error') {
-                if (!pendingDraftRef.current) {
-                    pendingDraftRef.current = draft;
+                try {
+                    response = await updateNote({
+                        id: noteId,
+                        title: draft.title,
+                        content: draft.content,
+                        ...(draft.layout ? { layout: draft.layout } : {}),
+                        editSessionId: editSessionIdRef.current,
+                        ...(ignoreConflict ? { force: true } : { expectedUpdatedAt: draft.baseUpdatedAt }),
+                    });
+                } catch {
+                    response = {
+                        type: 'error',
+                        category: 'network',
+                        errors: [
+                            {
+                                code: 'NETWORK_ERROR',
+                                message: 'Failed to save note.',
+                            },
+                        ],
+                    };
                 }
 
-                persistCurrentPendingDraft();
+                inFlightSaveRef.current = false;
+                inFlightSavePromiseRef.current = null;
 
-                const error = response.errors[0];
-
-                if (error.code === NOTE_UPDATE_CONFLICT_CODE && !ignoreConflict) {
-                    const currentUpdatedAt = (error.details as { extensions?: { currentUpdatedAt?: string } })
-                        ?.extensions?.currentUpdatedAt;
-                    isSaveConflictRef.current = true;
-
-                    if (!silent && isAliveRef.current) {
-                        setMountedSaveStatus('conflict');
-                        onConflictRef.current(currentUpdatedAt ?? serverUpdatedAtRef.current);
+                if (response.type === 'error') {
+                    if (!pendingDraftRef.current) {
+                        pendingDraftRef.current = draft;
                     }
 
-                    return;
+                    persistCurrentPendingDraft();
+
+                    const error = response.errors[0];
+
+                    if (error.code === NOTE_UPDATE_CONFLICT_CODE && !ignoreConflict) {
+                        const currentUpdatedAt = (error.details as { extensions?: { currentUpdatedAt?: string } })
+                            ?.extensions?.currentUpdatedAt;
+                        isSaveConflictRef.current = true;
+
+                        if (!silent && isAliveRef.current) {
+                            setMountedSaveStatus('conflict');
+                            onConflictRef.current(currentUpdatedAt ?? serverUpdatedAtRef.current);
+                        }
+
+                        return 'conflict';
+                    }
+
+                    if (!silent && isAliveRef.current) {
+                        setMountedSaveStatus('error');
+                        onErrorRef.current(error.message);
+                    }
+
+                    return 'error';
                 }
 
-                if (!silent && isAliveRef.current) {
-                    setMountedSaveStatus('error');
-                    onErrorRef.current(error.message);
+                isSaveConflictRef.current = false;
+                serverUpdatedAtRef.current = response.updateNote.updatedAt;
+                const shouldNotifySave = !silent && isAliveRef.current;
+                const noteDetailQueryKey = queryKeys.notes.detail(noteId);
+
+                await queryClient.cancelQueries({
+                    queryKey: noteDetailQueryKey,
+                    exact: true,
+                });
+
+                if (shouldNotifySave) {
+                    onSavedRef.current(response.updateNote.updatedAt);
                 }
 
-                return;
-            }
+                queryClient.setQueryData<NoteDetailCache>(noteDetailQueryKey, (current) => {
+                    if (!current) {
+                        return current;
+                    }
 
-            isSaveConflictRef.current = false;
-            serverUpdatedAtRef.current = response.updateNote.updatedAt;
-            const shouldNotifySave = !silent && isAliveRef.current;
-            const noteDetailQueryKey = queryKeys.notes.detail(noteId);
-
-            await queryClient.cancelQueries({
-                queryKey: noteDetailQueryKey,
-                exact: true,
-            });
-
-            if (shouldNotifySave) {
-                onSavedRef.current(response.updateNote.updatedAt);
-            }
-
-            queryClient.setQueryData<NoteDetailCache>(noteDetailQueryKey, (current) => {
-                if (!current) {
-                    return current;
-                }
-
-                return {
-                    ...current,
-                    title: response.updateNote.title,
-                    content: draft.content,
-                    ...(draft.layout ? { layout: draft.layout } : {}),
+                    return {
+                        ...current,
+                        title: response.updateNote.title,
+                        content: draft.content,
+                        ...(draft.layout ? { layout: draft.layout } : {}),
+                        updatedAt: response.updateNote.updatedAt,
+                    };
+                });
+                publishClientNoteUpdatedEvent({
+                    noteId,
                     updatedAt: response.updateNote.updatedAt,
-                };
-            });
-            publishClientNoteUpdatedEvent({
-                noteId,
-                updatedAt: response.updateNote.updatedAt,
-                editSessionId: editSessionIdRef.current,
-            });
-            const nextPendingDraft = pendingDraftRef.current as NoteSaveDraft | null;
+                    editSessionId: editSessionIdRef.current,
+                });
+                const nextPendingDraft = pendingDraftRef.current as NoteSaveDraft | null;
 
-            if (nextPendingDraft?.baseUpdatedAt === draft.baseUpdatedAt) {
-                pendingDraftRef.current = {
-                    ...nextPendingDraft,
-                    baseUpdatedAt: response.updateNote.updatedAt,
-                };
-                persistCurrentPendingDraft();
-            } else if (!nextPendingDraft) {
-                clearLocalNoteDraft(noteId);
-            }
-
-            if (shouldNotifySave) {
-                if (pendingDraftRef.current) {
-                    setSaveStatus('pending');
-                } else {
-                    setSaveStatus('saved');
-                    void queryClient.invalidateQueries({
-                        queryKey: queryKeys.notes.listAll(),
-                        exact: false,
-                    });
-                    void queryClient.invalidateQueries({
-                        queryKey: queryKeys.notes.tagListAll(),
-                        exact: false,
-                    });
-                    void queryClient.invalidateQueries({
-                        queryKey: queryKeys.notes.backReferencesAll(),
-                        exact: false,
-                    });
-                    void queryClient.invalidateQueries({
-                        queryKey: queryKeys.notes.graph(),
-                        exact: true,
-                    });
+                if (nextPendingDraft?.baseUpdatedAt === draft.baseUpdatedAt) {
+                    pendingDraftRef.current = {
+                        ...nextPendingDraft,
+                        baseUpdatedAt: response.updateNote.updatedAt,
+                    };
+                    persistCurrentPendingDraft();
+                } else if (!nextPendingDraft) {
+                    clearLocalNoteDraft(noteId);
                 }
-            }
 
-            if (pendingDraftRef.current || flushAfterInFlightRef.current) {
-                void flushPendingSave({ silent });
-            }
+                if (shouldNotifySave) {
+                    if (pendingDraftRef.current) {
+                        setSaveStatus('pending');
+                    } else {
+                        setSaveStatus('saved');
+                        void queryClient.invalidateQueries({
+                            queryKey: queryKeys.notes.listAll(),
+                            exact: false,
+                        });
+                        void queryClient.invalidateQueries({
+                            queryKey: queryKeys.notes.tagListAll(),
+                            exact: false,
+                        });
+                        void queryClient.invalidateQueries({
+                            queryKey: queryKeys.notes.backReferencesAll(),
+                            exact: false,
+                        });
+                        void queryClient.invalidateQueries({
+                            queryKey: queryKeys.notes.graph(),
+                            exact: true,
+                        });
+                    }
+                }
+
+                if (pendingDraftRef.current || flushAfterInFlightRef.current) {
+                    return flushPendingSave({ silent });
+                }
+
+                return 'saved';
+            })();
+
+            inFlightSavePromiseRef.current = savePromise;
+
+            return savePromise;
         },
         [clearSaveTimer, editSessionIdRef, noteId, persistCurrentPendingDraft, queryClient, setMountedSaveStatus],
     );
@@ -284,6 +311,7 @@ export function useNoteSaveController({
     const clearDrafts = useCallback(() => {
         clearSaveTimer();
         pendingDraftRef.current = null;
+        inFlightSavePromiseRef.current = null;
         flushAfterInFlightRef.current = false;
         isSaveConflictRef.current = false;
         clearLocalNoteDraft(noteId);
@@ -293,6 +321,7 @@ export function useNoteSaveController({
 
     const resolveConflict = useCallback(() => {
         clearSaveTimer();
+        inFlightSavePromiseRef.current = null;
         flushAfterInFlightRef.current = false;
         isSaveConflictRef.current = false;
         setMountedSaveStatus(pendingDraftRef.current ? 'pending' : 'saved');
@@ -322,6 +351,8 @@ export function useNoteSaveController({
     }, [onConflict, onError, onSaved]);
 
     useEffect(() => {
+        isAliveRef.current = true;
+
         return () => {
             isAliveRef.current = false;
         };
@@ -339,6 +370,7 @@ export function useNoteSaveController({
     useEffect(() => {
         pendingDraftRef.current = null;
         inFlightSaveRef.current = false;
+        inFlightSavePromiseRef.current = null;
         flushAfterInFlightRef.current = false;
         isSaveConflictRef.current = false;
         serverUpdatedAtRef.current = initialUpdatedAt;

--- a/packages/client/src/modules/time.spec.ts
+++ b/packages/client/src/modules/time.spec.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { getRecentTimeSinceRefreshDelay, recentTimeSince, timeSince } from './time';
+
+describe('timeSince', () => {
+    it('formats elapsed time using the provided current time', () => {
+        expect(timeSince(1_770_000_000_000, 1_770_000_065_000)).toBe('1 minute ago');
+        expect(timeSince(1_770_000_000_000, 1_770_000_125_000)).toBe('2 minutes ago');
+    });
+
+    it('does not return negative elapsed time for future timestamps', () => {
+        expect(timeSince(1_770_000_010_000, 1_770_000_000_000)).toBe('0 seconds ago');
+    });
+});
+
+describe('recentTimeSince', () => {
+    it('uses just now for the first minute', () => {
+        expect(recentTimeSince(1_770_000_000_000, 1_770_000_059_000)).toBe('just now');
+        expect(recentTimeSince(null, 1_770_000_059_000)).toBe('just now');
+        expect(recentTimeSince(1_770_000_010_000, 1_770_000_000_000)).toBe('just now');
+    });
+
+    it('uses minute-based relative time after the first minute', () => {
+        expect(recentTimeSince(1_770_000_000_000, 1_770_000_060_000)).toBe('1 minute ago');
+    });
+
+    it('returns the next meaningful refresh delay', () => {
+        expect(getRecentTimeSinceRefreshDelay(1_770_000_000_000, 1_770_000_010_000)).toBe(50_000);
+        expect(getRecentTimeSinceRefreshDelay(1_770_000_000_000, 1_770_000_070_000)).toBe(50_000);
+    });
+});

--- a/packages/client/src/modules/time.ts
+++ b/packages/client/src/modules/time.ts
@@ -1,27 +1,61 @@
-export function timeSince(timestamp: number) {
-    const now = new Date();
+const RECENT_TIME_JUST_NOW_DURATION_MS = 60_000;
+const RECENT_TIME_REFRESH_INTERVAL_MS = 60_000;
+
+const formatElapsed = (interval: number, unit: string) => {
+    return `${interval} ${unit}${interval === 1 ? '' : 's'} ago`;
+};
+
+export function timeSince(timestamp: number, now = Date.now()) {
     const past = new Date(timestamp);
-    const seconds = Math.floor((now.getTime() - past.getTime()) / 1000);
+    const seconds = Math.max(0, Math.floor((now - past.getTime()) / 1000));
     let interval = Math.floor(seconds / 31536000);
 
     if (interval >= 1) {
-        return interval + ' years ago';
+        return formatElapsed(interval, 'year');
     }
     interval = Math.floor(seconds / 2592000);
     if (interval >= 1) {
-        return interval + ' months ago';
+        return formatElapsed(interval, 'month');
     }
     interval = Math.floor(seconds / 86400);
     if (interval >= 1) {
-        return interval + ' days ago';
+        return formatElapsed(interval, 'day');
     }
     interval = Math.floor(seconds / 3600);
     if (interval >= 1) {
-        return interval + ' hours ago';
+        return formatElapsed(interval, 'hour');
     }
     interval = Math.floor(seconds / 60);
     if (interval >= 1) {
-        return interval + ' minutes ago';
+        return formatElapsed(interval, 'minute');
     }
-    return Math.floor(seconds) + ' seconds ago';
+    return formatElapsed(Math.floor(seconds), 'second');
+}
+
+export function recentTimeSince(timestamp: number | null, now = Date.now()) {
+    if (timestamp === null) {
+        return 'just now';
+    }
+
+    if (now - timestamp < RECENT_TIME_JUST_NOW_DURATION_MS) {
+        return 'just now';
+    }
+
+    return timeSince(timestamp, now);
+}
+
+export function getRecentTimeSinceRefreshDelay(timestamp: number | null, now = Date.now()) {
+    if (timestamp === null) {
+        return RECENT_TIME_REFRESH_INTERVAL_MS;
+    }
+
+    const elapsedMs = Math.max(0, now - timestamp);
+
+    if (elapsedMs < RECENT_TIME_JUST_NOW_DURATION_MS) {
+        return RECENT_TIME_JUST_NOW_DURATION_MS - elapsedMs;
+    }
+
+    const msPastMinute = elapsedMs % RECENT_TIME_REFRESH_INTERVAL_MS;
+
+    return msPastMinute === 0 ? RECENT_TIME_REFRESH_INTERVAL_MS : RECENT_TIME_REFRESH_INTERVAL_MS - msPastMinute;
 }

--- a/packages/client/src/pages/Note.external-change.spec.tsx
+++ b/packages/client/src/pages/Note.external-change.spec.tsx
@@ -1,7 +1,7 @@
 import { QueryClientProvider } from '@tanstack/react-query';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { Suspense } from 'react';
+import { StrictMode, Suspense } from 'react';
 import { fetchNote, updateNote } from '~/apis/note.api';
 import { ToastProvider } from '~/components/ui';
 import type { Note } from '~/models/note.model';
@@ -11,6 +11,7 @@ import { createTestQueryClient } from '~/test/test-utils';
 import { NoteContent } from './Note';
 
 const mockNavigate = vi.hoisted(() => vi.fn());
+const mockUseBlocker = vi.hoisted(() => vi.fn());
 const mockUseNoteMutate = vi.hoisted(() => ({
     onCreate: vi.fn(),
     onDelete: vi.fn(),
@@ -28,6 +29,7 @@ vi.mock('@tanstack/react-router', () => ({
             {children}
         </a>
     ),
+    useBlocker: mockUseBlocker,
 }));
 
 vi.mock('~/apis/note.api', () => ({
@@ -148,9 +150,11 @@ const renderNote = (note: Note) => {
     render(
         <QueryClientProvider client={queryClient}>
             <ToastProvider>
-                <Suspense fallback={<div>Loading</div>}>
-                    <NoteContent id={note.id} />
-                </Suspense>
+                <StrictMode>
+                    <Suspense fallback={<div>Loading</div>}>
+                        <NoteContent id={note.id} />
+                    </Suspense>
+                </StrictMode>
             </ToastProvider>
         </QueryClientProvider>,
     );
@@ -165,6 +169,7 @@ describe('<NoteContent /> external change handling', () => {
         mockUseNoteMutate.onCreate.mockReset();
         mockUseNoteMutate.onDelete.mockReset();
         mockUseNoteMutate.onPinned.mockReset();
+        mockUseBlocker.mockReset();
         editorMountCount = 0;
     });
 
@@ -346,7 +351,7 @@ describe('<NoteContent /> external change handling', () => {
         renderNote(initialNote);
 
         const editor = await screen.findByLabelText('Editor');
-        expect(editorMountCount).toBe(1);
+        const mountCountAfterInitialRender = editorMountCount;
 
         vi.mocked(updateNote).mockResolvedValue({
             type: 'success',
@@ -358,7 +363,92 @@ describe('<NoteContent /> external change handling', () => {
         await user.click(screen.getByRole('button', { name: 'Save' }));
 
         await waitFor(() => expect(updateNote).toHaveBeenCalledTimes(1));
-        expect(editorMountCount).toBe(1);
+        expect(editorMountCount).toBe(mountCountAfterInitialRender);
         expect(screen.getByLabelText('Editor')).toHaveValue('Local body');
+    });
+
+    it('flushes pending changes before allowing in-app navigation', async () => {
+        const user = userEvent.setup();
+        const initialNote = createNote({
+            title: 'Initial title',
+            content: createContent('Initial body'),
+            updatedAt: '1779700001000',
+        });
+        const savedNote = createNote({
+            title: 'Route-safe title',
+            updatedAt: '1779700002000',
+        });
+
+        renderNote(initialNote);
+
+        const titleInput = await screen.findByPlaceholderText('Title');
+        await user.clear(titleInput);
+        await user.type(titleInput, 'Route-safe title');
+
+        expect(screen.getByRole('status')).toHaveTextContent('Saving...');
+
+        vi.mocked(updateNote).mockResolvedValue({
+            type: 'success',
+            updateNote: savedNote,
+        });
+
+        const blockerOptions = mockUseBlocker.mock.calls.at(-1)?.[0] as
+            | { disabled: boolean; shouldBlockFn: () => Promise<boolean> }
+            | undefined;
+
+        expect(blockerOptions?.disabled).toBe(false);
+
+        let shouldBlock = true;
+
+        await act(async () => {
+            shouldBlock = (await blockerOptions?.shouldBlockFn()) ?? true;
+        });
+
+        expect(shouldBlock).toBe(false);
+        expect(updateNote).toHaveBeenCalledWith({
+            id: initialNote.id,
+            title: 'Route-safe title',
+            content: initialNote.content,
+            editSessionId: expect.any(String),
+            expectedUpdatedAt: initialNote.updatedAt,
+        });
+    });
+
+    it('blocks in-app navigation when the pending save fails', async () => {
+        const user = userEvent.setup();
+        const initialNote = createNote({
+            title: 'Initial title',
+            updatedAt: '1779700001000',
+        });
+
+        renderNote(initialNote);
+
+        const titleInput = await screen.findByPlaceholderText('Title');
+        await user.clear(titleInput);
+        await user.type(titleInput, 'Unsaved title');
+
+        vi.mocked(updateNote).mockResolvedValue({
+            type: 'error',
+            category: 'network',
+            errors: [
+                {
+                    code: 'NETWORK_ERROR',
+                    message: 'Network request failed',
+                },
+            ],
+        });
+
+        const blockerOptions = mockUseBlocker.mock.calls.at(-1)?.[0] as
+            | { disabled: boolean; shouldBlockFn: () => Promise<boolean> }
+            | undefined;
+
+        let shouldBlock = false;
+
+        await act(async () => {
+            shouldBlock = (await blockerOptions?.shouldBlockFn()) ?? false;
+        });
+
+        expect(shouldBlock).toBe(true);
+        expect(await screen.findByText('Save failed. Try again.')).toBeInTheDocument();
     });
 });

--- a/packages/client/src/pages/Note.tsx
+++ b/packages/client/src/pages/Note.tsx
@@ -1,9 +1,9 @@
 import { useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
-import { getRouteApi, Link } from '@tanstack/react-router';
+import { getRouteApi, Link, useBlocker } from '@tanstack/react-router';
 import classNames from 'classnames';
 import dayjs from 'dayjs';
 import { nanoid } from 'nanoid';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { fetchNote, updateNote } from '~/apis/note.api';
 import { QueryBoundary, QueryErrorView } from '~/components/app';
 import { BackReferences } from '~/components/entities';
@@ -36,23 +36,33 @@ import {
 } from '~/modules/note-export';
 import { queryKeys } from '~/modules/query-key-factory';
 import { publishClientNoteUpdatedEvent, subscribeServerEvent } from '~/modules/server-events';
+import { getRecentTimeSinceRefreshDelay, recentTimeSince } from '~/modules/time';
 import { NOTE_ROUTE, SETTINGS_TRASH_ROUTE } from '~/modules/url';
 
 const Route = getRouteApi(NOTE_ROUTE);
-
-const formatSavedAt = (updatedAt: string) => dayjs(Number(updatedAt)).format('YYYY-MM-DD HH:mm:ss');
-
-const createEditSessionId = () => nanoid();
-const NOTE_UPDATE_CONFLICT_CODE = 'NOTE_UPDATE_CONFLICT';
-
-const getConflictUpdatedAt = (details: unknown) => {
-    return (details as { extensions?: { currentUpdatedAt?: string } })?.extensions?.currentUpdatedAt;
-};
 
 const toNoteVersionTime = (updatedAt: string) => {
     const timestamp = /^\d+$/.test(updatedAt) ? Number(updatedAt) : Date.parse(updatedAt);
 
     return Number.isFinite(timestamp) ? timestamp : null;
+};
+
+const formatSavedAt = (updatedAt: string) => {
+    const timestamp = toNoteVersionTime(updatedAt);
+
+    return dayjs(timestamp ?? Number(updatedAt)).format('YYYY-MM-DD HH:mm:ss');
+};
+
+const formatSavedAgo = (updatedAt: string, now: number) => {
+    return recentTimeSince(toNoteVersionTime(updatedAt), now);
+};
+
+const createEditSessionId = () => nanoid();
+const NOTE_UPDATE_CONFLICT_CODE = 'NOTE_UPDATE_CONFLICT';
+const SAVE_CONFIRMATION_DURATION_MS = 2200;
+
+const getConflictUpdatedAt = (details: unknown) => {
+    return (details as { extensions?: { currentUpdatedAt?: string } })?.extensions?.currentUpdatedAt;
 };
 
 const compareNoteVersions = (left: string, right: string) => {
@@ -116,6 +126,8 @@ export function NoteContent({ id }: NoteContentProps) {
 
     const [title, setTitle] = useState(note.title);
     const [lastSavedAt, setLastSavedAt] = useState(() => formatSavedAt(note.updatedAt));
+    const [lastSavedVersion, setLastSavedVersion] = useState(note.updatedAt);
+    const [relativeNow, setRelativeNow] = useState(() => Date.now());
     const [isPinned, setIsPinned] = useState(note.pinned);
     const [layout, setLayout] = useState<NoteLayout>(note.layout || 'wide');
     const [isLayoutModalOpen, setIsLayoutModalOpen] = useState(false);
@@ -127,9 +139,15 @@ export function NoteContent({ id }: NoteContentProps) {
     const [externalNoteChange, setExternalNoteChange] = useState<ExternalNoteChange | null>(null);
     const [editorContentOverride, setEditorContentOverride] = useState<string | null>(null);
     const [editorRevision, setEditorRevision] = useState(0);
+    const [showSavedConfirmation, setShowSavedConfirmation] = useState(false);
     const appliedNoteVersionRef = useRef(note.updatedAt);
     const activeNoteIdRef = useRef(id);
     const layoutConflictRef = useRef<NoteLayout | null>(null);
+    const updateLastSavedAt = useCallback((updatedAt: string) => {
+        setLastSavedAt(formatSavedAt(updatedAt));
+        setLastSavedVersion(updatedAt);
+        setRelativeNow(Date.now());
+    }, []);
     const saveController = useNoteSaveController({
         noteId: id,
         initialContent: note.content,
@@ -139,7 +157,8 @@ export function NoteContent({ id }: NoteContentProps) {
         onSaved: (updatedAt) => {
             layoutConflictRef.current = null;
             appliedNoteVersionRef.current = updatedAt;
-            setLastSavedAt(formatSavedAt(updatedAt));
+            updateLastSavedAt(updatedAt);
+            setShowSavedConfirmation(true);
         },
         onConflict: (updatedAt) => {
             setExternalNoteChange({
@@ -168,6 +187,28 @@ export function NoteContent({ id }: NoteContentProps) {
         setServerUpdatedAt,
     } = saveController;
 
+    const shouldBlockNoteNavigation = useCallback(async () => {
+        if (saveStatus === 'conflict') {
+            toast('Resolve the note conflict before leaving.');
+            return true;
+        }
+
+        const result = await flushPendingSave();
+
+        if (result === 'error') {
+            toast('Save failed. Stay on this note and try again.');
+            return true;
+        }
+
+        return result === 'conflict';
+    }, [flushPendingSave, saveStatus, toast]);
+
+    useBlocker({
+        disabled: saveStatus === 'saved',
+        enableBeforeUnload: false,
+        shouldBlockFn: shouldBlockNoteNavigation,
+    });
+
     useEffect(() => {
         if (hasUnsavedChanges) {
             if (
@@ -190,7 +231,7 @@ export function NoteContent({ id }: NoteContentProps) {
         setLayout(note.layout || 'wide');
         setServerUpdatedAt(note.updatedAt);
         setTitle(note.title);
-        setLastSavedAt(formatSavedAt(note.updatedAt));
+        updateLastSavedAt(note.updatedAt);
 
         if (appliedNoteVersion !== note.updatedAt) {
             const currentEditorContent = editorRef.current?.getContent();
@@ -211,6 +252,7 @@ export function NoteContent({ id }: NoteContentProps) {
         pauseForConflict,
         serverUpdatedAtRef,
         setServerUpdatedAt,
+        updateLastSavedAt,
     ]);
 
     useEffect(() => {
@@ -225,7 +267,35 @@ export function NoteContent({ id }: NoteContentProps) {
         setExternalNoteChange(null);
         setEditorContentOverride(null);
         setEditorRevision((current) => current + 1);
+        setShowSavedConfirmation(false);
     }, [id, note.updatedAt]);
+
+    useEffect(() => {
+        if (saveStatus !== 'saved') {
+            return;
+        }
+
+        const timer = window.setTimeout(
+            () => {
+                setRelativeNow(Date.now());
+            },
+            getRecentTimeSinceRefreshDelay(toNoteVersionTime(lastSavedVersion), relativeNow),
+        );
+
+        return () => window.clearTimeout(timer);
+    }, [lastSavedVersion, relativeNow, saveStatus]);
+
+    useEffect(() => {
+        if (!showSavedConfirmation) {
+            return;
+        }
+
+        const timer = window.setTimeout(() => {
+            setShowSavedConfirmation(false);
+        }, SAVE_CONFIRMATION_DURATION_MS);
+
+        return () => window.clearTimeout(timer);
+    }, [showSavedConfirmation]);
 
     useEffect(() => {
         if (
@@ -238,9 +308,9 @@ export function NoteContent({ id }: NoteContentProps) {
 
         appliedNoteVersionRef.current = note.updatedAt;
         setServerUpdatedAt(note.updatedAt);
-        setLastSavedAt(formatSavedAt(note.updatedAt));
+        updateLastSavedAt(note.updatedAt);
         setExternalNoteChange(null);
-    }, [externalNoteChange, note.updatedAt, saveStatus, setServerUpdatedAt]);
+    }, [externalNoteChange, note.updatedAt, saveStatus, setServerUpdatedAt, updateLastSavedAt]);
 
     useEffect(() => {
         return subscribeServerEvent((event) => {
@@ -345,7 +415,7 @@ export function NoteContent({ id }: NoteContentProps) {
             updatedAt: response.updateNote.updatedAt,
             editSessionId: editSessionIdRef.current,
         });
-        setLastSavedAt(formatSavedAt(response.updateNote.updatedAt));
+        updateLastSavedAt(response.updateNote.updatedAt);
         setLayout(newLayout);
         toast('Layout has been updated.');
     };
@@ -442,7 +512,7 @@ export function NoteContent({ id }: NoteContentProps) {
         setServerUpdatedAt(response.data.updatedAt);
         setTitle(response.data.title);
         setLayout(response.data.layout || 'wide');
-        setLastSavedAt(formatSavedAt(response.data.updatedAt));
+        updateLastSavedAt(response.data.updatedAt);
         setEditorContentOverride(null);
         setEditorRevision((current) => current + 1);
         setExternalNoteChange(null);
@@ -498,7 +568,7 @@ export function NoteContent({ id }: NoteContentProps) {
                 updatedAt: response.updateNote.updatedAt,
                 editSessionId: editSessionIdRef.current,
             });
-            setLastSavedAt(formatSavedAt(response.updateNote.updatedAt));
+            updateLastSavedAt(response.updateNote.updatedAt);
             setLayout(layoutConflict);
             return;
         }
@@ -539,16 +609,62 @@ export function NoteContent({ id }: NoteContentProps) {
         discardLocalDraft();
     };
 
+    const isRecentSaveVisible = saveStatus === 'saved' && showSavedConfirmation;
+    const savedAgoText = formatSavedAgo(lastSavedVersion, relativeNow);
+    const createdAtText = formatSavedAt(note.createdAt);
     const saveStatusText =
         saveStatus === 'pending'
-            ? 'Unsaved changes'
+            ? 'Saving...'
             : saveStatus === 'saving'
-              ? 'Saving...'
+              ? 'Saving now...'
               : saveStatus === 'error'
                 ? 'Save failed. Try again.'
                 : saveStatus === 'conflict'
                   ? 'Save paused: changed elsewhere'
-                  : `Last saved ${lastSavedAt}`;
+                  : `Saved ${savedAgoText}`;
+    const saveStatusIndicatorClassName = classNames(
+        'inline-flex items-center gap-2 transition-colors',
+        saveStatus === 'saved' && !isRecentSaveVisible && 'text-fg-secondary',
+        isRecentSaveVisible && 'text-accent-success',
+        (saveStatus === 'pending' || saveStatus === 'saving') && 'text-fg-default',
+        (saveStatus === 'error' || saveStatus === 'conflict') && 'text-fg-error',
+    );
+    const saveProgressRingClassName = classNames(
+        'save-progress-ring flex h-4 w-4 shrink-0 items-center justify-center rounded-full',
+        (saveStatus === 'pending' || saveStatus === 'saving') && 'save-progress-ring-active',
+        saveStatus === 'saved' && isRecentSaveVisible && 'save-progress-ring-complete',
+        (saveStatus === 'error' || saveStatus === 'conflict') && 'save-progress-ring-error',
+    );
+    const saveStatusIcon =
+        saveStatus === 'saving' ? (
+            <span className={saveProgressRingClassName} aria-hidden>
+                <span className="h-2 w-2 rounded-full bg-elevated" />
+            </span>
+        ) : saveStatus === 'pending' ? (
+            <span className={saveProgressRingClassName} aria-hidden>
+                <span className="h-2 w-2 rounded-full bg-elevated" />
+            </span>
+        ) : saveStatus === 'error' || saveStatus === 'conflict' ? (
+            <Icon.WarningCircle className="h-3.5 w-3.5" weight="fill" />
+        ) : (
+            <span className={saveProgressRingClassName} aria-hidden>
+                <span className="h-2 w-2 rounded-full bg-elevated" />
+            </span>
+        );
+    const saveStatusIndicator = (
+        <Text
+            as="span"
+            variant="label"
+            weight="medium"
+            className={saveStatusIndicatorClassName}
+            role="status"
+            aria-live="polite"
+            title={lastSavedAt}
+        >
+            {saveStatusIcon}
+            {saveStatusText}
+        </Text>
+    );
     const isConflictedExternalUpdate = saveStatus === 'conflict' && externalNoteChange?.type === 'updated';
     const conflictDraft = isConflictedExternalUpdate ? getPendingDraft() : null;
     const isBlockingExternalChange =
@@ -666,13 +782,10 @@ export function NoteContent({ id }: NoteContentProps) {
                                 </Text>
                             )}
                             {isPinned && <span className="h-1 w-1 rounded-full bg-border-secondary" />}
-                            <Text
-                                as="span"
-                                variant="label"
-                                weight="medium"
-                                tone={saveStatus === 'error' || saveStatus === 'conflict' ? 'error' : 'secondary'}
-                            >
-                                {saveStatusText}
+                            {saveStatusIndicator}
+                            <span className="h-1 w-1 rounded-full bg-border-secondary" />
+                            <Text as="span" variant="micro" weight="medium" tone="tertiary">
+                                Created {createdAtText}
                             </Text>
                         </div>
                     </div>
@@ -898,7 +1011,7 @@ export function NoteContent({ id }: NoteContentProps) {
                         appliedNoteVersionRef.current = restoredNote.updatedAt;
                         setExternalNoteChange(null);
                         setServerUpdatedAt(restoredNote.updatedAt);
-                        setLastSavedAt(formatSavedAt(restoredNote.updatedAt));
+                        updateLastSavedAt(restoredNote.updatedAt);
                     }}
                 />
                 {deleteWarningDialog}

--- a/packages/client/src/styles/tailwind.css
+++ b/packages/client/src/styles/tailwind.css
@@ -2,6 +2,21 @@
 
 @custom-variant dark (&:where(html.dark *));
 
+@property --save-progress {
+    syntax: "<percentage>";
+    initial-value: 0%;
+    inherits: false;
+}
+
+@keyframes save-ring-progress {
+    from {
+        --save-progress: 0%;
+    }
+    to {
+        --save-progress: 92%;
+    }
+}
+
 :root {
     color-scheme: light;
     --surface: #f7f8fa;
@@ -385,6 +400,28 @@ html.dark .surface-base {
 /* Progress bar */
 .progress-fill {
     width: var(--progress-width);
+}
+
+.save-progress-ring {
+    --save-progress: 100%;
+    --save-ring-color: var(--border-secondary);
+    background: conic-gradient(from -90deg, var(--save-ring-color) var(--save-progress), var(--hover-subtle) 0);
+}
+
+.save-progress-ring-active {
+    --save-progress: 0%;
+    --save-ring-color: var(--accent-primary);
+    animation: save-ring-progress 1200ms linear forwards;
+}
+
+.save-progress-ring-complete {
+    --save-progress: 100%;
+    --save-ring-color: var(--accent-success);
+}
+
+.save-progress-ring-error {
+    --save-progress: 100%;
+    --save-ring-color: var(--accent-danger);
 }
 
 /* Skeleton sizing */


### PR DESCRIPTION
## :dart: Goal
- Make note editing safer when a user changes content and then navigates, reloads, or hits save while another save is in flight.
- Restore clear save feedback in the note header so users can see that saving is actually happening.

## :hammer_and_wrench: Core Changes
- Hardened the note save controller so pending saves return explicit `idle`, `saved`, `error`, or `conflict` outcomes.
- Kept failed saves recoverable by preserving local drafts and surfacing error state instead of silently moving on.
- Added in-app navigation blocking so pending saves finish before route changes proceed, while failures and conflicts keep the user on the note.
- Reworked the note header save status into the existing metadata row with a progress ring, `Saved just now` relative time, exact saved-time title text, and created-time metadata.
- Added focused tests for StrictMode save status behavior, navigation flushing, and relative-time formatting.

## :brain: Key Decisions
- Used TanStack Router `useBlocker` for in-app route changes, while keeping browser unload handling as a separate local-draft safety path.
- Reused the existing time module instead of adding a note-only relative-time implementation.
- Kept note detail save status calmer than card/list timestamps: first minute shows `Saved just now`, then minute-level relative time only.
- Left exact saved time available through the status title instead of making the metadata row visually heavier.

## :test_tube: Verification Guide
### How to verify
1. Run `pnpm check:encoding`.
2. Run `pnpm --filter @ocean-brain/client exec vitest run src/modules/time.spec.ts src/pages/Note.external-change.spec.tsx src/hooks/useNoteSaveController.spec.tsx --maxWorkers 1`.
3. Run `pnpm --filter @ocean-brain/client lint`.
4. Run `pnpm --filter @ocean-brain/client type-check`.
5. Run `pnpm --filter @ocean-brain/client build`.

### Expected result
- Encoding check passes.
- Vitest reports 3 files and 20 tests passing.
- Lint and type-check complete without errors.
- Client production build completes successfully.
- Editing a note shows `Saving...`, then `Saved just now`, with the progress ring in the metadata row.
- After the first minute, save status changes to minute-level relative time.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed) - No documentation change needed for this client behavior fix.