### PR TITLE
🐛 Preserve failed note drafts

### DIFF
--- a/packages/client/src/components/shared/Callout/Callout.tsx
+++ b/packages/client/src/components/shared/Callout/Callout.tsx
@@ -4,15 +4,22 @@ import { Text } from '~/components/ui';
 interface CalloutProps {
     children: React.ReactNode;
     className?: string;
+    tone?: 'info' | 'danger';
 }
 
-const Callout = ({ children, className = '' }: CalloutProps) => {
+const Callout = ({ children, className = '', tone = 'info' }: CalloutProps) => {
+    const IconComponent = tone === 'danger' ? Icon.WarningCircle : Icon.Info;
+    const toneClassName =
+        tone === 'danger'
+            ? 'border-border-error/70 bg-accent-soft-danger/60'
+            : 'border-border-subtle bg-hover-subtle/50';
+    const iconClassName = tone === 'danger' ? 'text-fg-error' : 'text-fg-tertiary';
+    const textTone = tone === 'danger' ? 'error' : 'secondary';
+
     return (
-        <div
-            className={`flex items-center gap-2.5 rounded-[12px] border border-border-subtle bg-hover-subtle/50 px-4 py-3 ${className}`}
-        >
-            <Icon.Info className="h-4 w-4 shrink-0 text-fg-tertiary" />
-            <Text as="div" variant="meta" weight="medium" tone="secondary">
+        <div className={`flex items-center gap-2.5 rounded-[12px] border px-4 py-3 ${toneClassName} ${className}`}>
+            <IconComponent className={`h-4 w-4 shrink-0 ${iconClassName}`} />
+            <Text as="div" variant="meta" weight="medium" tone={textTone}>
                 {children}
             </Text>
         </div>

--- a/packages/client/src/pages/Note.external-change.spec.tsx
+++ b/packages/client/src/pages/Note.external-change.spec.tsx
@@ -2,9 +2,10 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { StrictMode, Suspense } from 'react';
-import { fetchNote, updateNote } from '~/apis/note.api';
+import { createNote as createNoteApi, fetchNote, updateNote } from '~/apis/note.api';
 import { ToastProvider } from '~/components/ui';
 import type { Note } from '~/models/note.model';
+import { getDraftStorageKey, type NoteSaveDraft } from '~/modules/note-draft-storage';
 import { queryKeys } from '~/modules/query-key-factory';
 import { publishServerEvent } from '~/modules/server-events';
 import { createTestQueryClient } from '~/test/test-utils';
@@ -33,6 +34,7 @@ vi.mock('@tanstack/react-router', () => ({
 }));
 
 vi.mock('~/apis/note.api', () => ({
+    createNote: vi.fn(),
     fetchNote: vi.fn(),
     updateNote: vi.fn(),
     fetchNoteSnapshot: vi.fn(),
@@ -170,6 +172,7 @@ describe('<NoteContent /> external change handling', () => {
         mockUseNoteMutate.onDelete.mockReset();
         mockUseNoteMutate.onPinned.mockReset();
         mockUseBlocker.mockReset();
+        window.localStorage.clear();
         editorMountCount = 0;
     });
 
@@ -450,5 +453,142 @@ describe('<NoteContent /> external change handling', () => {
 
         expect(shouldBlock).toBe(true);
         expect(await screen.findByText('Save failed. Try again.')).toBeInTheDocument();
+    });
+
+    it('shows recovery actions after a save failure and retries the local draft', async () => {
+        const user = userEvent.setup();
+        const initialNote = createNote({
+            title: 'Initial title',
+            updatedAt: '1779700001000',
+        });
+        const savedNote = createNote({
+            title: 'Recovered title',
+            updatedAt: String(Date.now()),
+        });
+
+        vi.mocked(updateNote)
+            .mockResolvedValueOnce({
+                type: 'error',
+                category: 'network',
+                errors: [
+                    {
+                        code: 'NETWORK_ERROR',
+                        message: 'Network request failed',
+                    },
+                ],
+            })
+            .mockResolvedValueOnce({
+                type: 'success',
+                updateNote: savedNote,
+            });
+
+        renderNote(initialNote);
+
+        const titleInput = await screen.findByPlaceholderText('Title');
+        await user.clear(titleInput);
+        await user.type(titleInput, 'Recovered title');
+        await user.click(screen.getByRole('button', { name: 'Save' }));
+
+        expect(await screen.findByText(/Save failed. Your latest draft is still available here/)).toBeInTheDocument();
+
+        const storedDraft = JSON.parse(
+            window.localStorage.getItem(getDraftStorageKey(initialNote.id)) ?? '{}',
+        ) as NoteSaveDraft;
+
+        expect(storedDraft.title).toBe('Recovered title');
+
+        await user.click(screen.getByRole('button', { name: 'Retry save' }));
+
+        await waitFor(() => expect(updateNote).toHaveBeenCalledTimes(2));
+        await waitFor(() => {
+            expect(
+                screen.queryByText(/Save failed. Your latest draft is still available here/),
+            ).not.toBeInTheDocument();
+        });
+        expect(window.localStorage.getItem(getDraftStorageKey(initialNote.id))).toBeNull();
+        expect(screen.getByRole('status')).toHaveTextContent('Saved just now');
+    });
+
+    it('saves a failed draft as a new note without retrying the failed original save', async () => {
+        const user = userEvent.setup();
+        const initialNote = createNote({
+            title: 'Initial title',
+            content: createContent('Initial body'),
+            updatedAt: '1779700001000',
+        });
+
+        vi.mocked(updateNote).mockResolvedValue({
+            type: 'error',
+            category: 'network',
+            errors: [
+                {
+                    code: 'NETWORK_ERROR',
+                    message: 'Network request failed',
+                },
+            ],
+        });
+        vi.mocked(createNoteApi).mockResolvedValue({
+            type: 'success',
+            createNote: {
+                id: 'new-note-id',
+            },
+        });
+
+        renderNote(initialNote);
+
+        const titleInput = await screen.findByPlaceholderText('Title');
+        await user.clear(titleInput);
+        await user.type(titleInput, 'Recovered title');
+        await user.click(screen.getByRole('button', { name: 'Save' }));
+
+        expect(await screen.findByText(/Save failed. Your latest draft is still available here/)).toBeInTheDocument();
+
+        await user.click(screen.getByRole('button', { name: 'Save as new note' }));
+
+        expect(createNoteApi).toHaveBeenCalledWith({
+            title: 'Recovered title',
+            content: initialNote.content,
+            layout: 'wide',
+        });
+        expect(updateNote).toHaveBeenCalledTimes(1);
+        expect(window.localStorage.getItem(getDraftStorageKey(initialNote.id))).toBeNull();
+        expect(mockNavigate).toHaveBeenCalledWith({
+            to: '/$id',
+            params: { id: 'new-note-id' },
+        });
+    });
+
+    it('restores a saved browser draft into the editor', async () => {
+        const user = userEvent.setup();
+        const initialNote = createNote({
+            title: 'Initial title',
+            content: createContent('Initial body'),
+            updatedAt: '1779700001000',
+        });
+        const localDraft: NoteSaveDraft = {
+            title: 'Browser draft title',
+            content: 'Browser draft body',
+            createdAt: 1779700002000,
+            baseUpdatedAt: initialNote.updatedAt,
+        };
+
+        vi.mocked(updateNote).mockResolvedValue({
+            type: 'success',
+            updateNote: createNote({
+                title: localDraft.title,
+                updatedAt: '1779700003000',
+            }),
+        });
+
+        window.localStorage.setItem(getDraftStorageKey(initialNote.id), JSON.stringify(localDraft));
+
+        renderNote(initialNote);
+
+        expect(await screen.findByText(/A draft from/)).toBeInTheDocument();
+
+        await user.click(screen.getByRole('button', { name: 'Restore draft' }));
+
+        expect(screen.getByPlaceholderText('Title')).toHaveValue('Browser draft title');
+        expect(screen.getByLabelText('Editor')).toHaveValue('Browser draft body');
     });
 });

--- a/packages/client/src/pages/Note.tsx
+++ b/packages/client/src/pages/Note.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import dayjs from 'dayjs';
 import { nanoid } from 'nanoid';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { fetchNote, updateNote } from '~/apis/note.api';
+import { createNote, fetchNote, updateNote } from '~/apis/note.api';
 import { QueryBoundary, QueryErrorView } from '~/components/app';
 import { BackReferences } from '~/components/entities';
 import * as Icon from '~/components/icon';
@@ -27,6 +27,7 @@ import { Checkbox, MoreButton, Text, useToast } from '~/components/ui';
 import useNoteMutate from '~/hooks/resource/useNoteMutate';
 import { useNoteSaveController } from '~/hooks/useNoteSaveController';
 import type { Note, NoteLayout } from '~/models/note.model';
+import { replaceFixedPlaceholder } from '~/modules/fixed-placeholder';
 import {
     createHtmlExport,
     createMarkdownExport,
@@ -143,6 +144,7 @@ export function NoteContent({ id }: NoteContentProps) {
     const appliedNoteVersionRef = useRef(note.updatedAt);
     const activeNoteIdRef = useRef(id);
     const layoutConflictRef = useRef<NoteLayout | null>(null);
+    const allowNextNavigationRef = useRef(false);
     const updateLastSavedAt = useCallback((updatedAt: string) => {
         setLastSavedAt(formatSavedAt(updatedAt));
         setLastSavedVersion(updatedAt);
@@ -188,6 +190,11 @@ export function NoteContent({ id }: NoteContentProps) {
     } = saveController;
 
     const shouldBlockNoteNavigation = useCallback(async () => {
+        if (allowNextNavigationRef.current) {
+            allowNextNavigationRef.current = false;
+            return false;
+        }
+
         if (saveStatus === 'conflict') {
             toast('Resolve the note conflict before leaving.');
             return true;
@@ -584,11 +591,30 @@ export function NoteContent({ id }: NoteContentProps) {
             return;
         }
 
-        const createdId = await onCreate(draft.title || 'untitled', draft.content, draft.layout ?? layout);
+        const response = await createNote({
+            title: replaceFixedPlaceholder(draft.title || 'untitled'),
+            content: replaceFixedPlaceholder(draft.content),
+            layout: draft.layout ?? layout,
+        });
 
-        if (createdId) {
-            clearDrafts();
+        if (response.type === 'error') {
+            toast(response.errors[0].message);
+            return;
         }
+
+        allowNextNavigationRef.current = true;
+        layoutConflictRef.current = null;
+        setExternalNoteChange(null);
+        clearDrafts();
+
+        void Promise.resolve(
+            navigate({
+                to: NOTE_ROUTE,
+                params: { id: response.createNote.id },
+            }),
+        ).finally(() => {
+            allowNextNavigationRef.current = false;
+        });
     };
 
     const handleRestoreLocalDraft = () => {
@@ -609,6 +635,7 @@ export function NoteContent({ id }: NoteContentProps) {
         discardLocalDraft();
     };
 
+    const recoveredDraftCreatedAt = localDraft ? dayjs(localDraft.createdAt).format('YYYY-MM-DD HH:mm:ss') : null;
     const isRecentSaveVisible = saveStatus === 'saved' && showSavedConfirmation;
     const savedAgoText = formatSavedAgo(lastSavedVersion, relativeNow);
     const createdAtText = formatSavedAt(note.createdAt);
@@ -792,12 +819,9 @@ export function NoteContent({ id }: NoteContentProps) {
                 </div>
 
                 {localDraft && (
-                    <Callout className="mb-6">
+                    <Callout tone="danger" className="mb-6">
                         <div className="flex w-full flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                            <span>
-                                An unsaved local draft from {dayjs(localDraft.createdAt).format('YYYY-MM-DD HH:mm:ss')}{' '}
-                                is available.
-                            </span>
+                            <span>A draft from {recoveredDraftCreatedAt} is saved only in this browser.</span>
                             <div className="flex flex-wrap gap-2">
                                 <Button
                                     type="button"
@@ -816,6 +840,36 @@ export function NoteContent({ id }: NoteContentProps) {
                                     onClick={handleDiscardLocalDraft}
                                 >
                                     Discard
+                                </Button>
+                            </div>
+                        </div>
+                    </Callout>
+                )}
+
+                {saveStatus === 'error' && (
+                    <Callout tone="danger" className="mb-6">
+                        <div className="flex w-full flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                            <span>
+                                Save failed. Your latest draft is still available here. Retry before leaving this note.
+                            </span>
+                            <div className="flex flex-wrap gap-2">
+                                <Button
+                                    type="button"
+                                    size="sm"
+                                    variant="subtle"
+                                    className="self-start"
+                                    onClick={handleManualSave}
+                                >
+                                    Retry save
+                                </Button>
+                                <Button
+                                    type="button"
+                                    size="sm"
+                                    variant="ghost"
+                                    className="self-start"
+                                    onClick={() => void handleClonePendingDraft()}
+                                >
+                                    Save as new note
                                 </Button>
                             </div>
                         </div>


### PR DESCRIPTION
## :dart: Goal
- Prevent failed note saves from feeling like silent data loss.
- Keep a recoverable browser draft visible after a save failure.

## :hammer_and_wrench: Core Changes
- Show a danger callout when note save fails, with Retry save and Save as new note actions.
- Keep the failed draft in browser storage until retry or new-note recovery succeeds.
- Add a danger tone to the shared Callout component.
- Extend note tests for save failure, retry recovery, new-note recovery, and browser draft restore.

## :brain: Key Decisions
- Use createNote directly for Save as new note so the recovery path does not retry the failed original save.
- Allow the recovery navigation once after clearing the local draft to avoid re-triggering the note-leave blocker.
- Keep this scoped to client recovery behavior; no API, storage schema, or documentation changes are needed.

## :test_tube: Verification Guide
### How to verify
1. pnpm --filter @ocean-brain/client test:ci
2. pnpm --filter @ocean-brain/client lint
3. pnpm --filter @ocean-brain/client type-check
4. pnpm --filter @ocean-brain/client build

### Expected result
- Client test suite passes: 49 files, 151 tests.
- Lint, type-check, and build pass.
- Build may show the existing large chunk warning.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation not needed