### PR TITLE
🔖 Bump version to 0.5.0

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ocean-brain",
-    "version": "0.4.2",
+    "version": "0.5.0",
     "type": "module",
     "repository": {
         "type": "git",


### PR DESCRIPTION
## :dart: Goal
- Prepare the 0.5.0 release after the Phase 1 reliability updates.
- Set the npm CLI package version to 0.5.0.

## :hammer_and_wrench: Core Changes
- Bump `packages/cli/package.json` from 0.4.2 to 0.5.0.
- Expected release tag: `v0.5.0`.
- Release trigger plan: push explicit `v0.5.0` tag after this PR is merged into `main`.

## :brain: Key Decisions
- Use a minor release because the accumulated reliability changes include note write conflict protection and a GraphQL `updateNote` contract change for direct API callers.
- Keep the release bump isolated in a dedicated release PR as required by the release runbook.

## :test_tube: Verification Guide
### How to verify
1. pnpm check:encoding
2. pnpm lint
3. pnpm type-check
4. pnpm test:ci
5. pnpm build
6. node scripts/release/prepublish.mjs
7. Confirm GitHub CI and CLI_SMOKE checks pass on this PR.

### Expected result
- Encoding, lint, type-check, tests, build, and prepublish pass.
- GitHub CI passes.
- CLI_SMOKE passes for the release PR.

## :white_check_mark: Checklist
- [x] Encoding check completed
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Build completed
- [x] Prepublish completed
- [x] GitHub CI completed
- [x] CLI_SMOKE completed