### PR TITLE
✨ Add note properties

### DIFF
--- a/packages/cli/src/mcp-note-output.ts
+++ b/packages/cli/src/mcp-note-output.ts
@@ -3,6 +3,14 @@ export interface McpReadNoteTag {
     name: string;
 }
 
+export interface McpReadNoteProperty {
+    key: string;
+    name: string;
+    value: string;
+    valueType: string;
+    option?: { label: string; value: string } | null;
+}
+
 export interface McpReadNote {
     id: string;
     title: string;
@@ -10,6 +18,7 @@ export interface McpReadNote {
     createdAt: string;
     updatedAt: string;
     tags: McpReadNoteTag[];
+    properties?: McpReadNoteProperty[];
 }
 
 export interface McpReadNoteBackReference {
@@ -46,11 +55,17 @@ export const formatMcpReadNoteOutput = ({
     const backReferenceLines = backReferences.length > 0
         ? backReferences.map(formatBackReferenceLine)
         : ['- (none)'];
+    const propertyLines = note.properties && note.properties.length > 0
+        ? note.properties.map((property) => `- ${property.key}: ${property.option?.label ?? property.value} (${property.valueType})`)
+        : ['- (none)'];
 
     return [
         `# ${note.title}`,
         '',
         `Tags: ${note.tags.map((tag) => tag.name).join(', ') || '(none)'}`,
+        '',
+        'Properties:',
+        ...propertyLines,
         `Created: ${note.createdAt}`,
         `Updated: ${note.updatedAt}`,
         ...(truncated ? [`Content: ${totalLength} chars (showing first ${maxLength})`] : []),

--- a/packages/cli/src/mcp.ts
+++ b/packages/cli/src/mcp.ts
@@ -243,6 +243,7 @@ export async function startMcpServer(
                         createdAt
                         updatedAt
                         tags { id name }
+                        properties { key name value valueType option { label value } }
                     }
                     backReferences(id: $id) {
                         id
@@ -258,6 +259,7 @@ export async function startMcpServer(
                 createdAt: string;
                 updatedAt: string;
                 tags: Array<{ id: string; name: string }>;
+                properties?: Array<{ key: string; name: string; value: string; valueType: string }>;
             };
             const backReferences = (data?.backReferences as Array<{
                 id: string;

--- a/packages/client/src/apis/note.api.ts
+++ b/packages/client/src/apis/note.api.ts
@@ -1,9 +1,9 @@
-import type { Note } from '~/models/note.model';
+import type { Note, NotePropertyOption, NotePropertyValueType } from '~/models/note.model';
 import { graphQuery } from '~/modules/graph-query';
 
-type NoteAdditionalField = 'content' | 'order' | 'layout';
+type NoteAdditionalField = 'content' | 'order' | 'layout' | 'properties';
 
-const NOTE_ADDITIONAL_FIELDS = new Set<NoteAdditionalField>(['content', 'order', 'layout']);
+const NOTE_ADDITIONAL_FIELDS = new Set<NoteAdditionalField>(['content', 'order', 'layout', 'properties']);
 
 const FETCH_NOTES_QUERY = `query FetchNotes(
             $searchFilter: SearchFilterInput,
@@ -45,7 +45,15 @@ const buildAdditionalNoteSelection = (fields?: (keyof Note)[]) => {
         return '';
     }
 
-    return selectedFields.map((field) => '                    ' + field).join('\n') + '\n';
+    return (
+        selectedFields
+            .map((field) =>
+                field === 'properties'
+                    ? '                    properties {\n                        key\n                        name\n                        value\n                        valueType\n                        option { id label value color order }\n                        createdAt\n                        updatedAt\n                    }'
+                    : '                    ' + field,
+            )
+            .join('\n') + '\n'
+    );
 };
 
 export interface FetchNotesParams {
@@ -186,7 +194,7 @@ export function fetchNotesByTagNames({ tagNames, mode = 'and', limit = 25, offse
 export function fetchNote(id: string) {
     return graphQuery<
         {
-            note: Pick<Note, 'title' | 'content' | 'pinned' | 'layout' | 'createdAt' | 'updatedAt'>;
+            note: Pick<Note, 'title' | 'content' | 'pinned' | 'layout' | 'createdAt' | 'updatedAt' | 'properties'>;
         },
         { id: string }
     >(
@@ -198,6 +206,15 @@ export function fetchNote(id: string) {
                 content
                 createdAt
                 updatedAt
+                properties {
+                    key
+                    name
+                    value
+                    valueType
+                    option { id label value color order }
+                    createdAt
+                    updatedAt
+                }
             }
         }`,
         { id },
@@ -240,6 +257,126 @@ export function fetchImageNotes(src: string) {
     );
 }
 
+export interface NotePropertyKeySummary {
+    key: string;
+    name: string;
+    valueType: NotePropertyValueType;
+    noteCount: number;
+    options: NotePropertyOption[];
+    updatedAt: string;
+}
+
+export interface FetchNotePropertyKeysParams {
+    query?: string;
+    limit?: number;
+    offset?: number;
+}
+
+export function fetchNotePropertyKeys({ query = '', limit = 50, offset = 0 }: FetchNotePropertyKeysParams = {}) {
+    return graphQuery<
+        {
+            notePropertyKeys: {
+                totalCount: number;
+                keys: NotePropertyKeySummary[];
+            };
+        },
+        {
+            query?: string;
+            pagination: {
+                limit: number;
+                offset: number;
+            };
+        }
+    >(
+        `query FetchNotePropertyKeys($query: String, $pagination: PaginationInput) {
+            notePropertyKeys(query: $query, pagination: $pagination) {
+                totalCount
+                keys {
+                    key
+                    name
+                    valueType
+                    noteCount
+                    options { id label value color order }
+                    updatedAt
+                }
+            }
+        }`,
+        {
+            ...(query ? { query } : {}),
+            pagination: {
+                limit,
+                offset,
+            },
+        },
+    );
+}
+
+export interface CreateNotePropertyKeyRequestData {
+    key: string;
+    name?: string;
+    valueType: NotePropertyValueType;
+    options?: Array<
+        Omit<NotePropertyOption, 'id'> | { label: string; value?: string; color?: string | null; order?: number }
+    >;
+}
+
+export function createNotePropertyKey(input: CreateNotePropertyKeyRequestData) {
+    return graphQuery<
+        {
+            createNotePropertyKey: NotePropertyKeySummary;
+        },
+        { input: CreateNotePropertyKeyRequestData }
+    >(
+        `mutation CreateNotePropertyKey($input: NotePropertyDefinitionInput!) {
+            createNotePropertyKey(input: $input) {
+                key
+                name
+                valueType
+                noteCount
+                options { id label value color order }
+                updatedAt
+            }
+        }`,
+        { input },
+    );
+}
+
+export interface DeleteNotePropertyKeyRequestData {
+    key: string;
+    confirmImpact?: boolean;
+}
+
+export interface DeleteNotePropertyKeyResult {
+    key: string;
+    name: string;
+    valueType: NotePropertyValueType;
+    affectedNoteCount: number;
+    deleted: boolean;
+}
+
+export function deleteNotePropertyKey({ key, confirmImpact }: DeleteNotePropertyKeyRequestData) {
+    return graphQuery<
+        {
+            deleteNotePropertyKey: DeleteNotePropertyKeyResult;
+        },
+        DeleteNotePropertyKeyRequestData
+    >(
+        `mutation DeleteNotePropertyKey($key: String!, $confirmImpact: Boolean) {
+            deleteNotePropertyKey(key: $key, confirmImpact: $confirmImpact) {
+                key
+                name
+                valueType
+                affectedNoteCount
+                deleted
+            }
+        }`,
+        {
+            key,
+            ...(confirmImpact ? { confirmImpact: true } : {}),
+        },
+    );
+}
+
 export interface CreateNoteRequestData {
     title: string;
     content: string;
@@ -259,6 +396,85 @@ export function createNote(note: CreateNoteRequestData) {
             }
         }`,
         { note },
+    );
+}
+
+export interface NotePropertySetInput {
+    key: string;
+    name?: string;
+    value: string;
+    valueType: NotePropertyValueType;
+}
+
+export interface UpdateNotePropertiesRequestData {
+    id: string;
+    set?: NotePropertySetInput[];
+    deleteKeys?: string[];
+    editSessionId?: string;
+    expectedUpdatedAt: string;
+    force?: boolean;
+}
+
+export function updateNoteProperties({
+    id,
+    set = [],
+    deleteKeys = [],
+    editSessionId,
+    expectedUpdatedAt,
+    force,
+}: UpdateNotePropertiesRequestData) {
+    return graphQuery<
+        {
+            updateNoteProperties: Pick<Note, 'id' | 'updatedAt' | 'properties'>;
+        },
+        {
+            id: string;
+            patch: {
+                set?: NotePropertySetInput[];
+                deleteKeys?: string[];
+            };
+            editSessionId?: string;
+            expectedUpdatedAt: string;
+            force?: boolean;
+        }
+    >(
+        `mutation UpdateNoteProperties(
+            $id: ID!,
+            $patch: NotePropertiesPatchInput!,
+            $editSessionId: String,
+            $expectedUpdatedAt: String!,
+            $force: Boolean
+        ) {
+            updateNoteProperties(
+                id: $id,
+                patch: $patch,
+                editSessionId: $editSessionId,
+                expectedUpdatedAt: $expectedUpdatedAt,
+                force: $force
+            ) {
+                id
+                updatedAt
+                properties {
+                    key
+                    name
+                    value
+                    valueType
+                    option { id label value color order }
+                    createdAt
+                    updatedAt
+                }
+            }
+        }`,
+        {
+            id,
+            patch: {
+                ...(set.length > 0 ? { set } : {}),
+                ...(deleteKeys.length > 0 ? { deleteKeys } : {}),
+            },
+            ...(editSessionId ? { editSessionId } : {}),
+            expectedUpdatedAt,
+            ...(force ? { force: true } : {}),
+        },
     );
 }
 

--- a/packages/client/src/components/reminder/ReminderPanel.spec.tsx
+++ b/packages/client/src/components/reminder/ReminderPanel.spec.tsx
@@ -22,6 +22,7 @@ let mockReminderData: MockReminderRenderData = {
 };
 
 vi.mock('~/components/icon', () => ({
+    Bell: () => <span aria-hidden="true">Bell</span>,
     TriangleRight: () => <span aria-hidden="true">TriangleRight</span>,
     TriangleDown: () => <span aria-hidden="true">TriangleDown</span>,
     Plus: () => <span aria-hidden="true">Plus</span>,

--- a/packages/client/src/components/reminder/ReminderPanel.tsx
+++ b/packages/client/src/components/reminder/ReminderPanel.tsx
@@ -3,7 +3,7 @@ import dayjs from 'dayjs';
 import { useState } from 'react';
 import { Reminders } from '~/components/entities';
 import * as Icon from '~/components/icon';
-import { AuxiliaryPanelHeader, Button, Dropdown } from '~/components/shared';
+import { AuxiliaryPanel, Button, Dropdown } from '~/components/shared';
 import { Checkbox, MoreButton, Text } from '~/components/ui';
 import useReminderMutate from '~/hooks/resource/useReminderMutate';
 import type { Reminder } from '~/models/reminder.model';
@@ -98,125 +98,136 @@ export default function ReminderPanel({ noteId }: ReminderPanelProps) {
     };
 
     return (
-        <div className="surface-base mb-5 p-4">
-            <div className={classNames('flex items-center justify-between', !isCollapsed && 'mb-3')}>
-                <button
-                    type="button"
-                    onClick={() => setIsCollapsed(!isCollapsed)}
-                    className="focus-ring-soft flex items-center gap-2 rounded-[10px] px-2 py-1.5 text-fg-tertiary transition-colors hover:bg-hover-subtle hover:text-fg-default"
-                >
-                    <AuxiliaryPanelHeader
-                        icon={isCollapsed ? <Icon.TriangleRight size={12} /> : <Icon.TriangleDown size={12} />}
-                        title="Reminders"
-                    />
-                </button>
+        <>
+            <AuxiliaryPanel
+                title="Reminders"
+                icon={<Icon.Bell className="h-3.5 w-3.5" />}
+                action={
+                    <>
+                        {!isCollapsed && (
+                            <Button size="sm" variant="ghost" onClick={handleOpenCreateModal}>
+                                <Icon.Plus className="w-3 h-3" />
+                                <Text as="span" variant="label" className="hidden sm:inline">
+                                    Add
+                                </Text>
+                            </Button>
+                        )}
+                        <Button
+                            type="button"
+                            size="sm"
+                            variant="ghost"
+                            aria-label={isCollapsed ? 'Expand reminders' : 'Collapse reminders'}
+                            aria-expanded={!isCollapsed}
+                            onClick={() => setIsCollapsed(!isCollapsed)}
+                        >
+                            {isCollapsed ? (
+                                <Icon.TriangleRight className="h-3.5 w-3.5" />
+                            ) : (
+                                <Icon.TriangleDown className="h-3.5 w-3.5" />
+                            )}
+                            {isCollapsed ? 'Expand' : 'Collapse'}
+                        </Button>
+                    </>
+                }
+            >
                 {!isCollapsed && (
-                    <Button size="sm" variant="ghost" onClick={handleOpenCreateModal}>
-                        <Icon.Plus className="w-3 h-3" />
-                        <Text as="span" variant="label" className="hidden sm:inline">
-                            Add
-                        </Text>
-                    </Button>
-                )}
-            </div>
+                    <Reminders
+                        noteId={noteId}
+                        searchParams={{
+                            offset: 0,
+                            limit: 9999,
+                        }}
+                        render={({ reminders, totalCount }) => {
+                            return (
+                                <div className="flex flex-col gap-2">
+                                    {reminders.length === 0 ? (
+                                        <Text as="p" variant="meta" tone="secondary" className="py-3 text-center">
+                                            {totalCount === 0 ? 'No reminders yet' : 'All reminders complete'}
+                                        </Text>
+                                    ) : (
+                                        <div className="flex flex-col">
+                                            {reminders.map((reminder) => {
+                                                const urgency =
+                                                    reminder.priority || calculateUrgency(reminder.reminderDate);
+                                                const timeRemaining = getTimeRemaining(reminder.reminderDate);
+                                                const isOverdue = timeRemaining === 'Overdue';
 
-            {!isCollapsed && (
-                <Reminders
-                    noteId={noteId}
-                    searchParams={{
-                        offset: 0,
-                        limit: 9999,
-                    }}
-                    render={({ reminders, totalCount }) => {
-                        return (
-                            <div className="flex flex-col gap-2">
-                                {reminders.length === 0 ? (
-                                    <Text as="p" variant="meta" tone="secondary" className="py-3 text-center">
-                                        {totalCount === 0 ? 'No reminders yet' : 'All reminders complete'}
-                                    </Text>
-                                ) : (
-                                    <div className="flex flex-col">
-                                        {reminders.map((reminder) => {
-                                            const urgency =
-                                                reminder.priority || calculateUrgency(reminder.reminderDate);
-                                            const timeRemaining = getTimeRemaining(reminder.reminderDate);
-                                            const isOverdue = timeRemaining === 'Overdue';
-
-                                            return (
-                                                <div
-                                                    key={reminder.id}
-                                                    className={classNames('flex items-center gap-2.5 px-2 py-1.5')}
-                                                >
-                                                    <Checkbox
-                                                        checked={reminder.completed}
-                                                        onChange={() => handleToggleComplete(reminder)}
-                                                        size="sm"
-                                                    />
-                                                    <Text
-                                                        as="div"
-                                                        variant="body"
-                                                        weight="medium"
-                                                        className={classNames(
-                                                            'truncate flex-1 min-w-0',
-                                                            reminder.completed && 'line-through opacity-40',
-                                                        )}
-                                                    >
-                                                        {reminder.content || formatReminderDate(reminder.reminderDate)}
-                                                    </Text>
+                                                return (
                                                     <div
-                                                        className={classNames(
-                                                            'shrink-0 flex items-center gap-1',
-                                                            reminder.completed && 'opacity-40',
-                                                        )}
+                                                        key={reminder.id}
+                                                        className={classNames('flex items-center gap-2.5 px-2 py-1.5')}
                                                     >
-                                                        {reminder.content && (
-                                                            <Text as="span" variant="meta" tone="secondary">
-                                                                {formatReminderDate(reminder.reminderDate)}
-                                                            </Text>
-                                                        )}
-                                                        {!reminder.completed && (
-                                                            <Text
-                                                                as="span"
-                                                                variant="label"
-                                                                weight="medium"
-                                                                tone={
-                                                                    isOverdue || urgency === 'high'
-                                                                        ? 'error'
-                                                                        : 'tertiary'
-                                                                }
-                                                                className={classNames(
-                                                                    reminder.content &&
-                                                                        'before:content-["·"] before:mr-1',
-                                                                )}
-                                                            >
-                                                                {timeRemaining}
-                                                            </Text>
-                                                        )}
+                                                        <Checkbox
+                                                            checked={reminder.completed}
+                                                            onChange={() => handleToggleComplete(reminder)}
+                                                            size="sm"
+                                                        />
+                                                        <Text
+                                                            as="div"
+                                                            variant="body"
+                                                            weight="medium"
+                                                            className={classNames(
+                                                                'truncate flex-1 min-w-0',
+                                                                reminder.completed && 'line-through opacity-40',
+                                                            )}
+                                                        >
+                                                            {reminder.content ||
+                                                                formatReminderDate(reminder.reminderDate)}
+                                                        </Text>
+                                                        <div
+                                                            className={classNames(
+                                                                'shrink-0 flex items-center gap-1',
+                                                                reminder.completed && 'opacity-40',
+                                                            )}
+                                                        >
+                                                            {reminder.content && (
+                                                                <Text as="span" variant="meta" tone="secondary">
+                                                                    {formatReminderDate(reminder.reminderDate)}
+                                                                </Text>
+                                                            )}
+                                                            {!reminder.completed && (
+                                                                <Text
+                                                                    as="span"
+                                                                    variant="label"
+                                                                    weight="medium"
+                                                                    tone={
+                                                                        isOverdue || urgency === 'high'
+                                                                            ? 'error'
+                                                                            : 'tertiary'
+                                                                    }
+                                                                    className={classNames(
+                                                                        reminder.content &&
+                                                                            'before:content-["·"] before:mr-1',
+                                                                    )}
+                                                                >
+                                                                    {timeRemaining}
+                                                                </Text>
+                                                            )}
+                                                        </div>
+                                                        <Dropdown
+                                                            button={<MoreButton label="Reminder actions" />}
+                                                            items={[
+                                                                {
+                                                                    name: 'Edit',
+                                                                    onClick: () => handleOpenEditModal(reminder),
+                                                                },
+                                                                {
+                                                                    name: 'Delete',
+                                                                    onClick: () => onDelete(reminder.id, noteId),
+                                                                },
+                                                            ]}
+                                                        />
                                                     </div>
-                                                    <Dropdown
-                                                        button={<MoreButton label="Reminder actions" />}
-                                                        items={[
-                                                            {
-                                                                name: 'Edit',
-                                                                onClick: () => handleOpenEditModal(reminder),
-                                                            },
-                                                            {
-                                                                name: 'Delete',
-                                                                onClick: () => onDelete(reminder.id, noteId),
-                                                            },
-                                                        ]}
-                                                    />
-                                                </div>
-                                            );
-                                        })}
-                                    </div>
-                                )}
-                            </div>
-                        );
-                    }}
-                />
-            )}
-
+                                                );
+                                            })}
+                                        </div>
+                                    )}
+                                </div>
+                            );
+                        }}
+                    />
+                )}
+            </AuxiliaryPanel>
             <ReminderModal
                 isOpen={isModalOpen}
                 onClose={() => setIsModalOpen(false)}
@@ -224,6 +235,6 @@ export default function ReminderPanel({ noteId }: ReminderPanelProps) {
                 reminder={editingReminder}
                 mode={modalMode}
             />
-        </div>
+        </>
     );
 }

--- a/packages/client/src/components/shared/AuxiliaryPanel.tsx
+++ b/packages/client/src/components/shared/AuxiliaryPanel.tsx
@@ -1,0 +1,53 @@
+import classNames from 'classnames';
+import type { ButtonHTMLAttributes, ReactNode } from 'react';
+
+import AuxiliaryPanelHeader from './AuxiliaryPanelHeader';
+
+interface AuxiliaryPanelProps {
+    title: string;
+    icon: ReactNode;
+    action?: ReactNode;
+    titleButtonProps?: ButtonHTMLAttributes<HTMLButtonElement>;
+    ariaLabel?: string;
+    className?: string;
+    children?: ReactNode;
+}
+
+export default function AuxiliaryPanel({
+    title,
+    icon,
+    action,
+    titleButtonProps,
+    ariaLabel,
+    className,
+    children,
+}: AuxiliaryPanelProps) {
+    const hasBody = children !== undefined && children !== null && children !== false;
+    const hasAction = action !== undefined && action !== null && action !== false;
+    const header = <AuxiliaryPanelHeader icon={icon} title={title} className="text-fg-tertiary" />;
+
+    return (
+        <section className={classNames('surface-base mb-5 p-4', className)} aria-label={ariaLabel ?? title}>
+            <div className={classNames('relative', hasAction && 'pr-44 sm:pr-48', hasBody && 'mb-3')}>
+                {titleButtonProps ? (
+                    <button
+                        {...titleButtonProps}
+                        type="button"
+                        className={classNames(
+                            'focus-ring-soft -m-1 flex items-center gap-2 rounded-[10px] p-1 text-fg-tertiary transition-colors hover:bg-hover-subtle hover:text-fg-default',
+                            titleButtonProps.className,
+                        )}
+                    >
+                        {header}
+                    </button>
+                ) : (
+                    header
+                )}
+                {hasAction && (
+                    <div className="absolute top-1/2 right-0 flex -translate-y-1/2 items-center gap-2">{action}</div>
+                )}
+            </div>
+            {children}
+        </section>
+    );
+}

--- a/packages/client/src/components/shared/index.ts
+++ b/packages/client/src/components/shared/index.ts
@@ -1,4 +1,5 @@
 export { Button, Dropdown, Empty, Modal, MoreButton, Pagination, Progress, Skeleton } from '~/components/ui';
+export { default as AuxiliaryPanel } from './AuxiliaryPanel';
 export { default as AuxiliaryPanelHeader } from './AuxiliaryPanelHeader';
 export { default as Badge } from './Badge';
 export { default as Callout } from './Callout';

--- a/packages/client/src/models/note.model.ts
+++ b/packages/client/src/models/note.model.ts
@@ -1,4 +1,23 @@
 export type NoteLayout = 'narrow' | 'wide' | 'full';
+export type NotePropertyValueType = 'text' | 'number' | 'date' | 'boolean' | 'select';
+
+export interface NotePropertyOption {
+    id: string;
+    label: string;
+    value: string;
+    color?: string | null;
+    order: number;
+}
+
+export interface NoteProperty {
+    key: string;
+    name: string;
+    value: string;
+    valueType: NotePropertyValueType;
+    option?: NotePropertyOption | null;
+    createdAt: string;
+    updatedAt: string;
+}
 
 export interface Note {
     id: string;
@@ -11,6 +30,7 @@ export interface Note {
         id: string;
         name: string;
     }[];
+    properties?: NoteProperty[];
     createdAt: string;
     updatedAt: string;
 }

--- a/packages/client/src/modules/query-key-factory.ts
+++ b/packages/client/src/modules/query-key-factory.ts
@@ -1,5 +1,10 @@
 import type { FetchImagesParams } from '~/apis/image.api';
-import type { FetchNotesByTagNamesParams, FetchNotesParams, FetchTagNotesParams } from '~/apis/note.api';
+import type {
+    FetchNotePropertyKeysParams,
+    FetchNotesByTagNamesParams,
+    FetchNotesParams,
+    FetchTagNotesParams,
+} from '~/apis/note.api';
 import type { FetchPlaceholdersParams } from '~/apis/placeholder.api';
 import type { ReminderPaginationParams } from '~/apis/reminder.api';
 import type { FetchTagsParams } from '~/apis/tag.api';
@@ -95,6 +100,16 @@ export const queryKeys = {
         backReferencesAll: () => ['notes', 'back-references'] as const,
         backReferences: (noteId: string) => ['notes', 'back-references', { noteId }] as const,
         graph: () => ['notes', 'graph'] as const,
+        propertyKeys: (params: FetchNotePropertyKeysParams = {}) =>
+            [
+                'notes',
+                'property-keys',
+                {
+                    query: params.query ?? '',
+                    limit: params.limit ?? 50,
+                    offset: params.offset ?? 0,
+                },
+            ] as const,
     },
     tags: {
         all: () => ['tags'] as const,

--- a/packages/client/src/modules/url.ts
+++ b/packages/client/src/modules/url.ts
@@ -14,6 +14,7 @@ export const SETTINGS_TRASH_ROUTE = '/setting/trash' as const;
 export const SETTINGS_MANAGE_IMAGE_ROUTE = '/setting/manage-image' as const;
 export const SETTINGS_MANAGE_IMAGE_DETAIL_ROUTE = '/setting/manage-image/$id' as const;
 export const SETTINGS_PLACEHOLDER_ROUTE = '/setting/placeholder' as const;
+export const SETTINGS_PROPERTIES_ROUTE = '/setting/properties' as const;
 
 export const getTagURL = (id: string) => `/tag/${id}`;
 export const getNoteURL = (id: string) => `/${id}`;

--- a/packages/client/src/pages/Note.external-change.spec.tsx
+++ b/packages/client/src/pages/Note.external-change.spec.tsx
@@ -2,7 +2,7 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { StrictMode, Suspense } from 'react';
-import { createNote as createNoteApi, fetchNote, updateNote } from '~/apis/note.api';
+import { createNote as createNoteApi, fetchNote, fetchNotePropertyKeys, updateNote } from '~/apis/note.api';
 import { ToastProvider } from '~/components/ui';
 import type { Note } from '~/models/note.model';
 import { getDraftStorageKey, type NoteSaveDraft } from '~/modules/note-draft-storage';
@@ -36,7 +36,9 @@ vi.mock('@tanstack/react-router', () => ({
 vi.mock('~/apis/note.api', () => ({
     createNote: vi.fn(),
     fetchNote: vi.fn(),
+    fetchNotePropertyKeys: vi.fn(),
     updateNote: vi.fn(),
+    updateNoteProperties: vi.fn(),
     fetchNoteSnapshot: vi.fn(),
     fetchNoteSnapshots: vi.fn(),
     restoreNoteSnapshot: vi.fn(),
@@ -129,6 +131,7 @@ const createNote = (overrides: Partial<Note> = {}): Note => ({
     createdAt: '1779700000000',
     updatedAt: '1779700000000',
     tags: [],
+    properties: [],
     ...overrides,
 });
 
@@ -147,6 +150,13 @@ const renderNote = (note: Note) => {
     vi.mocked(fetchNote).mockResolvedValue({
         type: 'success',
         note,
+    });
+    vi.mocked(fetchNotePropertyKeys).mockResolvedValue({
+        type: 'success',
+        notePropertyKeys: {
+            keys: [],
+            totalCount: 0,
+        },
     });
 
     render(

--- a/packages/client/src/pages/Note.tsx
+++ b/packages/client/src/pages/Note.tsx
@@ -1,17 +1,24 @@
-import { useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
 import { getRouteApi, Link, useBlocker } from '@tanstack/react-router';
 import classNames from 'classnames';
 import dayjs from 'dayjs';
 import { nanoid } from 'nanoid';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { createNote, fetchNote, updateNote } from '~/apis/note.api';
+import {
+    createNote,
+    fetchNote,
+    fetchNotePropertyKeys,
+    type NotePropertyKeySummary,
+    updateNote,
+    updateNoteProperties,
+} from '~/apis/note.api';
 import { QueryBoundary, QueryErrorView } from '~/components/app';
 import { BackReferences } from '~/components/entities';
 import * as Icon from '~/components/icon';
 import { LayoutModal, NoteExternalChangeModal, RestoreSnapshotModal } from '~/components/note';
 import { ReminderPanel } from '~/components/reminder';
 import {
-    AuxiliaryPanelHeader,
+    AuxiliaryPanel,
     Button,
     Callout,
     Dropdown,
@@ -23,10 +30,24 @@ import {
 } from '~/components/shared';
 import type { EditorRef } from '~/components/shared/Editor';
 import Editor from '~/components/shared/Editor';
-import { Checkbox, MoreButton, Text, useToast } from '~/components/ui';
+import {
+    Checkbox,
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuLabel,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+    Input,
+    MoreButton,
+    Select,
+    SelectItem,
+    Text,
+    useToast,
+} from '~/components/ui';
 import useNoteMutate from '~/hooks/resource/useNoteMutate';
 import { useNoteSaveController } from '~/hooks/useNoteSaveController';
-import type { Note, NoteLayout } from '~/models/note.model';
+import type { Note, NoteLayout, NoteProperty, NotePropertyValueType } from '~/models/note.model';
 import { replaceFixedPlaceholder } from '~/modules/fixed-placeholder';
 import {
     createHtmlExport,
@@ -38,7 +59,7 @@ import {
 import { queryKeys } from '~/modules/query-key-factory';
 import { publishClientNoteUpdatedEvent, subscribeServerEvent } from '~/modules/server-events';
 import { getRecentTimeSinceRefreshDelay, recentTimeSince } from '~/modules/time';
-import { NOTE_ROUTE, SETTINGS_TRASH_ROUTE } from '~/modules/url';
+import { NOTE_ROUTE, SETTINGS_PROPERTIES_ROUTE, SETTINGS_TRASH_ROUTE } from '~/modules/url';
 
 const Route = getRouteApi(NOTE_ROUTE);
 
@@ -94,6 +115,463 @@ const notePageFallback = (
     </PageLayout>
 );
 
+interface EditableNotePropertyRow {
+    id: string;
+    key: string;
+    name: string;
+    value: string;
+    valueType: NotePropertyValueType;
+    persistedKey?: string;
+}
+
+const createEditablePropertyRow = (property?: NoteProperty): EditableNotePropertyRow => ({
+    id: property?.key ?? '',
+    key: property?.key ?? '',
+    name: property?.name ?? '',
+    value: property?.value ?? '',
+    valueType: property?.valueType ?? 'text',
+    persistedKey: property?.key,
+});
+
+const normalizePropertyKeySummaries = (value: unknown): NotePropertyKeySummary[] => {
+    if (Array.isArray(value)) {
+        return value as NotePropertyKeySummary[];
+    }
+
+    const keys = (value as { keys?: unknown })?.keys;
+
+    return Array.isArray(keys) ? (keys as NotePropertyKeySummary[]) : [];
+};
+
+interface NotePropertiesPatchDraft {
+    set: {
+        key: string;
+        name: string;
+        value: string;
+        valueType: NotePropertyValueType;
+    }[];
+    deleteKeys: string[];
+}
+
+const getNormalizedRows = (properties: NoteProperty[] = []) => properties.map(createEditablePropertyRow);
+
+const getPropertyRowsPatchDraft = (
+    rows: EditableNotePropertyRow[],
+    deletedKeys: string[],
+): NotePropertiesPatchDraft => {
+    const set: NotePropertiesPatchDraft['set'] = [];
+    const deleteKeySet = new Set(deletedKeys);
+
+    for (const row of rows) {
+        const key = row.key.trim();
+
+        if (!key) {
+            continue;
+        }
+
+        const value = row.value.trim();
+        const shouldDeleteBlankPersistedValue =
+            Boolean(row.persistedKey) &&
+            (row.valueType === 'number' || row.valueType === 'date' || row.valueType === 'select');
+
+        if (!value && shouldDeleteBlankPersistedValue) {
+            deleteKeySet.add(row.persistedKey as string);
+            continue;
+        }
+
+        if (!value && row.valueType !== 'text' && row.valueType !== 'boolean') {
+            continue;
+        }
+
+        set.push({
+            key,
+            name: row.name.trim() || key,
+            value: row.valueType === 'boolean' ? value || 'false' : value,
+            valueType: row.valueType,
+        });
+    }
+
+    return {
+        set: set.sort((left, right) => left.key.localeCompare(right.key)),
+        deleteKeys: Array.from(deleteKeySet).sort(),
+    };
+};
+
+const getPropertyRowsPatchSignature = (rows: EditableNotePropertyRow[], deletedKeys: string[] = []) =>
+    JSON.stringify(getPropertyRowsPatchDraft(rows, deletedKeys));
+
+interface NotePropertiesPanelProps {
+    noteId: string;
+    properties?: NoteProperty[];
+    expectedUpdatedAt: string;
+    editSessionId: string;
+    disabled?: boolean;
+    onSaved: (note: Pick<Note, 'id' | 'updatedAt' | 'properties'>) => void;
+}
+
+const NotePropertiesPanel = ({
+    noteId,
+    properties = [],
+    expectedUpdatedAt,
+    editSessionId,
+    disabled,
+    onSaved,
+}: NotePropertiesPanelProps) => {
+    const toast = useToast();
+    const queryClient = useQueryClient();
+    const [rows, setRows] = useState<EditableNotePropertyRow[]>(() => getNormalizedRows(properties));
+    const [deletedKeys, setDeletedKeys] = useState<string[]>([]);
+    const [autoSaveStatus, setAutoSaveStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle');
+    const rowsRef = useRef(rows);
+    const deletedKeysRef = useRef(deletedKeys);
+    const expectedUpdatedAtRef = useRef(expectedUpdatedAt);
+    const savedSignatureRef = useRef(getPropertyRowsPatchSignature(rows));
+    const autoSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const isAutoSavingRef = useRef(false);
+    const hasQueuedAutoSaveRef = useRef(false);
+
+    const propertyKeysQuery = useQuery({
+        queryKey: queryKeys.notes.propertyKeys({ limit: 50 }),
+        queryFn: async () => {
+            const response = await fetchNotePropertyKeys({ limit: 50 });
+
+            if (response.type === 'error') {
+                throw response;
+            }
+
+            return response.notePropertyKeys.keys;
+        },
+    });
+
+    useEffect(() => {
+        const nextRows = getNormalizedRows(properties);
+
+        setRows(nextRows);
+        setDeletedKeys([]);
+        savedSignatureRef.current = getPropertyRowsPatchSignature(nextRows);
+        setAutoSaveStatus('idle');
+    }, [properties]);
+
+    useEffect(() => {
+        rowsRef.current = rows;
+    }, [rows]);
+
+    useEffect(() => {
+        deletedKeysRef.current = deletedKeys;
+    }, [deletedKeys]);
+
+    useEffect(() => {
+        expectedUpdatedAtRef.current = expectedUpdatedAt;
+    }, [expectedUpdatedAt]);
+
+    const propertyKeySummaries = normalizePropertyKeySummaries(propertyKeysQuery.data);
+    const visiblePropertyKeys = propertyKeySummaries.filter(
+        (propertyKey) => !rows.some((row) => row.key === propertyKey.key),
+    );
+    const hasPropertyDefinitions = propertyKeySummaries.length > 0;
+
+    const saveCurrentRows = useCallback(async () => {
+        const signature = getPropertyRowsPatchSignature(rowsRef.current, deletedKeysRef.current);
+
+        if (disabled || signature === savedSignatureRef.current) {
+            return;
+        }
+
+        if (isAutoSavingRef.current) {
+            hasQueuedAutoSaveRef.current = true;
+            return;
+        }
+
+        const patch = getPropertyRowsPatchDraft(rowsRef.current, deletedKeysRef.current);
+
+        if (patch.set.length === 0 && patch.deleteKeys.length === 0) {
+            return;
+        }
+
+        isAutoSavingRef.current = true;
+        hasQueuedAutoSaveRef.current = false;
+        setAutoSaveStatus('saving');
+
+        try {
+            const response = await updateNoteProperties({
+                id: noteId,
+                set: patch.set,
+                deleteKeys: patch.deleteKeys,
+                editSessionId,
+                expectedUpdatedAt: expectedUpdatedAtRef.current,
+            });
+
+            if (response.type === 'error') {
+                setAutoSaveStatus('error');
+                toast(response.errors[0]?.message ?? 'Failed to save properties.');
+                return;
+            }
+
+            expectedUpdatedAtRef.current = response.updateNoteProperties.updatedAt;
+            savedSignatureRef.current = getPropertyRowsPatchSignature(
+                getNormalizedRows(response.updateNoteProperties.properties ?? []),
+            );
+            onSaved(response.updateNoteProperties);
+            void queryClient.invalidateQueries({ queryKey: queryKeys.notes.propertyKeys() });
+            setAutoSaveStatus('saved');
+        } catch {
+            setAutoSaveStatus('error');
+            toast('Failed to save properties.');
+        } finally {
+            isAutoSavingRef.current = false;
+
+            if (hasQueuedAutoSaveRef.current) {
+                hasQueuedAutoSaveRef.current = false;
+                void saveCurrentRows();
+            }
+        }
+    }, [disabled, editSessionId, noteId, onSaved, queryClient, toast]);
+
+    useEffect(() => {
+        if (autoSaveTimerRef.current) {
+            clearTimeout(autoSaveTimerRef.current);
+        }
+
+        if (disabled || getPropertyRowsPatchSignature(rows, deletedKeys) === savedSignatureRef.current) {
+            return;
+        }
+
+        autoSaveTimerRef.current = setTimeout(() => {
+            void saveCurrentRows();
+        }, 500);
+
+        return () => {
+            if (autoSaveTimerRef.current) {
+                clearTimeout(autoSaveTimerRef.current);
+            }
+        };
+    }, [deletedKeys, disabled, rows, saveCurrentRows]);
+
+    const addKnownProperty = (propertyKey: NotePropertyKeySummary) => {
+        setRows((current) => [
+            ...current,
+            {
+                id: propertyKey.key,
+                key: propertyKey.key,
+                name: propertyKey.name,
+                value: '',
+                valueType: propertyKey.valueType,
+                persistedKey: undefined,
+            },
+        ]);
+        setDeletedKeys((current) => current.filter((key) => key !== propertyKey.key));
+    };
+
+    const updateRow = (rowId: string, patch: Partial<EditableNotePropertyRow>) => {
+        setRows((current) => current.map((row) => (row.id === rowId ? { ...row, ...patch } : row)));
+    };
+
+    const removeRow = (row: EditableNotePropertyRow) => {
+        if (row.persistedKey) {
+            setDeletedKeys((current) => [...new Set([...current, row.persistedKey as string])]);
+        }
+
+        setRows((current) => current.filter((item) => item.id !== row.id));
+    };
+
+    const hasChanges = getPropertyRowsPatchSignature(rows, deletedKeys) !== savedSignatureRef.current;
+    const saveStatusText =
+        disabled || (!hasChanges && autoSaveStatus === 'idle')
+            ? null
+            : autoSaveStatus === 'saving'
+              ? 'Saving...'
+              : autoSaveStatus === 'error'
+                ? 'Save failed'
+                : hasChanges
+                  ? 'Waiting...'
+                  : 'Saved';
+
+    return (
+        <AuxiliaryPanel
+            title="Properties"
+            icon={<Icon.Tag className="h-3.5 w-3.5" />}
+            ariaLabel="Note properties"
+            action={
+                <>
+                    {saveStatusText && (
+                        <Text
+                            as="span"
+                            variant="micro"
+                            tone={autoSaveStatus === 'error' ? 'error' : 'tertiary'}
+                            className="px-1"
+                        >
+                            {saveStatusText}
+                        </Text>
+                    )}
+                    {hasPropertyDefinitions && (
+                        <Button asChild size="sm" variant="ghost">
+                            <Link to={SETTINGS_PROPERTIES_ROUTE} search={{ page: 1 }}>
+                                <Icon.Gear className="h-3 w-3" />
+                                Manage
+                            </Link>
+                        </Button>
+                    )}
+                </>
+            }
+        >
+            {disabled && (
+                <Text as="p" variant="label" tone="tertiary" className="mb-3">
+                    Finish the current note save or resolve conflicts before editing properties.
+                </Text>
+            )}
+
+            {rows.length === 0 ? (
+                <Text as="p" variant="label" tone="tertiary" className="px-1 py-2">
+                    No properties yet.
+                </Text>
+            ) : (
+                <div className="divide-y divide-border-subtle">
+                    {rows.map((row) => (
+                        <div
+                            key={row.id}
+                            className="group grid gap-2 py-2 sm:grid-cols-[minmax(0,180px)_minmax(0,1fr)_auto] sm:items-center"
+                        >
+                            <div className="flex min-w-0 items-center gap-2 px-1">
+                                <Text as="span" variant="label" tone="secondary" className="truncate">
+                                    {row.name}
+                                </Text>
+                                <Text
+                                    as="span"
+                                    variant="micro"
+                                    tone="tertiary"
+                                    className="hidden truncate font-mono sm:inline"
+                                >
+                                    {row.key}
+                                </Text>
+                            </div>
+                            {row.valueType === 'boolean' ? (
+                                <Select
+                                    size="sm"
+                                    variant="ghost"
+                                    value={row.value || 'false'}
+                                    disabled={disabled}
+                                    onValueChange={(value) => updateRow(row.id, { value })}
+                                >
+                                    <SelectItem value="false">False</SelectItem>
+                                    <SelectItem value="true">True</SelectItem>
+                                </Select>
+                            ) : row.valueType === 'select' ? (
+                                <Select
+                                    size="sm"
+                                    variant="ghost"
+                                    value={row.value}
+                                    placeholder="Select option"
+                                    disabled={disabled}
+                                    onValueChange={(value) => updateRow(row.id, { value })}
+                                >
+                                    {(
+                                        propertyKeySummaries.find((propertyKey) => propertyKey.key === row.key)
+                                            ?.options ?? []
+                                    ).map((option) => (
+                                        <SelectItem key={option.id} value={option.value}>
+                                            {option.label}
+                                        </SelectItem>
+                                    ))}
+                                </Select>
+                            ) : (
+                                <Input
+                                    size="sm"
+                                    variant="ghost"
+                                    type={
+                                        row.valueType === 'date'
+                                            ? 'date'
+                                            : row.valueType === 'number'
+                                              ? 'number'
+                                              : 'text'
+                                    }
+                                    aria-label="Property value"
+                                    placeholder="Value"
+                                    value={row.value}
+                                    disabled={disabled}
+                                    onChange={(event) => updateRow(row.id, { value: event.target.value })}
+                                />
+                            )}
+                            <Button
+                                type="button"
+                                size="icon-sm"
+                                variant="ghost"
+                                aria-label={`Remove ${row.name}`}
+                                disabled={disabled}
+                                className="justify-self-end text-fg-tertiary sm:opacity-0 sm:group-hover:opacity-100 sm:focus-visible:opacity-100"
+                                onClick={() => removeRow(row)}
+                            >
+                                <Icon.Close className="h-4 w-4" />
+                            </Button>
+                        </div>
+                    ))}
+                </div>
+            )}
+
+            <div className="mt-2 flex flex-wrap items-center gap-2">
+                {propertyKeysQuery.isLoading ? (
+                    <Button type="button" size="sm" variant="ghost" disabled>
+                        Loading properties...
+                    </Button>
+                ) : visiblePropertyKeys.length > 0 ? (
+                    <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                            <Button type="button" size="sm" variant="ghost" disabled={disabled}>
+                                <Icon.Plus className="h-4 w-4" />
+                                Add property
+                            </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent
+                            align="start"
+                            sideOffset={6}
+                            className="max-h-80 w-[min(22rem,calc(100vw-2rem))]"
+                            style={{ overflowY: 'auto' }}
+                        >
+                            <DropdownMenuLabel>
+                                <Text as="span" variant="label" weight="semibold">
+                                    Add property
+                                </Text>
+                            </DropdownMenuLabel>
+                            <DropdownMenuSeparator />
+                            {visiblePropertyKeys.map((propertyKey) => (
+                                <DropdownMenuItem
+                                    key={propertyKey.key}
+                                    className="flex-col items-start gap-0.5 whitespace-normal"
+                                    onClick={() => addKnownProperty(propertyKey)}
+                                >
+                                    <span className="flex w-full min-w-0 items-center justify-between gap-3">
+                                        <Text as="span" variant="label" weight="medium" className="truncate">
+                                            {propertyKey.name}
+                                        </Text>
+                                        <Text as="span" variant="micro" tone="tertiary" className="shrink-0 capitalize">
+                                            {propertyKey.valueType}
+                                        </Text>
+                                    </span>
+                                    <Text as="span" variant="micro" tone="tertiary" className="font-mono">
+                                        {propertyKey.key}
+                                    </Text>
+                                </DropdownMenuItem>
+                            ))}
+                        </DropdownMenuContent>
+                    </DropdownMenu>
+                ) : hasPropertyDefinitions ? (
+                    <Text as="span" variant="micro" tone="tertiary" className="px-1">
+                        All shared properties are attached.
+                    </Text>
+                ) : (
+                    <Link
+                        to={SETTINGS_PROPERTIES_ROUTE}
+                        search={{ page: 1 }}
+                        className="focus-ring-soft inline-flex items-center gap-2 rounded-[12px] px-2.5 py-1.5 text-sm font-medium text-fg-secondary outline-none hover:bg-hover-subtle hover:text-fg-default"
+                    >
+                        <Icon.Plus className="h-4 w-4" />
+                        Create property definition
+                    </Link>
+                )}
+            </div>
+        </AuxiliaryPanel>
+    );
+};
+
 interface NoteContentProps {
     id: string;
 }
@@ -102,7 +580,7 @@ type ExternalNoteChangeSource = 'web' | 'mcp' | 'unknown';
 type ExternalNoteChange =
     | { type: 'updated'; updatedAt: string; source: ExternalNoteChangeSource }
     | { type: 'deleted'; source: ExternalNoteChangeSource };
-type NoteDetailCache = Pick<Note, 'title' | 'content' | 'pinned' | 'layout' | 'createdAt' | 'updatedAt'>;
+type NoteDetailCache = Pick<Note, 'title' | 'content' | 'pinned' | 'layout' | 'createdAt' | 'updatedAt' | 'properties'>;
 
 export function NoteContent({ id }: NoteContentProps) {
     const toast = useToast();
@@ -876,6 +1354,36 @@ export function NoteContent({ id }: NoteContentProps) {
                     </Callout>
                 )}
 
+                <NotePropertiesPanel
+                    noteId={id}
+                    properties={note.properties}
+                    expectedUpdatedAt={serverUpdatedAtRef.current}
+                    editSessionId={editSessionIdRef.current}
+                    disabled={saveStatus !== 'saved'}
+                    onSaved={(updatedNote) => {
+                        appliedNoteVersionRef.current = updatedNote.updatedAt;
+                        setServerUpdatedAt(updatedNote.updatedAt);
+                        updateLastSavedAt(updatedNote.updatedAt);
+                        setShowSavedConfirmation(true);
+                        queryClient.setQueryData<NoteDetailCache>(queryKeys.notes.detail(id), (current) => {
+                            if (!current) {
+                                return current;
+                            }
+
+                            return {
+                                ...current,
+                                updatedAt: updatedNote.updatedAt,
+                                properties: updatedNote.properties,
+                            };
+                        });
+                        publishClientNoteUpdatedEvent({
+                            noteId: id,
+                            updatedAt: updatedNote.updatedAt,
+                            editSessionId: editSessionIdRef.current,
+                        });
+                    }}
+                />
+
                 <Editor
                     key={`${id}:${editorRevision}`}
                     ref={editorRef}
@@ -922,12 +1430,10 @@ export function NoteContent({ id }: NoteContentProps) {
                         render={(backReferences) =>
                             backReferences &&
                             backReferences.length > 0 && (
-                                <div className="surface-base p-4">
-                                    <AuxiliaryPanelHeader
-                                        icon={<Icon.LinkSimple className="h-3.5 w-3.5" />}
-                                        title="Back References"
-                                        className="mb-3 text-fg-tertiary"
-                                    />
+                                <AuxiliaryPanel
+                                    icon={<Icon.LinkSimple className="h-3.5 w-3.5" />}
+                                    title="Back References"
+                                >
                                     <ul className="flex flex-col">
                                         {backReferences.map((backLink) => (
                                             <li key={backLink.id}>
@@ -949,7 +1455,7 @@ export function NoteContent({ id }: NoteContentProps) {
                                             </li>
                                         ))}
                                     </ul>
-                                </div>
+                                </AuxiliaryPanel>
                             )
                         }
                     />

--- a/packages/client/src/pages/setting/index.tsx
+++ b/packages/client/src/pages/setting/index.tsx
@@ -6,6 +6,7 @@ import {
     SETTINGS_MANAGE_IMAGE_ROUTE,
     SETTINGS_MCP_ROUTE,
     SETTINGS_PLACEHOLDER_ROUTE,
+    SETTINGS_PROPERTIES_ROUTE,
     SETTINGS_TRASH_ROUTE,
 } from '~/modules/url';
 import { useTheme } from '~/store/theme';
@@ -108,6 +109,22 @@ const Setting = () => {
                                     </Text>
                                     <Text as="div" variant="meta" tone="secondary">
                                         Upload and organize images.
+                                    </Text>
+                                </div>
+                            </div>
+                            <Icon.ChevronRight className="mt-0.5 h-4 w-4 shrink-0 text-fg-tertiary transition-transform group-hover:translate-x-0.5 group-hover:text-fg-secondary" />
+                        </Link>
+                        <Link to={SETTINGS_PROPERTIES_ROUTE} search={{ page: 1 }} className={itemClassName}>
+                            <div className="flex min-w-0 items-start gap-3">
+                                <span className={leadingClassName}>
+                                    <Icon.Tag className={iconClassName} />
+                                </span>
+                                <div className={contentClassName}>
+                                    <Text as="div" variant="body" weight="medium">
+                                        Properties
+                                    </Text>
+                                    <Text as="div" variant="meta" tone="secondary">
+                                        Define shared fields for notes and future views.
                                     </Text>
                                 </div>
                             </div>

--- a/packages/client/src/pages/setting/properties.tsx
+++ b/packages/client/src/pages/setting/properties.tsx
@@ -1,0 +1,460 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { getRouteApi } from '@tanstack/react-router';
+import { useState } from 'react';
+import {
+    createNotePropertyKey,
+    deleteNotePropertyKey,
+    fetchNotePropertyKeys,
+    type NotePropertyKeySummary,
+} from '~/apis/note.api';
+import { Button, Modal, ModalActionRow, PageLayout } from '~/components/shared';
+import { Input, Select, SelectItem, Text, useToast } from '~/components/ui';
+import type { NotePropertyValueType } from '~/models/note.model';
+import { queryKeys } from '~/modules/query-key-factory';
+import { SETTINGS_PROPERTIES_ROUTE } from '~/modules/url';
+
+const Route = getRouteApi(SETTINGS_PROPERTIES_ROUTE);
+
+const PROPERTY_TYPE_OPTIONS: { value: NotePropertyValueType; label: string; description: string }[] = [
+    { value: 'text', label: 'Text', description: 'Short status or label values.' },
+    { value: 'number', label: 'Number', description: 'Priority, score, or count values.' },
+    { value: 'date', label: 'Date', description: 'Due dates and milestones.' },
+    { value: 'boolean', label: 'Boolean', description: 'True or false flags.' },
+    { value: 'select', label: 'Select', description: 'Choose one option from a controlled list.' },
+];
+
+export default function PropertiesSettings() {
+    const toast = useToast();
+    const queryClient = useQueryClient();
+    const search = Route.useSearch() as { page?: number };
+    const page = Number(search.page ?? 1);
+    const limit = 50;
+    const offset = Math.max(0, page - 1) * limit;
+    const [key, setKey] = useState('');
+    const [name, setName] = useState('');
+    const [valueType, setValueType] = useState<NotePropertyValueType>('text');
+    const [options, setOptions] = useState([{ label: '', value: '' }]);
+    const [propertyToDelete, setPropertyToDelete] = useState<NotePropertyKeySummary | null>(null);
+    const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+
+    const resetCreateForm = () => {
+        setKey('');
+        setName('');
+        setValueType('text');
+        setOptions([{ label: '', value: '' }]);
+    };
+
+    const propertyKeysQuery = useQuery({
+        queryKey: queryKeys.notes.propertyKeys({ limit, offset }),
+        queryFn: async () => {
+            const response = await fetchNotePropertyKeys({ limit, offset });
+
+            if (response.type === 'error') {
+                throw response;
+            }
+
+            return response.notePropertyKeys;
+        },
+    });
+
+    const createMutation = useMutation({
+        mutationFn: async () =>
+            createNotePropertyKey({
+                key,
+                name: name || key,
+                valueType,
+                ...(valueType === 'select'
+                    ? {
+                          options: options
+                              .map((option, index) => ({
+                                  label: option.label.trim(),
+                                  value: option.value.trim() || option.label.trim(),
+                                  order: index,
+                              }))
+                              .filter((option) => option.label),
+                      }
+                    : {}),
+            }),
+        onSuccess: (response) => {
+            if (response.type === 'error') {
+                toast(response.errors[0]?.message ?? 'Failed to create property.');
+                return;
+            }
+
+            resetCreateForm();
+            setIsCreateModalOpen(false);
+            void queryClient.invalidateQueries({ queryKey: queryKeys.notes.propertyKeys() });
+            toast('Property created.');
+        },
+        onError: () => {
+            toast('Failed to create property.');
+        },
+    });
+
+    const deleteMutation = useMutation({
+        mutationFn: async ({
+            propertyKey,
+            confirmImpact,
+        }: {
+            propertyKey: NotePropertyKeySummary;
+            confirmImpact: boolean;
+        }) =>
+            deleteNotePropertyKey({
+                key: propertyKey.key,
+                confirmImpact,
+            }),
+        onSuccess: (response) => {
+            if (response.type === 'error') {
+                toast(response.errors[0]?.message ?? 'Failed to delete property.');
+                return;
+            }
+
+            void queryClient.invalidateQueries({ queryKey: queryKeys.notes.all() });
+            setPropertyToDelete(null);
+            toast(
+                response.deleteNotePropertyKey.affectedNoteCount > 0
+                    ? `Property deleted from ${response.deleteNotePropertyKey.affectedNoteCount} note(s).`
+                    : 'Property deleted.',
+            );
+        },
+        onError: () => {
+            toast('Failed to delete property.');
+        },
+    });
+
+    const propertyKeys = propertyKeysQuery.data?.keys ?? [];
+    const hasValidSelectOption = valueType !== 'select' || options.some((option) => option.label.trim());
+    const handleConfirmDeleteProperty = () => {
+        if (!propertyToDelete) return;
+
+        deleteMutation.mutate({
+            propertyKey: propertyToDelete,
+            confirmImpact: propertyToDelete.noteCount > 0,
+        });
+    };
+
+    return (
+        <PageLayout
+            title="Properties"
+            description="Define shared note fields before using them in notes and future views."
+            headerRight={
+                <Button
+                    type="button"
+                    size="md"
+                    variant="primary"
+                    className="w-full sm:w-auto"
+                    onClick={() => setIsCreateModalOpen(true)}
+                >
+                    New property
+                </Button>
+            }
+        >
+            <section className="flex flex-col gap-3" aria-labelledby="shared-properties-heading">
+                <div className="flex items-center justify-between gap-3">
+                    <Text
+                        id="shared-properties-heading"
+                        as="h2"
+                        variant="label"
+                        weight="medium"
+                        className="text-fg-tertiary"
+                    >
+                        Shared fields
+                    </Text>
+                    {!propertyKeysQuery.isLoading && propertyKeys.length > 0 && (
+                        <Text as="span" variant="meta" tone="tertiary">
+                            {propertyKeys.length} field{propertyKeys.length === 1 ? '' : 's'}
+                        </Text>
+                    )}
+                </div>
+
+                {propertyKeysQuery.isLoading ? (
+                    <Text as="p" variant="body" tone="tertiary" className="surface-base px-4 py-3.5">
+                        Loading properties...
+                    </Text>
+                ) : propertyKeys.length === 0 ? (
+                    <div className="surface-base border-dashed p-6 text-center">
+                        <Text as="p" variant="body" weight="medium">
+                            No shared properties yet.
+                        </Text>
+                        <Text as="p" variant="label" tone="tertiary">
+                            Create one here, then attach it from the note screen.
+                        </Text>
+                    </div>
+                ) : (
+                    <div className="flex flex-col gap-3">
+                        {propertyKeys.map((propertyKey) => (
+                            <article
+                                key={propertyKey.key}
+                                className="surface-base grid gap-3 px-4 py-3.5 md:grid-cols-[minmax(0,1fr)_120px_120px_auto] md:items-center"
+                            >
+                                <div className="min-w-0">
+                                    <Text as="h3" variant="body" weight="semibold" className="truncate">
+                                        {propertyKey.name}
+                                    </Text>
+                                    <Text as="p" variant="micro" tone="tertiary" className="font-mono">
+                                        {propertyKey.key}
+                                    </Text>
+                                    {propertyKey.options.length > 0 && (
+                                        <div className="mt-2 flex flex-wrap gap-1.5">
+                                            {propertyKey.options.slice(0, 6).map((option) => (
+                                                <span
+                                                    key={option.id}
+                                                    className="rounded-full border border-border-subtle bg-subtle px-2 py-0.5 text-xs font-medium text-fg-secondary"
+                                                >
+                                                    {option.label}
+                                                </span>
+                                            ))}
+                                            {propertyKey.options.length > 6 && (
+                                                <span className="rounded-full border border-border-subtle bg-subtle px-2 py-0.5 text-xs font-medium text-fg-tertiary">
+                                                    +{propertyKey.options.length - 6}
+                                                </span>
+                                            )}
+                                        </div>
+                                    )}
+                                </div>
+                                <div className="min-w-0">
+                                    <Text as="span" variant="micro" tone="tertiary" className="block md:hidden">
+                                        Type
+                                    </Text>
+                                    <Text as="span" variant="label" tone="secondary" className="capitalize">
+                                        {propertyKey.valueType}
+                                    </Text>
+                                </div>
+                                <div className="min-w-0">
+                                    <Text as="span" variant="micro" tone="tertiary" className="block md:hidden">
+                                        Used in
+                                    </Text>
+                                    <Text as="span" variant="label" tone="tertiary">
+                                        {propertyKey.noteCount} note{propertyKey.noteCount === 1 ? '' : 's'}
+                                    </Text>
+                                </div>
+                                <Button
+                                    type="button"
+                                    size="sm"
+                                    variant="soft-danger"
+                                    className="justify-self-start md:justify-self-end"
+                                    disabled={deleteMutation.isPending}
+                                    onClick={() => setPropertyToDelete(propertyKey)}
+                                >
+                                    Delete
+                                </Button>
+                            </article>
+                        ))}
+                    </div>
+                )}
+            </section>
+
+            <Modal
+                isOpen={isCreateModalOpen}
+                onClose={() => {
+                    if (!createMutation.isPending) {
+                        setIsCreateModalOpen(false);
+                        resetCreateForm();
+                    }
+                }}
+                variant="form"
+            >
+                <Modal.Header
+                    title="New property"
+                    onClose={() => {
+                        setIsCreateModalOpen(false);
+                        resetCreateForm();
+                    }}
+                />
+                <Modal.Body>
+                    <div className="flex flex-col gap-3">
+                        <Text as="p" variant="label" tone="tertiary">
+                            Create a shared field that notes can use for values and future views.
+                        </Text>
+                        <label className="flex flex-col gap-1.5">
+                            <Text as="span" variant="label" weight="medium">
+                                Key
+                            </Text>
+                            <Input
+                                size="md"
+                                placeholder="status"
+                                value={key}
+                                onChange={(event) => setKey(event.target.value)}
+                            />
+                        </label>
+                        <label className="flex flex-col gap-1.5">
+                            <Text as="span" variant="label" weight="medium">
+                                Name
+                            </Text>
+                            <Input
+                                size="md"
+                                placeholder="Status"
+                                value={name}
+                                onChange={(event) => setName(event.target.value)}
+                            />
+                        </label>
+                        <label className="flex flex-col gap-1.5">
+                            <Text as="span" variant="label" weight="medium">
+                                Type
+                            </Text>
+                            <Select
+                                value={valueType}
+                                onValueChange={(value) => setValueType(value as NotePropertyValueType)}
+                            >
+                                {PROPERTY_TYPE_OPTIONS.map((option) => (
+                                    <SelectItem key={option.value} value={option.value}>
+                                        {option.label}
+                                    </SelectItem>
+                                ))}
+                            </Select>
+                        </label>
+                        {valueType === 'select' && (
+                            <div className="rounded-[14px] border border-border-subtle bg-subtle/50 p-3">
+                                <div className="mb-2 flex items-center justify-between gap-2">
+                                    <Text as="span" variant="label" weight="semibold">
+                                        Options
+                                    </Text>
+                                    <Button
+                                        type="button"
+                                        size="sm"
+                                        variant="subtle"
+                                        onClick={() => setOptions((current) => [...current, { label: '', value: '' }])}
+                                    >
+                                        Add option
+                                    </Button>
+                                </div>
+                                <div className="flex flex-col gap-2">
+                                    {options.map((option, index) => (
+                                        <div key={index} className="grid gap-2 sm:grid-cols-[1fr_1fr_auto]">
+                                            <Input
+                                                size="sm"
+                                                placeholder="Label"
+                                                value={option.label}
+                                                onChange={(event) =>
+                                                    setOptions((current) =>
+                                                        current.map((item, itemIndex) =>
+                                                            itemIndex === index
+                                                                ? { ...item, label: event.target.value }
+                                                                : item,
+                                                        ),
+                                                    )
+                                                }
+                                            />
+                                            <Input
+                                                size="sm"
+                                                placeholder="value"
+                                                value={option.value}
+                                                onChange={(event) =>
+                                                    setOptions((current) =>
+                                                        current.map((item, itemIndex) =>
+                                                            itemIndex === index
+                                                                ? { ...item, value: event.target.value }
+                                                                : item,
+                                                        ),
+                                                    )
+                                                }
+                                            />
+                                            <Button
+                                                type="button"
+                                                size="sm"
+                                                variant="soft-danger"
+                                                onClick={() =>
+                                                    setOptions((current) =>
+                                                        current.filter((_, itemIndex) => itemIndex !== index),
+                                                    )
+                                                }
+                                            >
+                                                Remove
+                                            </Button>
+                                        </div>
+                                    ))}
+                                </div>
+                            </div>
+                        )}
+                        <Text as="p" variant="micro" tone="tertiary">
+                            {PROPERTY_TYPE_OPTIONS.find((option) => option.value === valueType)?.description}
+                        </Text>
+                    </div>
+                </Modal.Body>
+                <Modal.Footer>
+                    <ModalActionRow>
+                        <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            disabled={createMutation.isPending}
+                            onClick={() => {
+                                setIsCreateModalOpen(false);
+                                resetCreateForm();
+                            }}
+                        >
+                            Cancel
+                        </Button>
+                        <Button
+                            type="button"
+                            variant="primary"
+                            size="sm"
+                            disabled={!key.trim() || !hasValidSelectOption || createMutation.isPending}
+                            isLoading={createMutation.isPending}
+                            onClick={() => createMutation.mutate()}
+                        >
+                            Create property
+                        </Button>
+                    </ModalActionRow>
+                </Modal.Footer>
+            </Modal>
+
+            <Modal
+                isOpen={Boolean(propertyToDelete)}
+                onClose={() => {
+                    if (!deleteMutation.isPending) setPropertyToDelete(null);
+                }}
+                variant="confirm"
+            >
+                <Modal.Header title="Delete property" onClose={() => setPropertyToDelete(null)} />
+                <Modal.Body>
+                    {propertyToDelete && (
+                        <div className="space-y-3">
+                            <Text as="p" variant="body" weight="medium">
+                                Delete “{propertyToDelete.name}”?
+                            </Text>
+                            {propertyToDelete.noteCount > 0 ? (
+                                <div className="rounded-[14px] border border-border-subtle bg-subtle p-3">
+                                    <Text as="p" variant="label" tone="secondary">
+                                        This property is used by {propertyToDelete.noteCount} note
+                                        {propertyToDelete.noteCount === 1 ? '' : 's'}.
+                                    </Text>
+                                    <Text as="p" variant="micro" tone="tertiary" className="mt-1 leading-5">
+                                        Deleting it removes this value from those notes. Future views using this
+                                        property will need configuration.
+                                    </Text>
+                                </div>
+                            ) : (
+                                <Text as="p" variant="label" tone="tertiary">
+                                    This property is not used by any note yet.
+                                </Text>
+                            )}
+                        </div>
+                    )}
+                </Modal.Body>
+                <Modal.Footer>
+                    <ModalActionRow>
+                        <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            disabled={deleteMutation.isPending}
+                            onClick={() => setPropertyToDelete(null)}
+                        >
+                            Cancel
+                        </Button>
+                        <Button
+                            type="button"
+                            variant="danger"
+                            size="sm"
+                            isLoading={deleteMutation.isPending}
+                            onClick={handleConfirmDeleteProperty}
+                        >
+                            Delete
+                        </Button>
+                    </ModalActionRow>
+                </Modal.Footer>
+            </Modal>
+        </PageLayout>
+    );
+}

--- a/packages/client/src/router.tsx
+++ b/packages/client/src/router.tsx
@@ -20,6 +20,7 @@ import {
     SETTINGS_MANAGE_IMAGE_ROUTE,
     SETTINGS_MCP_ROUTE,
     SETTINGS_PLACEHOLDER_ROUTE,
+    SETTINGS_PROPERTIES_ROUTE,
     SETTINGS_ROUTE,
     SETTINGS_TRASH_ROUTE,
     TAG_NOTES_ROUTE,
@@ -174,6 +175,16 @@ const manageImageDetailRoute = createRoute({
     ),
 });
 
+const propertiesRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: SETTINGS_PROPERTIES_ROUTE,
+    component: lazyRouteComponent(() => import('~/pages/setting/properties')),
+    pendingComponent: () => (
+        <RoutePendingView title="Loading properties" description="Preparing shared property definitions." />
+    ),
+    validateSearch: validatePaginationSearch,
+});
+
 const placeholderRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: SETTINGS_PLACEHOLDER_ROUTE,
@@ -201,6 +212,7 @@ const routeTree = rootRoute.addChildren([
     manageImageRoute,
     manageImageDetailRoute,
     placeholderRoute,
+    propertiesRoute,
 ]);
 
 export const router = createRouter({

--- a/packages/client/src/styles/tailwind.css
+++ b/packages/client/src/styles/tailwind.css
@@ -2,18 +2,9 @@
 
 @custom-variant dark (&:where(html.dark *));
 
-@property --save-progress {
-    syntax: "<percentage>";
-    initial-value: 0%;
-    inherits: false;
-}
-
-@keyframes save-ring-progress {
-    from {
-        --save-progress: 0%;
-    }
+@keyframes save-ring-spin {
     to {
-        --save-progress: 92%;
+        transform: rotate(360deg);
     }
 }
 
@@ -409,9 +400,9 @@ html.dark .surface-base {
 }
 
 .save-progress-ring-active {
-    --save-progress: 0%;
+    --save-progress: 28%;
     --save-ring-color: var(--accent-primary);
-    animation: save-ring-progress 1200ms linear forwards;
+    animation: save-ring-spin 800ms linear infinite;
 }
 
 .save-progress-ring-complete {
@@ -422,6 +413,13 @@ html.dark .surface-base {
 .save-progress-ring-error {
     --save-progress: 100%;
     --save-ring-color: var(--accent-danger);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .save-progress-ring-active {
+        --save-progress: 100%;
+        animation: none;
+    }
 }
 
 /* Skeleton sizing */

--- a/packages/server/prisma/migrations/20260527073000_0017_note_properties/migration.sql
+++ b/packages/server/prisma/migrations/20260527073000_0017_note_properties/migration.sql
@@ -1,0 +1,105 @@
+-- CreateTable
+CREATE TABLE "PropertyDefinition" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "key" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "valueType" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "PropertyOption" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "propertyDefinitionId" INTEGER NOT NULL,
+    "label" TEXT NOT NULL,
+    "value" TEXT NOT NULL,
+    "color" TEXT,
+    "order" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "PropertyOption_propertyDefinitionId_fkey" FOREIGN KEY ("propertyDefinitionId") REFERENCES "PropertyDefinition" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "NoteProperty" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "noteId" INTEGER NOT NULL,
+    "propertyDefinitionId" INTEGER NOT NULL,
+    "optionId" INTEGER,
+    "textValue" TEXT,
+    "textValueNormalized" TEXT,
+    "numberValue" REAL,
+    "dateValue" DATETIME,
+    "boolValue" BOOLEAN,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "NoteProperty_noteId_fkey" FOREIGN KEY ("noteId") REFERENCES "Note" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "NoteProperty_propertyDefinitionId_fkey" FOREIGN KEY ("propertyDefinitionId") REFERENCES "PropertyDefinition" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "NoteProperty_optionId_fkey" FOREIGN KEY ("optionId") REFERENCES "PropertyOption" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "DeletedNoteProperty" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "deletedNoteId" INTEGER NOT NULL,
+    "key" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "valueType" TEXT NOT NULL,
+    "textValue" TEXT,
+    "textValueNormalized" TEXT,
+    "numberValue" REAL,
+    "dateValue" DATETIME,
+    "boolValue" BOOLEAN,
+    "optionValue" TEXT,
+    "optionLabel" TEXT,
+    "optionColor" TEXT,
+    "createdAt" DATETIME NOT NULL,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "DeletedNoteProperty_deletedNoteId_fkey" FOREIGN KEY ("deletedNoteId") REFERENCES "DeletedNote" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PropertyDefinition_key_key" ON "PropertyDefinition"("key");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PropertyOption_propertyDefinitionId_value_key" ON "PropertyOption"("propertyDefinitionId", "value");
+
+-- CreateIndex
+CREATE INDEX "PropertyOption_propertyDefinitionId_order_idx" ON "PropertyOption"("propertyDefinitionId", "order");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "NoteProperty_noteId_propertyDefinitionId_key" ON "NoteProperty"("noteId", "propertyDefinitionId");
+
+-- CreateIndex
+CREATE INDEX "NoteProperty_propertyDefinitionId_noteId_idx" ON "NoteProperty"("propertyDefinitionId", "noteId");
+
+-- CreateIndex
+CREATE INDEX "NoteProperty_propertyDefinitionId_textValueNormalized_noteId_idx" ON "NoteProperty"("propertyDefinitionId", "textValueNormalized", "noteId");
+
+-- CreateIndex
+CREATE INDEX "NoteProperty_propertyDefinitionId_numberValue_noteId_idx" ON "NoteProperty"("propertyDefinitionId", "numberValue", "noteId");
+
+-- CreateIndex
+CREATE INDEX "NoteProperty_propertyDefinitionId_dateValue_noteId_idx" ON "NoteProperty"("propertyDefinitionId", "dateValue", "noteId");
+
+-- CreateIndex
+CREATE INDEX "NoteProperty_propertyDefinitionId_boolValue_noteId_idx" ON "NoteProperty"("propertyDefinitionId", "boolValue", "noteId");
+
+-- CreateIndex
+CREATE INDEX "NoteProperty_propertyDefinitionId_optionId_noteId_idx" ON "NoteProperty"("propertyDefinitionId", "optionId", "noteId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DeletedNoteProperty_deletedNoteId_key_key" ON "DeletedNoteProperty"("deletedNoteId", "key");
+
+-- CreateIndex
+CREATE INDEX "DeletedNoteProperty_deletedNoteId_idx" ON "DeletedNoteProperty"("deletedNoteId");
+
+-- CreateIndex
+CREATE INDEX "Note_updatedAt_id_idx" ON "Note"("updatedAt", "id");
+
+-- CreateIndex
+CREATE INDEX "Note_createdAt_id_idx" ON "Note"("createdAt", "id");
+
+-- CreateIndex
+CREATE INDEX "Note_pinned_updatedAt_id_idx" ON "Note"("pinned", "updatedAt", "id");

--- a/packages/server/prisma/schema.prisma
+++ b/packages/server/prisma/schema.prisma
@@ -39,6 +39,64 @@ model Note {
     tags                 Tag[]      @relation("NoteToTag")
     reminders            Reminder[] @relation("NoteToReminder")
     snapshots            NoteSnapshot[]
+    properties           NoteProperty[]
+
+    @@index([updatedAt, id])
+    @@index([createdAt, id])
+    @@index([pinned, updatedAt, id])
+}
+
+model PropertyDefinition {
+    id         Int               @id @default(autoincrement())
+    key        String            @unique
+    name       String
+    valueType  PropertyValueType
+    createdAt  DateTime          @default(now())
+    updatedAt  DateTime          @updatedAt
+    options    PropertyOption[]
+    properties NoteProperty[]
+}
+
+
+model PropertyOption {
+    id                   Int                @id @default(autoincrement())
+    propertyDefinitionId Int
+    definition           PropertyDefinition @relation(fields: [propertyDefinitionId], references: [id], onDelete: Cascade)
+    label                String
+    value                String
+    color                String?
+    order                Int                @default(0)
+    properties           NoteProperty[]
+    createdAt            DateTime           @default(now())
+    updatedAt            DateTime           @updatedAt
+
+    @@unique([propertyDefinitionId, value])
+    @@index([propertyDefinitionId, order])
+}
+
+model NoteProperty {
+    id                   Int                @id @default(autoincrement())
+    noteId               Int
+    propertyDefinitionId Int
+    note                 Note               @relation(fields: [noteId], references: [id], onDelete: Cascade)
+    definition           PropertyDefinition @relation(fields: [propertyDefinitionId], references: [id], onDelete: Cascade)
+    optionId             Int?
+    option               PropertyOption?    @relation(fields: [optionId], references: [id], onDelete: SetNull)
+    textValue            String?
+    textValueNormalized  String?
+    numberValue          Float?
+    dateValue            DateTime?
+    boolValue            Boolean?
+    createdAt            DateTime           @default(now())
+    updatedAt            DateTime           @updatedAt
+
+    @@unique([noteId, propertyDefinitionId])
+    @@index([propertyDefinitionId, noteId])
+    @@index([propertyDefinitionId, textValueNormalized, noteId])
+    @@index([propertyDefinitionId, numberValue, noteId])
+    @@index([propertyDefinitionId, dateValue, noteId])
+    @@index([propertyDefinitionId, boolValue, noteId])
+    @@index([propertyDefinitionId, optionId, noteId])
 }
 
 model NoteSnapshot {
@@ -67,8 +125,31 @@ model DeletedNote {
     layout     NoteLayout       @default(wide)
     tags       DeletedNoteTag[]
     reminders  DeletedReminder[]
+    properties DeletedNoteProperty[]
 
     @@index([deletedAt, updatedAt])
+}
+
+model DeletedNoteProperty {
+    id                  Int               @id @default(autoincrement())
+    deletedNoteId       Int
+    deletedNote         DeletedNote       @relation(fields: [deletedNoteId], references: [id], onDelete: Cascade)
+    key                 String
+    name                String
+    valueType           PropertyValueType
+    textValue           String?
+    textValueNormalized String?
+    numberValue         Float?
+    dateValue           DateTime?
+    boolValue           Boolean?
+    optionValue         String?
+    optionLabel         String?
+    optionColor         String?
+    createdAt           DateTime
+    updatedAt           DateTime
+
+    @@unique([deletedNoteId, key])
+    @@index([deletedNoteId])
 }
 
 model DeletedNoteTag {
@@ -121,6 +202,14 @@ enum NoteLayout {
     narrow
     wide
     full
+}
+
+enum PropertyValueType {
+    text
+    number
+    date
+    boolean
+    select
 }
 
 model Reminder {

--- a/packages/server/src/features/note/graphql/note.field.resolver.ts
+++ b/packages/server/src/features/note/graphql/note.field.resolver.ts
@@ -1,4 +1,5 @@
 import type { IResolvers } from '@graphql-tools/utils';
+import { listNoteProperties } from '~/features/note/services/properties.js';
 import { renderNoteSnapshotContentAsMarkdown } from '~/features/note/services/snapshot.js';
 import type { Note } from '~/models.js';
 import models from '~/models.js';
@@ -13,6 +14,7 @@ interface NoteSnapshotSource {
 
 export const noteFieldResolvers: NoteFieldResolvers = {
     tags: async (note: Note) => models.tag.findMany({ where: { notes: { some: { id: note.id } } } }),
+    properties: async (note: Note) => listNoteProperties(note.id),
     contentAsMarkdown: async (note: Note) => {
         const { blocksToMarkdown } = await import('~/modules/blocknote.js');
         return blocksToMarkdown(note.content);

--- a/packages/server/src/features/note/graphql/note.mutation.resolver.ts
+++ b/packages/server/src/features/note/graphql/note.mutation.resolver.ts
@@ -2,6 +2,15 @@ import type { IResolvers } from '@graphql-tools/utils';
 import type { Request } from 'express';
 import { GraphQLError } from 'graphql';
 import { extractBlocksByType, parseNoteContent } from '~/features/note/services/content-blocks.js';
+import {
+    createNotePropertyDefinition,
+    deleteNotePropertyDefinition,
+    InvalidNotePropertyInputError,
+    type NotePropertiesPatchInput,
+    type NotePropertyDefinitionInput,
+    NotePropertyDeleteConfirmationRequiredError,
+    updateNotePropertiesWithVersionGuard,
+} from '~/features/note/services/properties.js';
 import { buildNoteSearchProjection } from '~/features/note/services/search.js';
 import { createSnapshotMetaFromUserAgent, restoreNoteSnapshot } from '~/features/note/services/snapshot.js';
 import { purgeTrashedNoteById, restoreTrashedNoteById, trashNoteById } from '~/features/note/services/trash.js';
@@ -211,6 +220,119 @@ export const noteMutationResolvers: NoteMutationResolvers = {
         }
 
         return true;
+    },
+    createNotePropertyKey: async (_, { input }: { input: NotePropertyDefinitionInput }) => {
+        try {
+            return await createNotePropertyDefinition(input);
+        } catch (error) {
+            if (error instanceof InvalidNotePropertyInputError) {
+                throw new GraphQLError(error.message, {
+                    extensions: {
+                        code: 'INVALID_NOTE_PROPERTY_INPUT',
+                    },
+                });
+            }
+
+            throw error;
+        }
+    },
+    deleteNotePropertyKey: async (_, { key, confirmImpact }: { key: string; confirmImpact?: boolean }) => {
+        try {
+            const result = await deleteNotePropertyDefinition({ key, confirmImpact });
+
+            if (!result) {
+                throw 'NOT FOUND';
+            }
+
+            return result;
+        } catch (error) {
+            if (error instanceof InvalidNotePropertyInputError) {
+                throw new GraphQLError(error.message, {
+                    extensions: {
+                        code: 'INVALID_NOTE_PROPERTY_INPUT',
+                    },
+                });
+            }
+
+            if (error instanceof NotePropertyDeleteConfirmationRequiredError) {
+                throw new GraphQLError(error.message, {
+                    extensions: {
+                        code: error.code,
+                        affectedNoteCount: error.affectedNoteCount,
+                    },
+                });
+            }
+
+            throw error;
+        }
+    },
+    updateNoteProperties: async (
+        _,
+        {
+            id,
+            patch,
+            editSessionId,
+            expectedUpdatedAt,
+            force,
+        }: {
+            id: string;
+            patch: NotePropertiesPatchInput;
+            editSessionId?: string;
+            expectedUpdatedAt?: string;
+            force?: boolean;
+        },
+    ) => {
+        try {
+            const note = await updateNotePropertiesWithVersionGuard({
+                id: Number(id),
+                patch,
+                ...(editSessionId ? { editSessionId } : {}),
+                ...(expectedUpdatedAt ? { expectedUpdatedAt } : {}),
+                ...(force ? { force: true } : {}),
+            });
+
+            if (!note) {
+                throw 'NOT FOUND';
+            }
+
+            return note;
+        } catch (error) {
+            if (error instanceof InvalidNotePropertyInputError) {
+                throw new GraphQLError(error.message, {
+                    extensions: {
+                        code: 'INVALID_NOTE_PROPERTY_INPUT',
+                    },
+                });
+            }
+
+            if (isNoteVersionConflictError(error)) {
+                throw new GraphQLError(error.message, {
+                    extensions: {
+                        code: error.code,
+                        currentUpdatedAt: error.currentUpdatedAt,
+                        expectedUpdatedAt: error.expectedUpdatedAt,
+                    },
+                });
+            }
+
+            if (isInvalidNoteVersionError(error)) {
+                throw new GraphQLError(error.message, {
+                    extensions: {
+                        code: error.code,
+                    },
+                });
+            }
+
+            if (isMissingNoteVersionError(error)) {
+                throw new GraphQLError(error.message, {
+                    extensions: {
+                        code: error.code,
+                    },
+                });
+            }
+
+            throw error;
+        }
     },
     pinNote: (_, { id, pinned }: { id: string; pinned: boolean }) =>
         models.note.update({

--- a/packages/server/src/features/note/graphql/note.query.resolver.ts
+++ b/packages/server/src/features/note/graphql/note.query.resolver.ts
@@ -7,6 +7,7 @@ import {
     normalizeReferenceId,
     syncReferenceTitlesInContent,
 } from '~/features/note/services/content-blocks.js';
+import { listNotePropertyKeys } from '~/features/note/services/properties.js';
 import {
     buildNoteSearchProjection,
     filterNotesBySearchQuery,
@@ -494,6 +495,25 @@ export const noteQueryResolvers: NoteQueryResolvers = {
     },
     noteSnapshot: async (_, { id }: { id: string }) => {
         return getNoteSnapshot(Number(id));
+    },
+    notePropertyKeys: async (
+        _,
+        {
+            query,
+            pagination = {
+                limit: 50,
+                offset: 0,
+            },
+        }: {
+            query?: string;
+            pagination: Pagination;
+        },
+    ) => {
+        return listNotePropertyKeys({
+            query,
+            limit: Number(pagination.limit),
+            offset: Number(pagination.offset),
+        });
     },
     trashedNote: async (_, { id }: { id: string }) => {
         return getTrashedNoteById(Number(id));

--- a/packages/server/src/features/note/graphql/note.type-defs.ts
+++ b/packages/server/src/features/note/graphql/note.type-defs.ts
@@ -29,10 +29,44 @@ export const noteType = gql`
         or
     }
 
+    enum NotePropertyValueType {
+        text
+        number
+        date
+        boolean
+        select
+    }
+
     input NoteInput {
         title: String
         content: String
         layout: NoteLayout
+    }
+
+    input NotePropertySetInput {
+        key: String!
+        name: String
+        value: String!
+        valueType: NotePropertyValueType!
+    }
+
+    input NotePropertyOptionInput {
+        label: String!
+        value: String
+        color: String
+        order: Int
+    }
+
+    input NotePropertyDefinitionInput {
+        key: String!
+        name: String
+        valueType: NotePropertyValueType!
+        options: [NotePropertyOptionInput!]
+    }
+
+    input NotePropertiesPatchInput {
+        set: [NotePropertySetInput!]
+        deleteKeys: [String!]
     }
 
     input NoteOrderInput {
@@ -58,6 +92,47 @@ export const noteType = gql`
         order: Int!
         layout: NoteLayout!
         tags: [Tag!]!
+        properties: [NoteProperty!]!
+    }
+
+    type NoteProperty {
+        key: String!
+        name: String!
+        value: String!
+        valueType: NotePropertyValueType!
+        createdAt: String!
+        option: NotePropertyOption
+        updatedAt: String!
+    }
+
+    type NotePropertyOption {
+        id: ID!
+        label: String!
+        value: String!
+        color: String
+        order: Int!
+    }
+
+    type NotePropertyKey {
+        key: String!
+        name: String!
+        valueType: NotePropertyValueType!
+        noteCount: Int!
+        options: [NotePropertyOption!]!
+        updatedAt: String!
+    }
+
+    type NotePropertyKeys {
+        totalCount: Int!
+        keys: [NotePropertyKey!]!
+    }
+
+    type NotePropertyDeleteResult {
+        key: String!
+        name: String!
+        valueType: NotePropertyValueType!
+        affectedNoteCount: Int!
+        deleted: Boolean!
     }
 
     type Notes {
@@ -161,6 +236,7 @@ export const noteQuery = gql`
         noteCleanupPreview(id: ID!): NoteCleanupPreview
         noteSnapshots(id: ID!, limit: Int): [NoteSnapshot!]!
         noteSnapshot(id: ID!): NoteSnapshot
+        notePropertyKeys(query: String, pagination: PaginationInput): NotePropertyKeys!
         trashedNote(id: ID!): DeletedNote
         trashedNotes(pagination: PaginationInput): DeletedNotes!
         noteGraph: NoteGraph!
@@ -175,6 +251,15 @@ export const noteMutation = gql`
         restoreNoteSnapshot(id: ID!): Note!
         restoreTrashedNote(id: ID!): Note!
         purgeTrashedNote(id: ID!): Boolean!
+        createNotePropertyKey(input: NotePropertyDefinitionInput!): NotePropertyKey!
+        deleteNotePropertyKey(key: String!, confirmImpact: Boolean): NotePropertyDeleteResult!
+        updateNoteProperties(
+            id: ID!
+            patch: NotePropertiesPatchInput!
+            editSessionId: String
+            expectedUpdatedAt: String!
+            force: Boolean
+        ): Note!
         pinNote(id: ID!, pinned: Boolean!): Note!
         reorderNotes(notes: [NoteOrderInput!]!): [Note!]!
     }

--- a/packages/server/src/features/note/services/properties.test.ts
+++ b/packages/server/src/features/note/services/properties.test.ts
@@ -1,0 +1,108 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+    createNotePropertyDefinition,
+    InvalidNotePropertyInputError,
+    normalizePropertyKey,
+    updateNotePropertiesWithVersionGuard,
+} from './properties.js';
+import { MissingNoteVersionError } from './write-conflict.js';
+
+test('normalizePropertyKey normalizes user input into a stable query key', () => {
+    assert.equal(normalizePropertyKey(' Project State '), 'project-state');
+    assert.equal(normalizePropertyKey('project_state'), 'project_state');
+});
+
+test('normalizePropertyKey rejects empty or unsupported keys', () => {
+    assert.throws(() => normalizePropertyKey('   '), InvalidNotePropertyInputError);
+    assert.throws(() => normalizePropertyKey('#state'), InvalidNotePropertyInputError);
+});
+
+test('property definitions require valid select option datasets before write', async () => {
+    await assert.rejects(
+        () =>
+            createNotePropertyDefinition({
+                key: 'state',
+                name: 'State',
+                valueType: 'select',
+                options: [],
+            }),
+        (error: unknown) =>
+            error instanceof InvalidNotePropertyInputError &&
+            error.message === 'Select properties require at least one option.',
+    );
+
+    await assert.rejects(
+        () =>
+            createNotePropertyDefinition({
+                key: 'state',
+                name: 'State',
+                valueType: 'select',
+                options: [{ label: 'Todo' }, { label: 'Todo' }],
+            }),
+        (error: unknown) =>
+            error instanceof InvalidNotePropertyInputError &&
+            error.message === 'Property options contain duplicate values.',
+    );
+
+    await assert.rejects(
+        () =>
+            createNotePropertyDefinition({
+                key: 'memo',
+                name: 'Memo',
+                valueType: 'text',
+                options: [{ label: 'Todo' }],
+            }),
+        (error: unknown) =>
+            error instanceof InvalidNotePropertyInputError &&
+            error.message === 'Only select properties can have options.',
+    );
+});
+
+test('note property patches reject duplicate and conflicting keys before write', async () => {
+    await assert.rejects(
+        () =>
+            updateNotePropertiesWithVersionGuard({
+                id: 1,
+                expectedUpdatedAt: '2026-05-30T00:00:00.000Z',
+                patch: {
+                    set: [
+                        { key: 'state', valueType: 'select', value: 'todo' },
+                        { key: ' State ', valueType: 'select', value: 'done' },
+                    ],
+                },
+            }),
+        (error: unknown) =>
+            error instanceof InvalidNotePropertyInputError &&
+            error.message === 'Property patch contains duplicate keys.',
+    );
+
+    await assert.rejects(
+        () =>
+            updateNotePropertiesWithVersionGuard({
+                id: 1,
+                expectedUpdatedAt: '2026-05-30T00:00:00.000Z',
+                patch: {
+                    set: [{ key: 'state', valueType: 'select', value: 'todo' }],
+                    deleteKeys: [' State '],
+                },
+            }),
+        (error: unknown) =>
+            error instanceof InvalidNotePropertyInputError &&
+            error.message === 'Property patch cannot set and delete the same key.',
+    );
+});
+
+test('note property updates require the existing note version unless forced', async () => {
+    await assert.rejects(
+        () =>
+            updateNotePropertiesWithVersionGuard({
+                id: 1,
+                patch: {
+                    set: [{ key: 'state', valueType: 'select', value: 'todo' }],
+                },
+            }),
+        (error: unknown) => error instanceof MissingNoteVersionError,
+    );
+});

--- a/packages/server/src/features/note/services/properties.ts
+++ b/packages/server/src/features/note/services/properties.ts
@@ -1,0 +1,670 @@
+import models, { type Note, Prisma, type PropertyValueType } from '~/models.js';
+import { captureNoteBaseline } from './snapshot.js';
+import { createNoteVersionConflictError, MissingNoteVersionError, parseNoteVersion } from './write-conflict.js';
+
+export interface SerializedNotePropertyOption {
+    id: string;
+    label: string;
+    value: string;
+    color?: string | null;
+    order: number;
+}
+
+export interface SerializedNoteProperty {
+    key: string;
+    name: string;
+    value: string;
+    valueType: PropertyValueType;
+    option?: SerializedNotePropertyOption | null;
+    createdAt: string;
+    updatedAt: string;
+}
+
+export interface SerializedNotePropertyKey {
+    key: string;
+    name: string;
+    valueType: PropertyValueType;
+    noteCount: number;
+    options: SerializedNotePropertyOption[];
+    updatedAt: string;
+}
+
+export interface SerializedNotePropertyKeysResult {
+    totalCount: number;
+    keys: SerializedNotePropertyKey[];
+}
+
+export interface SerializedNotePropertyDeleteResult {
+    key: string;
+    name: string;
+    valueType: PropertyValueType;
+    affectedNoteCount: number;
+    deleted: boolean;
+}
+
+export interface NotePropertySetInput {
+    key: string;
+    name?: string | null;
+    value: string;
+    valueType: PropertyValueType;
+}
+
+export interface NotePropertiesPatchInput {
+    set?: NotePropertySetInput[] | null;
+    deleteKeys?: string[] | null;
+}
+
+export interface NotePropertyOptionInput {
+    label: string;
+    value?: string | null;
+    color?: string | null;
+    order?: number | null;
+}
+
+export interface NotePropertyDefinitionInput {
+    key: string;
+    name?: string | null;
+    valueType: PropertyValueType;
+    options?: NotePropertyOptionInput[] | null;
+}
+
+type NotePropertyWithDefinition = Prisma.NotePropertyGetPayload<{
+    include: { definition: true; option: true };
+}>;
+
+type PropertyDefinitionWithOptions = Prisma.PropertyDefinitionGetPayload<{
+    include: { options: true; _count: { select: { properties: true } } };
+}>;
+
+const PROPERTY_KEY_MAX_LENGTH = 80;
+const PROPERTY_NAME_MAX_LENGTH = 120;
+const PROPERTY_TEXT_VALUE_MAX_LENGTH = 2000;
+const PROPERTY_OPTION_LABEL_MAX_LENGTH = 80;
+const PROPERTY_OPTION_VALUE_MAX_LENGTH = 80;
+const PROPERTY_OPTION_LIMIT = 50;
+const PROPERTY_PATCH_SET_LIMIT = 50;
+const PROPERTY_PATCH_DELETE_LIMIT = 50;
+
+export class InvalidNotePropertyInputError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'InvalidNotePropertyInputError';
+    }
+}
+
+export class NotePropertyDeleteConfirmationRequiredError extends Error {
+    code = 'NOTE_PROPERTY_DELETE_CONFIRMATION_REQUIRED' as const;
+    affectedNoteCount: number;
+
+    constructor(key: string, affectedNoteCount: number) {
+        super(`Property ${key} is used by ${affectedNoteCount} note(s). Confirm deletion to remove those values.`);
+        this.name = 'NotePropertyDeleteConfirmationRequiredError';
+        this.affectedNoteCount = affectedNoteCount;
+    }
+}
+
+const isRecordNotFoundError = (error: unknown) => {
+    return error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025';
+};
+
+export const normalizePropertyKey = (value: string) => {
+    const normalized = value.trim().toLowerCase().replace(/\s+/g, '-');
+
+    if (!normalized) {
+        throw new InvalidNotePropertyInputError('Property key is required.');
+    }
+
+    if (normalized.length > PROPERTY_KEY_MAX_LENGTH) {
+        throw new InvalidNotePropertyInputError(`Property key must be ${PROPERTY_KEY_MAX_LENGTH} characters or fewer.`);
+    }
+
+    if (!/^[a-z0-9][a-z0-9_-]*$/.test(normalized)) {
+        throw new InvalidNotePropertyInputError('Property key must use letters, numbers, dashes, or underscores.');
+    }
+
+    return normalized;
+};
+
+const normalizePropertyName = (value: string | null | undefined, key: string) => {
+    const normalized = value?.trim() || key;
+
+    if (normalized.length > PROPERTY_NAME_MAX_LENGTH) {
+        throw new InvalidNotePropertyInputError(
+            `Property name must be ${PROPERTY_NAME_MAX_LENGTH} characters or fewer.`,
+        );
+    }
+
+    return normalized;
+};
+
+const normalizeOptionValue = (value: string) => {
+    const normalized = value.trim().toLowerCase().replace(/\s+/g, '-');
+
+    if (!normalized) {
+        throw new InvalidNotePropertyInputError('Property option value is required.');
+    }
+
+    if (normalized.length > PROPERTY_OPTION_VALUE_MAX_LENGTH) {
+        throw new InvalidNotePropertyInputError(
+            `Property option value must be ${PROPERTY_OPTION_VALUE_MAX_LENGTH} characters or fewer.`,
+        );
+    }
+
+    if (!/^[a-z0-9][a-z0-9_-]*$/.test(normalized)) {
+        throw new InvalidNotePropertyInputError(
+            'Property option value must use letters, numbers, dashes, or underscores.',
+        );
+    }
+
+    return normalized;
+};
+
+const normalizeOptionLabel = (value: string) => {
+    const normalized = value.trim();
+
+    if (!normalized) {
+        throw new InvalidNotePropertyInputError('Property option label is required.');
+    }
+
+    if (normalized.length > PROPERTY_OPTION_LABEL_MAX_LENGTH) {
+        throw new InvalidNotePropertyInputError(
+            `Property option label must be ${PROPERTY_OPTION_LABEL_MAX_LENGTH} characters or fewer.`,
+        );
+    }
+
+    return normalized;
+};
+
+const normalizePropertyOptions = (options: NotePropertyOptionInput[] | null | undefined) => {
+    const normalizedOptions = options ?? [];
+
+    if (normalizedOptions.length > PROPERTY_OPTION_LIMIT) {
+        throw new InvalidNotePropertyInputError(`Select properties can have up to ${PROPERTY_OPTION_LIMIT} options.`);
+    }
+
+    const seenValues = new Set<string>();
+
+    return normalizedOptions.map((option, index) => {
+        const label = normalizeOptionLabel(option.label);
+        const value = normalizeOptionValue(option.value ?? label);
+
+        if (seenValues.has(value)) {
+            throw new InvalidNotePropertyInputError('Property options contain duplicate values.');
+        }
+
+        seenValues.add(value);
+
+        return {
+            label,
+            value,
+            color: option.color?.trim() || null,
+            order: Number.isFinite(Number(option.order)) ? Number(option.order) : index,
+        };
+    });
+};
+
+const normalizeTextValue = (value: string) => {
+    if (value.length > PROPERTY_TEXT_VALUE_MAX_LENGTH) {
+        throw new InvalidNotePropertyInputError(
+            `Property text value must be ${PROPERTY_TEXT_VALUE_MAX_LENGTH} characters or fewer.`,
+        );
+    }
+
+    return value;
+};
+
+const normalizeDateValue = (value: string) => {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+        throw new InvalidNotePropertyInputError('Date property values must use YYYY-MM-DD.');
+    }
+
+    const date = new Date(`${value}T00:00:00.000Z`);
+
+    if (Number.isNaN(date.getTime()) || date.toISOString().slice(0, 10) !== value) {
+        throw new InvalidNotePropertyInputError('Date property value is invalid.');
+    }
+
+    return date;
+};
+
+const normalizeBooleanValue = (value: string) => {
+    if (value === 'true') {
+        return true;
+    }
+
+    if (value === 'false') {
+        return false;
+    }
+
+    throw new InvalidNotePropertyInputError('Boolean property values must be true or false.');
+};
+
+const normalizeNumberValue = (value: string) => {
+    const numberValue = Number(value);
+
+    if (!Number.isFinite(numberValue)) {
+        throw new InvalidNotePropertyInputError('Number property value must be finite.');
+    }
+
+    return numberValue;
+};
+
+const serializeOption = (option: NonNullable<NotePropertyWithDefinition['option']>): SerializedNotePropertyOption => ({
+    id: String(option.id),
+    label: option.label,
+    value: option.value,
+    color: option.color,
+    order: option.order,
+});
+
+const serializeDefinitionOption = (
+    option: PropertyDefinitionWithOptions['options'][number],
+): SerializedNotePropertyOption => ({
+    id: String(option.id),
+    label: option.label,
+    value: option.value,
+    color: option.color,
+    order: option.order,
+});
+
+const serializePropertyValue = (property: NotePropertyWithDefinition) => {
+    switch (property.definition.valueType) {
+        case 'number':
+            return property.numberValue === null ? '' : String(property.numberValue);
+        case 'date':
+            return property.dateValue ? property.dateValue.toISOString().slice(0, 10) : '';
+        case 'boolean':
+            return property.boolValue === null ? '' : String(property.boolValue);
+        case 'select':
+            return property.option?.value ?? '';
+        case 'text':
+        default:
+            return property.textValue ?? '';
+    }
+};
+
+export const serializeNoteProperty = (property: NotePropertyWithDefinition): SerializedNoteProperty => ({
+    key: property.definition.key,
+    name: property.definition.name,
+    value: serializePropertyValue(property),
+    valueType: property.definition.valueType,
+    option: property.option ? serializeOption(property.option) : null,
+    createdAt: property.createdAt.toISOString(),
+    updatedAt: property.updatedAt.toISOString(),
+});
+
+export const serializeNoteProperties = (properties: NotePropertyWithDefinition[]) => {
+    return properties.map(serializeNoteProperty).sort((left, right) => left.key.localeCompare(right.key));
+};
+
+const serializePropertyDefinition = (definition: PropertyDefinitionWithOptions): SerializedNotePropertyKey => ({
+    key: definition.key,
+    name: definition.name,
+    valueType: definition.valueType,
+    noteCount: definition._count.properties,
+    options: definition.options.sort((left, right) => left.order - right.order).map(serializeDefinitionOption),
+    updatedAt: definition.updatedAt.toISOString(),
+});
+
+const buildTypedValueData = async (
+    input: NotePropertySetInput,
+    definitionId: number,
+    tx: Pick<typeof models, 'propertyOption'> = models,
+) => {
+    const resetValues = {
+        textValue: null,
+        textValueNormalized: null,
+        numberValue: null,
+        dateValue: null,
+        boolValue: null,
+        optionId: null,
+    };
+
+    switch (input.valueType) {
+        case 'number': {
+            const numberValue = normalizeNumberValue(input.value);
+            return { ...resetValues, numberValue };
+        }
+        case 'date': {
+            const dateValue = normalizeDateValue(input.value);
+            return { ...resetValues, dateValue };
+        }
+        case 'boolean': {
+            const boolValue = normalizeBooleanValue(input.value);
+            return { ...resetValues, boolValue };
+        }
+        case 'select': {
+            const optionValue = normalizeOptionValue(input.value);
+            const option = await tx.propertyOption.findUnique({
+                where: {
+                    propertyDefinitionId_value: {
+                        propertyDefinitionId: definitionId,
+                        value: optionValue,
+                    },
+                },
+            });
+
+            if (!option) {
+                throw new InvalidNotePropertyInputError(`Property option ${optionValue} is not defined.`);
+            }
+
+            return { ...resetValues, optionId: option.id };
+        }
+        case 'text': {
+            const textValue = normalizeTextValue(input.value);
+            return { ...resetValues, textValue, textValueNormalized: textValue.toLowerCase() };
+        }
+        default:
+            throw new InvalidNotePropertyInputError('Unsupported property value type.');
+    }
+};
+
+const normalizePatch = (patch: NotePropertiesPatchInput) => {
+    const set = patch.set ?? [];
+    const deleteKeys = patch.deleteKeys ?? [];
+
+    if (set.length === 0 && deleteKeys.length === 0) {
+        throw new InvalidNotePropertyInputError('At least one property change is required.');
+    }
+
+    if (set.length > PROPERTY_PATCH_SET_LIMIT || deleteKeys.length > PROPERTY_PATCH_DELETE_LIMIT) {
+        throw new InvalidNotePropertyInputError('Too many property changes in one request.');
+    }
+
+    const normalizedSet = set.map((item) => {
+        const key = normalizePropertyKey(item.key);
+        return {
+            ...item,
+            key,
+            name: normalizePropertyName(item.name, key),
+        };
+    });
+    const normalizedDeleteKeys = deleteKeys.map(normalizePropertyKey);
+    const seenSetKeys = new Set<string>();
+    const seenDeleteKeys = new Set<string>();
+
+    for (const item of normalizedSet) {
+        if (seenSetKeys.has(item.key)) {
+            throw new InvalidNotePropertyInputError('Property patch contains duplicate keys.');
+        }
+
+        seenSetKeys.add(item.key);
+    }
+
+    for (const key of normalizedDeleteKeys) {
+        if (seenDeleteKeys.has(key)) {
+            throw new InvalidNotePropertyInputError('Property patch contains duplicate delete keys.');
+        }
+
+        if (seenSetKeys.has(key)) {
+            throw new InvalidNotePropertyInputError('Property patch cannot set and delete the same key.');
+        }
+
+        seenDeleteKeys.add(key);
+    }
+
+    return { set: normalizedSet, deleteKeys: normalizedDeleteKeys };
+};
+
+export const listNoteProperties = async (noteId: number) => {
+    const properties = await models.noteProperty.findMany({
+        where: { noteId },
+        include: { definition: true, option: true },
+        orderBy: [{ definition: { key: 'asc' } }],
+    });
+
+    return serializeNoteProperties(properties);
+};
+
+export const listNotePropertyKeys = async (input?: { query?: string; limit?: number; offset?: number }) => {
+    const normalizedQuery = input?.query?.trim();
+    const where = normalizedQuery
+        ? {
+              OR: [{ key: { contains: normalizedQuery } }, { name: { contains: normalizedQuery } }],
+          }
+        : undefined;
+    const take = Math.max(1, Math.min(100, Number(input?.limit ?? 50)));
+    const skip = Math.max(0, Number(input?.offset ?? 0));
+    const [definitions, totalCount] = await Promise.all([
+        models.propertyDefinition.findMany({
+            where,
+            orderBy: { key: 'asc' },
+            take,
+            skip,
+            include: { options: { orderBy: { order: 'asc' } }, _count: { select: { properties: true } } },
+        }),
+        models.propertyDefinition.count({ where }),
+    ]);
+
+    return {
+        totalCount,
+        keys: definitions.map(serializePropertyDefinition),
+    } satisfies SerializedNotePropertyKeysResult;
+};
+
+export const createNotePropertyDefinition = async (input: NotePropertyDefinitionInput) => {
+    const key = normalizePropertyKey(input.key);
+    const name = normalizePropertyName(input.name, key);
+    const options = normalizePropertyOptions(input.options);
+
+    if (input.valueType !== 'select' && options.length > 0) {
+        throw new InvalidNotePropertyInputError('Only select properties can have options.');
+    }
+
+    if (input.valueType === 'select' && options.length === 0) {
+        throw new InvalidNotePropertyInputError('Select properties require at least one option.');
+    }
+
+    try {
+        const definition = await models.propertyDefinition.create({
+            data: {
+                key,
+                name,
+                valueType: input.valueType,
+                ...(input.valueType === 'select'
+                    ? {
+                          options: {
+                              create: options,
+                          },
+                      }
+                    : {}),
+            },
+            include: { options: { orderBy: { order: 'asc' } }, _count: { select: { properties: true } } },
+        });
+
+        return serializePropertyDefinition(definition);
+    } catch (error) {
+        if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+            throw new InvalidNotePropertyInputError(`Property ${key} already exists.`);
+        }
+
+        throw error;
+    }
+};
+
+export const deleteNotePropertyDefinition = async ({
+    key,
+    confirmImpact = false,
+}: {
+    key: string;
+    confirmImpact?: boolean;
+}): Promise<SerializedNotePropertyDeleteResult | null> => {
+    const normalizedKey = normalizePropertyKey(key);
+
+    return models.$transaction(async (tx) => {
+        const definition = await tx.propertyDefinition.findUnique({
+            where: { key: normalizedKey },
+            include: { _count: { select: { properties: true } } },
+        });
+
+        if (!definition) {
+            return null;
+        }
+
+        const affectedNoteCount = definition._count.properties;
+
+        if (affectedNoteCount > 0 && !confirmImpact) {
+            throw new NotePropertyDeleteConfirmationRequiredError(normalizedKey, affectedNoteCount);
+        }
+
+        if (affectedNoteCount > 0) {
+            await tx.note.updateMany({
+                where: {
+                    properties: {
+                        some: {
+                            propertyDefinitionId: definition.id,
+                        },
+                    },
+                },
+                data: {
+                    updatedAt: new Date(),
+                },
+            });
+        }
+
+        await tx.propertyDefinition.delete({
+            where: { id: definition.id },
+        });
+
+        return {
+            key: definition.key,
+            name: definition.name,
+            valueType: definition.valueType,
+            affectedNoteCount,
+            deleted: true,
+        };
+    });
+};
+
+export const updateNotePropertiesWithVersionGuard = async ({
+    id,
+    patch,
+    editSessionId,
+    expectedUpdatedAt,
+    force = false,
+}: {
+    id: number;
+    patch: NotePropertiesPatchInput;
+    editSessionId?: string;
+    expectedUpdatedAt?: string;
+    force?: boolean;
+}): Promise<Note | null> => {
+    const normalizedPatch = normalizePatch(patch);
+    const expectedTimestamp = parseNoteVersion(expectedUpdatedAt);
+
+    if (expectedTimestamp === null && !force) {
+        throw new MissingNoteVersionError();
+    }
+
+    try {
+        const result = await models.$transaction(async (tx) => {
+            const existingNote = await tx.note.findUnique({
+                where: { id },
+                include: { properties: { include: { definition: true, option: true } } },
+            });
+
+            if (!existingNote) {
+                return null;
+            }
+
+            if (!force && existingNote.updatedAt.getTime() !== expectedTimestamp) {
+                throw createNoteVersionConflictError({
+                    currentUpdatedAt: existingNote.updatedAt.getTime(),
+                    expectedUpdatedAt: expectedTimestamp ?? existingNote.updatedAt.getTime(),
+                });
+            }
+
+            const baseline = {
+                ...existingNote,
+                properties: existingNote.properties.map((property) => ({
+                    key: property.definition.key,
+                    name: property.definition.name,
+                    valueType: property.definition.valueType,
+                    textValue: property.textValue,
+                    textValueNormalized: property.textValueNormalized,
+                    numberValue: property.numberValue,
+                    dateValue: property.dateValue,
+                    boolValue: property.boolValue,
+                    optionValue: property.option?.value ?? null,
+                    optionLabel: property.option?.label ?? null,
+                    optionColor: property.option?.color ?? null,
+                })),
+            };
+
+            for (const item of normalizedPatch.set) {
+                const definition = await tx.propertyDefinition.findUnique({ where: { key: item.key } });
+
+                if (!definition) {
+                    throw new InvalidNotePropertyInputError(
+                        `Property ${item.key} is not defined. Create it in property settings first.`,
+                    );
+                }
+
+                if (definition.valueType !== item.valueType) {
+                    throw new InvalidNotePropertyInputError(
+                        `Property ${item.key} already uses ${definition.valueType} values.`,
+                    );
+                }
+
+                const valueData = await buildTypedValueData(item, definition.id, tx);
+
+                await tx.noteProperty.upsert({
+                    where: {
+                        noteId_propertyDefinitionId: {
+                            noteId: id,
+                            propertyDefinitionId: definition.id,
+                        },
+                    },
+                    create: {
+                        noteId: id,
+                        propertyDefinitionId: definition.id,
+                        ...valueData,
+                    },
+                    update: valueData,
+                });
+            }
+
+            if (normalizedPatch.deleteKeys.length > 0) {
+                const definitions = await tx.propertyDefinition.findMany({
+                    where: { key: { in: normalizedPatch.deleteKeys } },
+                    select: { id: true },
+                });
+
+                if (definitions.length > 0) {
+                    await tx.noteProperty.deleteMany({
+                        where: {
+                            noteId: id,
+                            propertyDefinitionId: { in: definitions.map((definition) => definition.id) },
+                        },
+                    });
+                }
+            }
+
+            const updatedNote = await tx.note.update({
+                where: { id },
+                data: { updatedAt: new Date() },
+            });
+
+            return { updatedNote, baseline };
+        });
+
+        if (!result) {
+            return null;
+        }
+
+        await captureNoteBaseline({
+            noteId: id,
+            baseline: result.baseline,
+            ...(editSessionId && !force ? { editSessionId } : {}),
+            ...(force ? { force: true } : {}),
+        });
+
+        return result.updatedNote;
+    } catch (error) {
+        if (isRecordNotFoundError(error)) {
+            return null;
+        }
+
+        throw error;
+    }
+};

--- a/packages/server/src/features/note/services/snapshot.ts
+++ b/packages/server/src/features/note/services/snapshot.ts
@@ -1,5 +1,5 @@
 import { ensureTagByName } from '~/features/tag/services/organization.js';
-import models, { type NoteLayout } from '~/models.js';
+import models, { type NoteLayout, type PropertyValueType } from '~/models.js';
 import { blocksToMarkdown, extractTagIdsFromContentJson } from '~/modules/blocknote.js';
 import { type BlockNoteTreeNode, parseBlockNoteContent, walkBlockNoteTree } from '~/modules/blocknote-tree.js';
 import {
@@ -20,6 +20,21 @@ interface NoteRecord {
     order: number;
     layout: NoteLayout;
     updatedAt?: Date;
+    properties?: SnapshotNoteProperty[];
+}
+
+interface SnapshotNoteProperty {
+    key: string;
+    name: string;
+    valueType: PropertyValueType;
+    textValue?: string | null;
+    textValueNormalized?: string | null;
+    numberValue?: number | null;
+    dateValue?: Date | string | null;
+    boolValue?: boolean | null;
+    optionValue?: string | null;
+    optionLabel?: string | null;
+    optionColor?: string | null;
 }
 
 interface NoteSnapshotRecord {
@@ -57,6 +72,7 @@ interface NoteSnapshotDeps {
             order: number;
             layout: NoteLayout;
             tagIds?: number[];
+            properties?: SnapshotNoteProperty[];
         },
     ) => Promise<NoteRecord>;
 }
@@ -72,6 +88,7 @@ interface NoteSnapshotPayload {
     pinned: boolean;
     order: number;
     layout: NoteLayout;
+    properties?: SnapshotNoteProperty[];
 }
 
 interface TagRecord {
@@ -149,6 +166,14 @@ const serializePayload = (note: NoteRecord): string => {
         pinned: note.pinned,
         order: note.order,
         layout: note.layout,
+        ...(note.properties
+            ? {
+                  properties: note.properties.map((property) => ({
+                      ...property,
+                      ...(property.dateValue instanceof Date ? { dateValue: property.dateValue.toISOString() } : {}),
+                  })),
+              }
+            : {}),
     };
 
     return JSON.stringify(payload);
@@ -470,7 +495,35 @@ export const createNoteSnapshotService = (deps: NoteSnapshotDeps) => ({
 
 export const defaultNoteSnapshotService = createNoteSnapshotService({
     findNoteById: async (id) => {
-        return models.note.findUnique({ where: { id } });
+        const note = await models.note.findUnique({
+            where: { id },
+            include: {
+                properties: {
+                    include: { definition: true, option: true },
+                },
+            },
+        });
+
+        if (!note) {
+            return null;
+        }
+
+        return {
+            ...note,
+            properties: note.properties.map((property) => ({
+                key: property.definition.key,
+                name: property.definition.name,
+                valueType: property.definition.valueType,
+                textValue: property.textValue,
+                textValueNormalized: property.textValueNormalized,
+                numberValue: property.numberValue,
+                dateValue: property.dateValue,
+                boolValue: property.boolValue,
+                optionValue: property.option?.value ?? null,
+                optionLabel: property.option?.label ?? null,
+                optionColor: property.option?.color ?? null,
+            })),
+        };
     },
     findSnapshotByEditSessionId: async (noteId, editSessionId) => {
         return models.noteSnapshot.findFirst({
@@ -530,18 +583,76 @@ export const defaultNoteSnapshotService = createNoteSnapshotService({
         return models.noteSnapshot.findUnique({ where: { id } });
     },
     updateNote: async (id, input) => {
-        const { tagIds, ...noteInput } = input;
+        const { tagIds, properties, ...noteInput } = input;
 
-        return models.note.update({
-            where: { id },
-            data: {
-                ...noteInput,
-                ...buildNoteSearchProjection({
-                    title: noteInput.title,
-                    content: noteInput.content,
-                }),
-                ...(tagIds !== undefined ? { tags: { set: tagIds.map((tagId) => ({ id: tagId })) } } : {}),
-            },
+        return models.$transaction(async (tx) => {
+            const note = await tx.note.update({
+                where: { id },
+                data: {
+                    ...noteInput,
+                    ...buildNoteSearchProjection({
+                        title: noteInput.title,
+                        content: noteInput.content,
+                    }),
+                    ...(tagIds !== undefined ? { tags: { set: tagIds.map((tagId) => ({ id: tagId })) } } : {}),
+                },
+            });
+
+            if (properties !== undefined) {
+                await tx.noteProperty.deleteMany({ where: { noteId: id } });
+
+                for (const property of properties) {
+                    const definition = await tx.propertyDefinition.upsert({
+                        where: { key: property.key },
+                        create: {
+                            key: property.key,
+                            name: property.name,
+                            valueType: property.valueType,
+                        },
+                        update: {
+                            name: property.name,
+                            valueType: property.valueType,
+                        },
+                    });
+
+                    const option =
+                        property.valueType === 'select' && property.optionValue
+                            ? await tx.propertyOption.upsert({
+                                  where: {
+                                      propertyDefinitionId_value: {
+                                          propertyDefinitionId: definition.id,
+                                          value: property.optionValue,
+                                      },
+                                  },
+                                  create: {
+                                      propertyDefinitionId: definition.id,
+                                      value: property.optionValue,
+                                      label: property.optionLabel ?? property.optionValue,
+                                      color: property.optionColor ?? null,
+                                  },
+                                  update: {
+                                      label: property.optionLabel ?? property.optionValue,
+                                      color: property.optionColor ?? null,
+                                  },
+                              })
+                            : null;
+
+                    await tx.noteProperty.create({
+                        data: {
+                            noteId: id,
+                            propertyDefinitionId: definition.id,
+                            optionId: option?.id ?? null,
+                            textValue: property.textValue ?? null,
+                            textValueNormalized: property.textValueNormalized ?? null,
+                            numberValue: property.numberValue ?? null,
+                            dateValue: property.dateValue ? new Date(property.dateValue) : null,
+                            boolValue: property.boolValue ?? null,
+                        },
+                    });
+                }
+            }
+
+            return note;
         });
     },
 });

--- a/packages/server/src/features/note/services/trash.test.ts
+++ b/packages/server/src/features/note/services/trash.test.ts
@@ -53,6 +53,7 @@ test('note trash service moves a live note to trash and returns a summary', asyn
                 deletedAt: new Date('2026-03-31T01:00:00.000Z'),
                 tags: note.tags.map((tag) => ({ name: tag.name })),
                 reminders: [],
+                properties: [],
             };
         },
         purgeDeletedNote: async () => {

--- a/packages/server/src/features/note/services/trash.ts
+++ b/packages/server/src/features/note/services/trash.ts
@@ -1,4 +1,4 @@
-import models, { type NoteLayout, type ReminderPriority } from '~/models.js';
+import models, { type NoteLayout, type PropertyValueType, type ReminderPriority } from '~/models.js';
 import {
     createRetentionCutoff,
     RECOVERY_CLEANUP_BATCH_LIMIT,
@@ -34,6 +34,24 @@ interface LiveNoteRecord {
     layout: NoteLayout;
     tags: LiveTagRecord[];
     reminders: LiveReminderRecord[];
+    properties?: LivePropertyRecord[];
+}
+
+interface LivePropertyRecord {
+    id: number;
+    textValue: string | null;
+    textValueNormalized: string | null;
+    numberValue: number | null;
+    dateValue: Date | null;
+    boolValue: boolean | null;
+    option: { value: string; label: string; color: string | null } | null;
+    createdAt: Date;
+    updatedAt: Date;
+    definition: {
+        key: string;
+        name: string;
+        valueType: PropertyValueType;
+    };
 }
 
 interface RestoredNoteRecord {
@@ -73,6 +91,23 @@ interface DeletedNoteRecord {
     layout: NoteLayout;
     tags: DeletedTagRecord[];
     reminders: DeletedReminderRecord[];
+    properties?: DeletedPropertyRecord[];
+}
+
+interface DeletedPropertyRecord {
+    key: string;
+    name: string;
+    valueType: PropertyValueType;
+    textValue: string | null;
+    textValueNormalized: string | null;
+    numberValue: number | null;
+    dateValue: Date | null;
+    boolValue: boolean | null;
+    optionValue: string | null;
+    optionLabel: string | null;
+    optionColor: string | null;
+    createdAt: Date;
+    updatedAt: Date;
 }
 
 interface BlockNoteNode {
@@ -262,6 +297,7 @@ export const createNoteTrashService = (deps: NoteTrashServiceDeps) => ({
 const includeDeletedNote = {
     reminders: { orderBy: { reminderDate: 'asc' as const } },
     tags: { orderBy: { name: 'asc' as const } },
+    properties: { orderBy: { key: 'asc' as const } },
 };
 
 const defaultPurgeExpiredDeletedNotes = async (before: Date, limit: number) => {
@@ -295,6 +331,10 @@ const noteTrashService = createNoteTrashService({
             include: {
                 reminders: { orderBy: { reminderDate: 'asc' } },
                 tags: { orderBy: { name: 'asc' } },
+                properties: {
+                    orderBy: { definition: { key: 'asc' } },
+                    include: { definition: true, option: true },
+                },
             },
         });
     },
@@ -339,6 +379,23 @@ const noteTrashService = createNoteTrashService({
                             content: reminder.content,
                             createdAt: reminder.createdAt,
                             updatedAt: reminder.updatedAt,
+                        })),
+                    },
+                    properties: {
+                        create: (note.properties ?? []).map((property) => ({
+                            key: property.definition.key,
+                            name: property.definition.name,
+                            valueType: property.definition.valueType,
+                            textValue: property.textValue,
+                            textValueNormalized: property.textValueNormalized,
+                            numberValue: property.numberValue,
+                            dateValue: property.dateValue,
+                            boolValue: property.boolValue,
+                            optionValue: property.option?.value ?? null,
+                            optionLabel: property.option?.label ?? null,
+                            optionColor: property.option?.color ?? null,
+                            createdAt: property.createdAt,
+                            updatedAt: property.updatedAt,
                         })),
                     },
                 },
@@ -430,6 +487,58 @@ const noteTrashService = createNoteTrashService({
                         : {}),
                 },
             });
+
+            for (const property of deletedNote.properties ?? []) {
+                const definition = await tx.propertyDefinition.upsert({
+                    where: { key: property.key },
+                    create: {
+                        key: property.key,
+                        name: property.name,
+                        valueType: property.valueType,
+                    },
+                    update: {
+                        name: property.name,
+                        valueType: property.valueType,
+                    },
+                });
+
+                const option =
+                    property.valueType === 'select' && property.optionValue
+                        ? await tx.propertyOption.upsert({
+                              where: {
+                                  propertyDefinitionId_value: {
+                                      propertyDefinitionId: definition.id,
+                                      value: property.optionValue,
+                                  },
+                              },
+                              create: {
+                                  propertyDefinitionId: definition.id,
+                                  value: property.optionValue,
+                                  label: property.optionLabel ?? property.optionValue,
+                                  color: property.optionColor,
+                              },
+                              update: {
+                                  label: property.optionLabel ?? property.optionValue,
+                                  color: property.optionColor,
+                              },
+                          })
+                        : null;
+
+                await tx.noteProperty.create({
+                    data: {
+                        noteId: note.id,
+                        propertyDefinitionId: definition.id,
+                        optionId: option?.id ?? null,
+                        textValue: property.textValue,
+                        textValueNormalized: property.textValueNormalized,
+                        numberValue: property.numberValue,
+                        dateValue: property.dateValue,
+                        boolValue: property.boolValue,
+                        createdAt: property.createdAt,
+                        updatedAt: property.updatedAt,
+                    },
+                });
+            }
 
             await tx.deletedNote.delete({ where: { id: deletedNote.id } });
 


### PR DESCRIPTION
## :dart: Goal
- Add schema-first note properties so notes can attach shared typed metadata before View Query work.
- Keep the Phase 2 scope focused on the smallest useful property foundation without adding query views yet.

## :hammer_and_wrench: Core Changes
- Added Prisma schema/migration for property definitions, select options, note properties, and deleted-note property preservation.
- Added GraphQL read/write APIs for property definitions and note property values.
- Added Settings > Properties and note-level property editing with autosave.
- Updated note snapshots, trash/restore, MCP read output, and shared auxiliary panel UI.
- Added server unit coverage for property key normalization, select option validation, patch conflict validation, and note version guard behavior.
- Aligned note save indicator with status-based spinning instead of fake progress.

## :brain: Key Decisions
- Properties are schema-first shared fields, not arbitrary per-note key/value rows.
- Select values come from managed option datasets.
- Property deletion is explicit and requires confirmation when notes are affected.
- Property changes use the existing note version guard and snapshot baseline flow.
- Local plan docs were kept out of the PR; behavior is captured in code and PR notes.

## :test_tube: Verification Guide
### How to verify
1. Run `pnpm check:encoding`.
2. Run `pnpm lint`.
3. Run `pnpm type-check`.
4. Run `pnpm test:ci`.
5. Run `pnpm build`.
6. Locally start with `OCEAN_BRAIN_ALLOW_INSECURE_NO_AUTH=true pnpm dev`, open `/setting/properties`, create a shared property, attach it from a note, edit/delete it, and verify autosave/status UI.

### Expected result
- All commands complete successfully.
- Shared properties can be created in settings, attached to notes, autosaved, listed, and deleted with impact confirmation.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)
