### PR TITLE
✨ Add saved view filters

### DIFF
--- a/packages/client/src/apis/view.api.ts
+++ b/packages/client/src/apis/view.api.ts
@@ -1,13 +1,44 @@
 import type { Note } from '~/models/note.model';
-import type { ViewSection, ViewsWorkspace } from '~/models/view.model';
+import type {
+    ViewDisplayType,
+    ViewPropertyFilter,
+    ViewSection,
+    ViewSortBy,
+    ViewSortOrder,
+    ViewsWorkspace,
+} from '~/models/view.model';
 import { graphQuery } from '~/modules/graph-query';
 
 export interface ViewSectionInput {
     title?: string;
-    tagNames: string[];
+    displayType?: ViewDisplayType;
+    tagNames?: string[];
     mode?: 'and' | 'or';
+    propertyFilters?: Array<Pick<ViewPropertyFilter, 'key' | 'valueType' | 'operator' | 'value'>>;
+    sortBy?: ViewSortBy;
+    sortOrder?: ViewSortOrder;
     limit?: number;
 }
+
+const VIEW_SECTION_FIELDS = `
+    id
+    tabId
+    title
+    displayType
+    tagNames
+    mode
+    propertyFilters {
+        key
+        name
+        valueType
+        operator
+        value
+    }
+    sortBy
+    sortOrder
+    limit
+    order
+`;
 
 export function fetchViewWorkspace() {
     return graphQuery<{
@@ -20,13 +51,7 @@ export function fetchViewWorkspace() {
                 title
                 order
                 sections {
-                    id
-                    tabId
-                    title
-                    tagNames
-                    mode
-                    limit
-                    order
+                    ${VIEW_SECTION_FIELDS}
                 }
             }
         }
@@ -42,13 +67,7 @@ export function fetchViewSection(id: string) {
     >(
         `query FetchViewSection($id: ID!) {
             viewSection(id: $id) {
-                id
-                tabId
-                title
-                tagNames
-                mode
-                limit
-                order
+                ${VIEW_SECTION_FIELDS}
             }
         }`,
         { id },
@@ -81,6 +100,15 @@ export function fetchViewSectionNotes(
                     }
                     createdAt
                     updatedAt
+                    properties {
+                        key
+                        name
+                        value
+                        valueType
+                        option { id label value color order }
+                        createdAt
+                        updatedAt
+                    }
                 }
             }
         }`,
@@ -159,13 +187,7 @@ export function setActiveViewTab(id: string) {
                     title
                     order
                     sections {
-                        id
-                        tabId
-                        title
-                        tagNames
-                        mode
-                        limit
-                        order
+                        ${VIEW_SECTION_FIELDS}
                     }
                 }
             }

--- a/packages/client/src/components/view/ViewSectionCard.tsx
+++ b/packages/client/src/components/view/ViewSectionCard.tsx
@@ -8,7 +8,7 @@ import type { ViewSection } from '~/models/view.model';
 import { queryKeys } from '~/modules/query-key-factory';
 import { timeSince } from '~/modules/time';
 import { NOTE_ROUTE, VIEW_NOTES_ROUTE } from '~/modules/url';
-import { buildViewNotesSearch, getViewTagMatchToken } from '~/modules/view-dashboard';
+import { buildViewNotesSearch, formatViewPropertyFilter, getViewTagMatchToken } from '~/modules/view-dashboard';
 
 interface ViewSectionCardProps {
     section: ViewSection;
@@ -42,6 +42,7 @@ export default function ViewSectionCard({ section, onEdit, onDelete, dragHandle 
     const notes = data?.notes ?? [];
     const totalCount = data?.totalCount ?? 0;
     const tagMatchToken = getViewTagMatchToken(section.mode);
+    const hasFilters = section.tagNames.length > 0 || section.propertyFilters.length > 0;
 
     return (
         <SurfaceCard className="flex h-full flex-col gap-4">
@@ -74,6 +75,19 @@ export default function ViewSectionCard({ section, onEdit, onDelete, dragHandle 
                                 </span>
                             </div>
                         ))}
+                        {section.propertyFilters.map((filter) => (
+                            <span
+                                key={`${filter.key}-${filter.operator}-${filter.value ?? ''}`}
+                                className="inline-flex items-center rounded-full border border-border-subtle/80 bg-subtle px-2.5 py-1 text-xs font-medium text-fg-secondary"
+                            >
+                                {formatViewPropertyFilter(filter)}
+                            </span>
+                        ))}
+                        {!hasFilters && (
+                            <span className="inline-flex items-center rounded-full border border-border-subtle/80 bg-transparent px-2.5 py-1 text-xs font-medium text-fg-tertiary">
+                                All notes
+                            </span>
+                        )}
                     </div>
                 </div>
                 <div className="shrink-0">
@@ -109,7 +123,7 @@ export default function ViewSectionCard({ section, onEdit, onDelete, dragHandle 
                             Failed to load this section
                         </Text>
                         <Text as="p" variant="meta" tone="tertiary" className="mt-1">
-                            Retry to refresh the tag-based note block.
+                            Retry to refresh this saved query.
                         </Text>
                         <div className="mt-3">
                             <Button type="button" variant="ghost" size="sm" onClick={() => refetch()}>
@@ -125,7 +139,7 @@ export default function ViewSectionCard({ section, onEdit, onDelete, dragHandle 
                             No notes match yet
                         </Text>
                         <Text as="p" variant="meta" tone="tertiary" className="mt-1">
-                            Add more notes with these tags, or edit the section filter.
+                            Add matching notes, or edit this view query.
                         </Text>
                     </div>
                 )}

--- a/packages/client/src/components/view/ViewSectionDialog.tsx
+++ b/packages/client/src/components/view/ViewSectionDialog.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import type { NotePropertyKeySummary } from '~/apis/note.api';
 import { ModalActionRow } from '~/components/shared';
 import {
     Button,
@@ -13,38 +14,127 @@ import {
     ToggleGroupItem,
 } from '~/components/ui';
 import type { Tag } from '~/models/tag.model';
-import type { ViewSection, ViewTagMatchMode } from '~/models/view.model';
-import { getViewTagMatchLabel, normalizeViewTagNames } from '~/modules/view-dashboard';
+import type {
+    ViewDisplayType,
+    ViewPropertyFilter,
+    ViewPropertyFilterOperator,
+    ViewSection,
+    ViewSortBy,
+    ViewSortOrder,
+    ViewTagMatchMode,
+} from '~/models/view.model';
+import { getViewPropertyOperatorLabel, getViewTagMatchLabel, normalizeViewTagNames } from '~/modules/view-dashboard';
+
+export interface ViewSectionDialogDraft {
+    title: string;
+    displayType: ViewDisplayType;
+    tagNames: string[];
+    mode: ViewTagMatchMode;
+    propertyFilters: Array<Pick<ViewPropertyFilter, 'key' | 'valueType' | 'operator' | 'value'>>;
+    sortBy: ViewSortBy;
+    sortOrder: ViewSortOrder;
+    limit: number;
+}
+
+interface PropertyFilterDraft {
+    id: string;
+    key: string;
+    operator: ViewPropertyFilterOperator;
+    value: string;
+}
 
 interface ViewSectionDialogProps {
     open: boolean;
     mode: 'create' | 'edit';
     initialSection?: ViewSection | null;
     availableTags: Pick<Tag, 'id' | 'name'>[];
+    availableProperties: NotePropertyKeySummary[];
     isTagsLoading?: boolean;
+    isPropertiesLoading?: boolean;
     onClose: () => void;
-    onSubmit: (draft: { title: string; tagNames: string[]; mode: ViewTagMatchMode; limit: number }) => void;
+    onSubmit: (draft: ViewSectionDialogDraft) => void;
 }
+
+const PROPERTY_PLACEHOLDER_VALUE = '__choose_property__';
 
 const getInitialLimitValue = (section?: ViewSection | null) => String(section?.limit ?? 5);
 const getInitialModeValue = (section?: ViewSection | null): ViewTagMatchMode => section?.mode ?? 'and';
 const getInitialTagsValue = (section?: ViewSection | null) => (section ? section.tagNames.join(', ') : '');
 const getInitialTitleValue = (section?: ViewSection | null) => section?.title ?? '';
+const getInitialSortByValue = (section?: ViewSection | null): ViewSortBy => section?.sortBy ?? 'updatedAt';
+const getInitialSortOrderValue = (section?: ViewSection | null): ViewSortOrder => section?.sortOrder ?? 'desc';
+
+const createFilterId = (index: number) => `property-filter-${Date.now()}-${index}`;
+
+const toFilterDrafts = (section?: ViewSection | null): PropertyFilterDraft[] => {
+    return (section?.propertyFilters ?? []).map((filter, index) => ({
+        id: createFilterId(index),
+        key: filter.key,
+        operator: filter.operator,
+        value: filter.value ?? '',
+    }));
+};
+
+const getOperatorsForProperty = (property?: NotePropertyKeySummary): ViewPropertyFilterOperator[] => {
+    if (!property) {
+        return ['exists', 'notExists'];
+    }
+
+    if (property.valueType === 'date' || property.valueType === 'number') {
+        return ['equals', 'before', 'after', 'exists', 'notExists'];
+    }
+
+    return ['equals', 'exists', 'notExists'];
+};
+
+const getDefaultOperator = (property?: NotePropertyKeySummary): ViewPropertyFilterOperator => {
+    return property ? 'equals' : 'exists';
+};
+
+const getDefaultValue = (property?: NotePropertyKeySummary) => {
+    if (!property) {
+        return '';
+    }
+
+    if (property.valueType === 'boolean') {
+        return 'true';
+    }
+
+    if (property.valueType === 'select') {
+        return property.options[0]?.value ?? '';
+    }
+
+    return '';
+};
+
+const shouldShowFilterValue = (operator: ViewPropertyFilterOperator) =>
+    operator !== 'exists' && operator !== 'notExists';
 
 export default function ViewSectionDialog({
     open,
     mode,
     initialSection = null,
     availableTags,
+    availableProperties,
     isTagsLoading = false,
+    isPropertiesLoading = false,
     onClose,
     onSubmit,
 }: ViewSectionDialogProps) {
     const [title, setTitle] = useState(getInitialTitleValue(initialSection));
     const [tagInput, setTagInput] = useState(getInitialTagsValue(initialSection));
     const [matchMode, setMatchMode] = useState<ViewTagMatchMode>(getInitialModeValue(initialSection));
+    const [sortBy, setSortBy] = useState<ViewSortBy>(getInitialSortByValue(initialSection));
+    const [sortOrder, setSortOrder] = useState<ViewSortOrder>(getInitialSortOrderValue(initialSection));
     const [limit, setLimit] = useState(getInitialLimitValue(initialSection));
-    const [tagError, setTagError] = useState('');
+    const [filters, setFilters] = useState<PropertyFilterDraft[]>(toFilterDrafts(initialSection));
+    const [isTagFilterOpen, setIsTagFilterOpen] = useState((initialSection?.tagNames.length ?? 0) > 0);
+    const [formError, setFormError] = useState('');
+
+    const propertyByKey = useMemo(
+        () => new Map(availableProperties.map((property) => [property.key, property])),
+        [availableProperties],
+    );
 
     useEffect(() => {
         if (!open) {
@@ -54,11 +144,17 @@ export default function ViewSectionDialog({
         setTitle(getInitialTitleValue(initialSection));
         setTagInput(getInitialTagsValue(initialSection));
         setMatchMode(getInitialModeValue(initialSection));
+        setSortBy(getInitialSortByValue(initialSection));
+        setSortOrder(getInitialSortOrderValue(initialSection));
         setLimit(getInitialLimitValue(initialSection));
-        setTagError('');
+        setFilters(toFilterDrafts(initialSection));
+        setIsTagFilterOpen((initialSection?.tagNames.length ?? 0) > 0);
+        setFormError('');
     }, [initialSection, open]);
 
     const selectedTagNames = normalizeViewTagNames([tagInput]);
+    const showTagFilter = isTagFilterOpen || selectedTagNames.length > 0;
+    const isAllNotesView = selectedTagNames.length === 0 && filters.length === 0;
 
     const toggleTagName = (tagName: string) => {
         const nextTagNames = selectedTagNames.includes(tagName)
@@ -66,12 +162,73 @@ export default function ViewSectionDialog({
             : [...selectedTagNames, tagName];
 
         setTagInput(nextTagNames.join(', '));
-        setTagError('');
+        setFormError('');
+    };
+
+    const handleAddTagFilter = () => {
+        setIsTagFilterOpen(true);
+        setFormError('');
+    };
+
+    const removeTagFilter = () => {
+        setTagInput('');
+        setMatchMode('and');
+        setIsTagFilterOpen(false);
+        setFormError('');
+    };
+
+    const handleAddPropertyFilter = () => {
+        if (availableProperties.length === 0) {
+            setFormError('Create a shared property before adding a filter.');
+            return;
+        }
+
+        setFilters((current) => [
+            ...current,
+            {
+                id: createFilterId(current.length),
+                key: '',
+                operator: 'exists',
+                value: '',
+            },
+        ]);
+        setFormError('');
+    };
+
+    const updateFilter = (id: string, patch: Partial<PropertyFilterDraft>) => {
+        setFilters((current) =>
+            current.map((filter) => {
+                if (filter.id !== id) {
+                    return filter;
+                }
+
+                const nextFilter = { ...filter, ...patch };
+                const property = propertyByKey.get(nextFilter.key);
+                const operators = getOperatorsForProperty(property);
+
+                if (!operators.includes(nextFilter.operator)) {
+                    nextFilter.operator = getDefaultOperator(property);
+                }
+
+                if ('key' in patch) {
+                    nextFilter.value = getDefaultValue(property);
+                    nextFilter.operator = getDefaultOperator(property);
+                }
+
+                return nextFilter;
+            }),
+        );
+        setFormError('');
+    };
+
+    const removeFilter = (id: string) => {
+        setFilters((current) => current.filter((filter) => filter.id !== id));
+        setFormError('');
     };
 
     return (
-        <Modal isOpen={open} onClose={onClose} variant="form" className="sm:max-w-[640px]">
-            <Modal.Header title={mode === 'create' ? 'Create section' : 'Edit section'} onClose={onClose} />
+        <Modal isOpen={open} onClose={onClose} variant="form" className="sm:max-w-[720px]">
+            <Modal.Header title={mode === 'create' ? 'Create view' : 'Edit view'} onClose={onClose} />
             <Modal.Body>
                 <form
                     id="view-section-form"
@@ -81,129 +238,365 @@ export default function ViewSectionDialog({
 
                         const tagNames = normalizeViewTagNames([tagInput]);
 
-                        if (tagNames.length === 0) {
-                            setTagError('Add at least one tag for this section.');
+                        if (showTagFilter && tagNames.length === 0) {
+                            setFormError('Choose at least one tag, or remove this tag filter.');
+                            return;
+                        }
+
+                        const missingPropertyFilter = filters.find(
+                            (filter) => !filter.key || !propertyByKey.has(filter.key),
+                        );
+
+                        if (missingPropertyFilter) {
+                            setFormError('Choose a property for every filter.');
+                            return;
+                        }
+
+                        const propertyFilters = filters.map((filter) => {
+                            const property = propertyByKey.get(filter.key);
+
+                            return {
+                                key: property?.key ?? filter.key,
+                                valueType: property?.valueType ?? 'text',
+                                operator: filter.operator,
+                                value: shouldShowFilterValue(filter.operator) ? filter.value : null,
+                            };
+                        });
+
+                        const hasIncompleteFilter = propertyFilters.some(
+                            (filter) => shouldShowFilterValue(filter.operator) && !filter.value?.trim(),
+                        );
+
+                        if (hasIncompleteFilter) {
+                            setFormError('Fill every filter value, or switch it to is set / is empty.');
                             return;
                         }
 
                         onSubmit({
                             title,
+                            displayType: 'list',
                             tagNames,
                             mode: matchMode,
+                            propertyFilters,
+                            sortBy,
+                            sortOrder,
                             limit: Number(limit),
                         });
                     }}
                 >
-                    <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_180px]">
-                        <div className="flex flex-col gap-2">
-                            <Label htmlFor="view-section-title" size="md">
-                                Section title
-                            </Label>
-                            <Input
-                                id="view-section-title"
-                                value={title}
-                                onChange={(event) => setTitle(event.target.value)}
-                                placeholder="Agent work"
-                                autoFocus
-                            />
-                        </div>
-                        <div className="flex flex-col gap-2">
-                            <Label htmlFor="view-section-limit" size="md">
-                                Max notes
-                            </Label>
-                            <Select value={limit} onValueChange={setLimit}>
-                                <SelectItem value="3">3 notes</SelectItem>
-                                <SelectItem value="5">5 notes</SelectItem>
-                                <SelectItem value="8">8 notes</SelectItem>
-                                <SelectItem value="10">10 notes</SelectItem>
-                                <SelectItem value="12">12 notes</SelectItem>
-                            </Select>
-                        </div>
+                    <div className="flex flex-col gap-2">
+                        <Label htmlFor="view-section-title" size="md">
+                            View name
+                        </Label>
+                        <Input
+                            id="view-section-title"
+                            value={title}
+                            onChange={(event) => setTitle(event.target.value)}
+                            placeholder="Doing notes"
+                            autoFocus
+                        />
                     </div>
 
-                    <div className="flex flex-col gap-2">
-                        <Label htmlFor="view-section-tags" size="md">
-                            Tags
-                        </Label>
-                        <Textarea
-                            id="view-section-tags"
-                            value={tagInput}
-                            onChange={(event) => {
-                                setTagInput(event.target.value);
-                                setTagError('');
-                            }}
-                            placeholder="@OceanBrain, @todo"
-                            size="sm"
-                        />
+                    <section className="flex flex-col gap-3 rounded-[20px] border border-border-subtle bg-subtle/40 p-4">
+                        <div className="flex flex-wrap items-start justify-between gap-3">
+                            <div className="min-w-0">
+                                <Label size="md">Filters</Label>
+                                <Text as="p" variant="meta" tone="tertiary" className="mt-1">
+                                    Use properties for structured fields, and tags for loose topics or context.
+                                </Text>
+                            </div>
+                            <div className="flex flex-wrap gap-2">
+                                <Button type="button" variant="subtle" size="sm" onClick={handleAddPropertyFilter}>
+                                    Add property filter
+                                </Button>
+                                {!showTagFilter && (
+                                    <Button type="button" variant="subtle" size="sm" onClick={handleAddTagFilter}>
+                                        Add tag filter
+                                    </Button>
+                                )}
+                            </div>
+                        </div>
+
+                        {filters.length === 0 && !showTagFilter ? (
+                            <div className="rounded-[16px] border border-dashed border-border-subtle bg-elevated/60 px-4 py-3">
+                                <Text as="p" variant="label" tone="default">
+                                    {isAllNotesView ? 'All notes' : 'No filters'}
+                                </Text>
+                                <Text as="p" variant="meta" tone="tertiary" className="mt-1">
+                                    Add a property filter, a tag filter, or leave this view open to all notes.
+                                </Text>
+                            </div>
+                        ) : null}
+
+                        {filters.length > 0 ? (
+                            <div className="flex flex-col gap-2.5">
+                                {filters.map((filter) => {
+                                    const property = propertyByKey.get(filter.key);
+                                    const operators = getOperatorsForProperty(property);
+
+                                    return (
+                                        <div
+                                            key={filter.id}
+                                            className="grid gap-2 rounded-[16px] border border-border-subtle bg-elevated p-3 md:grid-cols-[minmax(0,1fr)_150px_minmax(0,1fr)_auto] md:items-center"
+                                        >
+                                            <Select
+                                                value={filter.key || PROPERTY_PLACEHOLDER_VALUE}
+                                                onValueChange={(value) => {
+                                                    if (value === PROPERTY_PLACEHOLDER_VALUE) {
+                                                        return;
+                                                    }
+
+                                                    updateFilter(filter.id, { key: value });
+                                                }}
+                                            >
+                                                <SelectItem value={PROPERTY_PLACEHOLDER_VALUE} disabled>
+                                                    Choose property
+                                                </SelectItem>
+                                                {availableProperties.map((propertyOption) => (
+                                                    <SelectItem key={propertyOption.key} value={propertyOption.key}>
+                                                        {propertyOption.name}
+                                                    </SelectItem>
+                                                ))}
+                                            </Select>
+
+                                            <Select
+                                                value={filter.operator}
+                                                disabled={!property}
+                                                onValueChange={(value) =>
+                                                    updateFilter(filter.id, {
+                                                        operator: value as ViewPropertyFilterOperator,
+                                                    })
+                                                }
+                                            >
+                                                {operators.map((operator) => (
+                                                    <SelectItem key={operator} value={operator}>
+                                                        {getViewPropertyOperatorLabel(operator)}
+                                                    </SelectItem>
+                                                ))}
+                                            </Select>
+
+                                            {shouldShowFilterValue(filter.operator) && property ? (
+                                                property.valueType === 'select' ? (
+                                                    <Select
+                                                        value={filter.value}
+                                                        onValueChange={(value) => updateFilter(filter.id, { value })}
+                                                    >
+                                                        {property.options.map((option) => (
+                                                            <SelectItem key={option.value} value={option.value}>
+                                                                {option.label}
+                                                            </SelectItem>
+                                                        ))}
+                                                    </Select>
+                                                ) : property.valueType === 'boolean' ? (
+                                                    <Select
+                                                        value={filter.value || 'true'}
+                                                        onValueChange={(value) => updateFilter(filter.id, { value })}
+                                                    >
+                                                        <SelectItem value="true">True</SelectItem>
+                                                        <SelectItem value="false">False</SelectItem>
+                                                    </Select>
+                                                ) : (
+                                                    <Input
+                                                        type={
+                                                            property.valueType === 'date'
+                                                                ? 'date'
+                                                                : property.valueType === 'number'
+                                                                  ? 'number'
+                                                                  : 'text'
+                                                        }
+                                                        value={filter.value}
+                                                        onChange={(event) =>
+                                                            updateFilter(filter.id, { value: event.target.value })
+                                                        }
+                                                        placeholder={
+                                                            property.valueType === 'text' ? 'Value' : undefined
+                                                        }
+                                                    />
+                                                )
+                                            ) : (
+                                                <Text as="span" variant="label" tone="tertiary">
+                                                    {property ? 'No value needed' : 'Choose a property first'}
+                                                </Text>
+                                            )}
+
+                                            <Button
+                                                type="button"
+                                                variant="ghost"
+                                                size="sm"
+                                                onClick={() => removeFilter(filter.id)}
+                                            >
+                                                Remove
+                                            </Button>
+                                        </div>
+                                    );
+                                })}
+                            </div>
+                        ) : null}
+
+                        {showTagFilter ? (
+                            <div className="flex flex-col gap-3 rounded-[16px] border border-border-subtle bg-elevated p-3">
+                                <div className="flex flex-wrap items-start justify-between gap-3">
+                                    <div className="min-w-0">
+                                        <Text as="p" variant="label" tone="default">
+                                            Tag filter
+                                        </Text>
+                                        <Text as="p" variant="meta" tone="tertiary" className="mt-1">
+                                            Match notes by selected tags.
+                                        </Text>
+                                    </div>
+                                    <Button type="button" variant="ghost" size="sm" onClick={removeTagFilter}>
+                                        Remove
+                                    </Button>
+                                </div>
+
+                                <div className="flex flex-col gap-2">
+                                    <Label htmlFor="view-section-tags" size="sm">
+                                        Tag names
+                                    </Label>
+                                    <Textarea
+                                        id="view-section-tags"
+                                        value={tagInput}
+                                        onChange={(event) => {
+                                            setTagInput(event.target.value);
+                                            setFormError('');
+                                        }}
+                                        placeholder="@OceanBrain, @todo"
+                                        size="sm"
+                                    />
+                                    <Text as="p" variant="meta" tone="tertiary">
+                                        You can use tags only, properties only, both together, or no filters.
+                                    </Text>
+                                </div>
+
+                                {selectedTagNames.length > 1 ? (
+                                    <div className="flex flex-col gap-2">
+                                        <Label size="sm">When multiple tags are selected</Label>
+                                        <ToggleGroup
+                                            type="single"
+                                            value={matchMode}
+                                            onValueChange={(value) => {
+                                                if (value === 'and' || value === 'or') {
+                                                    setMatchMode(value);
+                                                }
+                                            }}
+                                            variant="quiet"
+                                            size="sm"
+                                            className="self-start"
+                                        >
+                                            <ToggleGroupItem value="and" aria-label={getViewTagMatchLabel('and')}>
+                                                Match all
+                                            </ToggleGroupItem>
+                                            <ToggleGroupItem value="or" aria-label={getViewTagMatchLabel('or')}>
+                                                Match any
+                                            </ToggleGroupItem>
+                                        </ToggleGroup>
+                                    </div>
+                                ) : null}
+
+                                <div className="flex items-center justify-between gap-3">
+                                    <Label size="sm">Existing tags</Label>
+                                    <Text as="span" variant="meta" tone="tertiary">
+                                        {isTagsLoading ? 'Loading...' : `${availableTags.length} available`}
+                                    </Text>
+                                </div>
+                                {availableTags.length > 0 ? (
+                                    <div className="max-h-44 overflow-y-auto rounded-[16px] border border-border-subtle bg-hover-subtle/60 p-3">
+                                        <div className="flex flex-wrap gap-2">
+                                            {availableTags.map((tag) => {
+                                                const isSelected = selectedTagNames.includes(tag.name);
+
+                                                return (
+                                                    <button
+                                                        key={tag.id}
+                                                        type="button"
+                                                        className={`inline-flex items-center rounded-full border px-3 py-1.5 text-sm font-medium transition-colors ${
+                                                            isSelected
+                                                                ? 'border-border-secondary bg-elevated text-fg-default'
+                                                                : 'border-border-subtle bg-transparent text-fg-secondary hover:border-border-secondary hover:bg-elevated hover:text-fg-default'
+                                                        }`}
+                                                        onClick={() => toggleTagName(tag.name)}
+                                                    >
+                                                        {tag.name}
+                                                    </button>
+                                                );
+                                            })}
+                                        </div>
+                                    </div>
+                                ) : (
+                                    <Text as="p" variant="meta" tone="tertiary">
+                                        No tags yet. You can still type tag names manually.
+                                    </Text>
+                                )}
+                            </div>
+                        ) : null}
+
                         <Text
                             as="p"
                             variant="meta"
-                            tone={tagError ? 'default' : 'tertiary'}
-                            className={tagError ? 'text-fg-error' : undefined}
+                            tone={formError ? 'default' : 'tertiary'}
+                            className={formError ? 'text-fg-error' : undefined}
                         >
-                            {tagError || 'Separate tags with commas. Plain words become @tags automatically.'}
+                            {formError ||
+                                (isPropertiesLoading || isTagsLoading
+                                    ? 'Loading filter options...'
+                                    : `${availableProperties.length} properties · ${availableTags.length} tags available`)}
                         </Text>
-                    </div>
+                    </section>
 
-                    <div className="flex flex-col gap-2">
-                        <Label size="md">Tag match</Label>
-                        <ToggleGroup
-                            type="single"
-                            value={matchMode}
-                            onValueChange={(value) => {
-                                if (value === 'and' || value === 'or') {
-                                    setMatchMode(value);
-                                }
-                            }}
-                            variant="quiet"
-                            size="sm"
-                            className="self-start"
-                        >
-                            <ToggleGroupItem value="and" aria-label={getViewTagMatchLabel('and')}>
-                                Match all
-                            </ToggleGroupItem>
-                            <ToggleGroupItem value="or" aria-label={getViewTagMatchLabel('or')}>
-                                Match any
-                            </ToggleGroupItem>
-                        </ToggleGroup>
-                    </div>
-
-                    <div className="flex flex-col gap-3">
-                        <div className="flex items-center justify-between gap-3">
-                            <Label size="md">Existing tags</Label>
-                            <Text as="span" variant="meta" tone="tertiary">
-                                {isTagsLoading ? 'Loading tag catalog...' : `${availableTags.length} tags available`}
-                            </Text>
-                        </div>
-                        {availableTags.length > 0 ? (
-                            <div className="max-h-44 overflow-y-auto rounded-[18px] border border-border-subtle bg-hover-subtle/60 p-3">
-                                <div className="flex flex-wrap gap-2">
-                                    {availableTags.map((tag) => {
-                                        const isSelected = selectedTagNames.includes(tag.name);
-
-                                        return (
-                                            <button
-                                                key={tag.id}
-                                                type="button"
-                                                className={`inline-flex items-center rounded-full border px-3 py-1.5 text-sm font-medium transition-colors ${
-                                                    isSelected
-                                                        ? 'border-border-secondary bg-elevated text-fg-default'
-                                                        : 'border-border-subtle bg-transparent text-fg-secondary hover:border-border-secondary hover:bg-elevated hover:text-fg-default'
-                                                }`}
-                                                onClick={() => toggleTagName(tag.name)}
-                                            >
-                                                {tag.name}
-                                            </button>
-                                        );
-                                    })}
+                    <details className="group rounded-[18px] border border-border-subtle bg-elevated px-4 py-3">
+                        <summary className="cursor-pointer list-none">
+                            <div className="flex items-center justify-between gap-3">
+                                <div>
+                                    <Text as="span" variant="label" tone="default">
+                                        Sort and limit
+                                    </Text>
+                                    <Text as="p" variant="meta" tone="tertiary" className="mt-1">
+                                        Defaults to recently updated notes.
+                                    </Text>
                                 </div>
+                                <Text as="span" variant="meta" tone="tertiary">
+                                    {limit} notes
+                                </Text>
                             </div>
-                        ) : (
-                            <Text as="p" variant="meta" tone="tertiary">
-                                No tags yet. You can still type tag names manually.
-                            </Text>
-                        )}
-                    </div>
+                        </summary>
+
+                        <div className="mt-4 grid gap-4 md:grid-cols-3">
+                            <div className="flex flex-col gap-2">
+                                <Label htmlFor="view-section-sort-by" size="sm">
+                                    Sort by
+                                </Label>
+                                <Select value={sortBy} onValueChange={(value) => setSortBy(value as ViewSortBy)}>
+                                    <SelectItem value="updatedAt">Updated time</SelectItem>
+                                    <SelectItem value="createdAt">Created time</SelectItem>
+                                    <SelectItem value="title">Title</SelectItem>
+                                </Select>
+                            </div>
+                            <div className="flex flex-col gap-2">
+                                <Label htmlFor="view-section-sort-order" size="sm">
+                                    Order
+                                </Label>
+                                <Select
+                                    value={sortOrder}
+                                    onValueChange={(value) => setSortOrder(value as ViewSortOrder)}
+                                >
+                                    <SelectItem value="desc">Descending</SelectItem>
+                                    <SelectItem value="asc">Ascending</SelectItem>
+                                </Select>
+                            </div>
+                            <div className="flex flex-col gap-2">
+                                <Label htmlFor="view-section-limit" size="sm">
+                                    Max notes
+                                </Label>
+                                <Select value={limit} onValueChange={setLimit}>
+                                    <SelectItem value="3">3 notes</SelectItem>
+                                    <SelectItem value="5">5 notes</SelectItem>
+                                    <SelectItem value="8">8 notes</SelectItem>
+                                    <SelectItem value="10">10 notes</SelectItem>
+                                    <SelectItem value="12">12 notes</SelectItem>
+                                </Select>
+                            </div>
+                        </div>
+                    </details>
                 </form>
             </Modal.Body>
             <Modal.Footer>
@@ -212,7 +605,7 @@ export default function ViewSectionDialog({
                         Cancel
                     </Button>
                     <Button type="submit" size="sm" form="view-section-form">
-                        {mode === 'create' ? 'Create section' : 'Save section'}
+                        {mode === 'create' ? 'Create view' : 'Save view'}
                     </Button>
                 </ModalActionRow>
             </Modal.Footer>

--- a/packages/client/src/components/view/index.ts
+++ b/packages/client/src/components/view/index.ts
@@ -1,3 +1,4 @@
 export { default as ViewSectionCard } from './ViewSectionCard';
+export type { ViewSectionDialogDraft } from './ViewSectionDialog';
 export { default as ViewSectionDialog } from './ViewSectionDialog';
 export { default as ViewTabDialog } from './ViewTabDialog';

--- a/packages/client/src/models/view.model.ts
+++ b/packages/client/src/models/view.model.ts
@@ -1,11 +1,27 @@
 export type ViewTagMatchMode = 'and' | 'or';
+export type ViewDisplayType = 'list' | 'calendar';
+export type ViewPropertyFilterOperator = 'equals' | 'before' | 'after' | 'exists' | 'notExists';
+export type ViewSortBy = 'updatedAt' | 'createdAt' | 'title';
+export type ViewSortOrder = 'asc' | 'desc';
+
+export interface ViewPropertyFilter {
+    key: string;
+    name: string;
+    valueType: 'text' | 'number' | 'date' | 'boolean' | 'select';
+    operator: ViewPropertyFilterOperator;
+    value?: string | null;
+}
 
 export interface ViewSection {
     id: string;
     tabId: string;
     title: string;
+    displayType: ViewDisplayType;
     tagNames: string[];
     mode: ViewTagMatchMode;
+    propertyFilters: ViewPropertyFilter[];
+    sortBy: ViewSortBy;
+    sortOrder: ViewSortOrder;
     limit: number;
     order: number;
 }

--- a/packages/client/src/modules/view-dashboard.spec.ts
+++ b/packages/client/src/modules/view-dashboard.spec.ts
@@ -1,12 +1,30 @@
 import {
     EMPTY_VIEWS_WORKSPACE,
+    formatViewPropertyFilter,
     getActiveViewTab,
+    getViewPropertyOperatorLabel,
     getViewTagMatchToken,
     normalizeViewTagNames,
     reorderViewSectionsInWorkspace,
     reorderViewTabsInWorkspace,
     setActiveViewTabInWorkspace,
 } from './view-dashboard';
+
+const createSection = (section: {
+    id: string;
+    tabId: string;
+    title: string;
+    tagNames: string[];
+    mode: 'and' | 'or';
+    limit: number;
+    order: number;
+}) => ({
+    displayType: 'list' as const,
+    propertyFilters: [],
+    sortBy: 'updatedAt' as const,
+    sortOrder: 'desc' as const,
+    ...section,
+});
 
 describe('view-dashboard helpers', () => {
     it('normalizes hash-prefixed or plain tags to the canonical @ form', () => {
@@ -85,7 +103,7 @@ describe('view-dashboard helpers', () => {
                             title: 'Now',
                             order: 0,
                             sections: [
-                                {
+                                createSection({
                                     id: 'section-1',
                                     tabId: 'tab-1',
                                     title: 'One',
@@ -93,8 +111,8 @@ describe('view-dashboard helpers', () => {
                                     mode: 'and',
                                     limit: 5,
                                     order: 0,
-                                },
-                                {
+                                }),
+                                createSection({
                                     id: 'section-2',
                                     tabId: 'tab-1',
                                     title: 'Two',
@@ -102,8 +120,8 @@ describe('view-dashboard helpers', () => {
                                     mode: 'and',
                                     limit: 5,
                                     order: 1,
-                                },
-                                {
+                                }),
+                                createSection({
                                     id: 'section-3',
                                     tabId: 'tab-1',
                                     title: 'Three',
@@ -111,7 +129,7 @@ describe('view-dashboard helpers', () => {
                                     mode: 'or',
                                     limit: 3,
                                     order: 2,
-                                },
+                                }),
                             ],
                         },
                     ],
@@ -126,5 +144,28 @@ describe('view-dashboard helpers', () => {
     it('returns a short conjunction token for tag matching', () => {
         expect(getViewTagMatchToken('and')).toBe('AND');
         expect(getViewTagMatchToken('or')).toBe('OR');
+    });
+
+    it('formats property filter labels for display', () => {
+        expect(getViewPropertyOperatorLabel('exists')).toBe('is set');
+        expect(getViewPropertyOperatorLabel('notExists')).toBe('is empty');
+        expect(
+            formatViewPropertyFilter({
+                key: 'state',
+                name: 'State',
+                valueType: 'select',
+                operator: 'equals',
+                value: 'doing',
+            }),
+        ).toBe('State is doing');
+        expect(
+            formatViewPropertyFilter({
+                key: 'state',
+                name: 'State',
+                valueType: 'select',
+                operator: 'exists',
+                value: null,
+            }),
+        ).toBe('State is set');
     });
 });

--- a/packages/client/src/modules/view-dashboard.ts
+++ b/packages/client/src/modules/view-dashboard.ts
@@ -1,4 +1,11 @@
-import type { ViewSection, ViewsWorkspace, ViewTab, ViewTagMatchMode } from '~/models/view.model';
+import type {
+    ViewPropertyFilter,
+    ViewPropertyFilterOperator,
+    ViewSection,
+    ViewsWorkspace,
+    ViewTab,
+    ViewTagMatchMode,
+} from '~/models/view.model';
 
 export const DEFAULT_VIEW_SECTION_LIMIT = 5;
 export const MIN_VIEW_SECTION_LIMIT = 1;
@@ -112,6 +119,32 @@ export const getViewTagMatchLabel = (mode: ViewTagMatchMode) => {
 
 export const getViewTagMatchToken = (mode: ViewTagMatchMode) => {
     return mode === 'or' ? 'OR' : 'AND';
+};
+
+export const getViewPropertyOperatorLabel = (operator: ViewPropertyFilterOperator) => {
+    switch (operator) {
+        case 'before':
+            return 'before';
+        case 'after':
+            return 'after';
+        case 'exists':
+            return 'is set';
+        case 'notExists':
+            return 'is empty';
+        case 'equals':
+        default:
+            return 'is';
+    }
+};
+
+export const formatViewPropertyFilter = (filter: ViewPropertyFilter) => {
+    const operatorLabel = getViewPropertyOperatorLabel(filter.operator);
+
+    if (filter.operator === 'exists' || filter.operator === 'notExists') {
+        return `${filter.name} ${operatorLabel}`;
+    }
+
+    return `${filter.name} ${operatorLabel} ${filter.value ?? ''}`.trim();
 };
 
 export const buildViewNotesSearch = (section: Pick<ViewSection, 'id'>) => ({

--- a/packages/client/src/pages/ViewNotes.tsx
+++ b/packages/client/src/pages/ViewNotes.tsx
@@ -9,7 +9,7 @@ import { Text } from '~/components/ui';
 import useNoteMutate from '~/hooks/resource/useNoteMutate';
 import { queryKeys } from '~/modules/query-key-factory';
 import { VIEW_NOTES_ROUTE } from '~/modules/url';
-import { getViewTagMatchLabel } from '~/modules/view-dashboard';
+import { formatViewPropertyFilter, getViewTagMatchLabel } from '~/modules/view-dashboard';
 
 const Route = getRouteApi(VIEW_NOTES_ROUTE);
 
@@ -54,6 +54,16 @@ function ViewNotesContent() {
     const heading = sectionData?.title || 'View Notes';
     const tagNames = sectionData?.tagNames ?? [];
     const mode = sectionData?.mode ?? 'and';
+    const propertyFilters = sectionData?.propertyFilters ?? [];
+    const hasTagFilter = tagNames.length > 0;
+    const hasPropertyFilter = propertyFilters.length > 0;
+    const filterSummary = hasTagFilter
+        ? hasPropertyFilter
+            ? `Property and tag filters · ${getViewTagMatchLabel(mode)}`
+            : `Tag filters · ${getViewTagMatchLabel(mode)}`
+        : hasPropertyFilter
+          ? 'Property filters'
+          : 'All notes';
 
     return (
         <PageLayout
@@ -62,7 +72,7 @@ function ViewNotesContent() {
             description={
                 <div className="flex flex-col gap-2">
                     <Text as="span" variant="meta" tone="tertiary">
-                        {getViewTagMatchLabel(mode)}
+                        {filterSummary}
                     </Text>
                     <div className="flex flex-wrap gap-1.5">
                         {tagNames.map((tagName) => (
@@ -73,6 +83,19 @@ function ViewNotesContent() {
                                 {tagName}
                             </span>
                         ))}
+                        {propertyFilters.map((filter) => (
+                            <span
+                                key={`${filter.key}-${filter.operator}-${filter.value ?? ''}`}
+                                className="inline-flex items-center rounded-full border border-border-subtle bg-hover-subtle px-2.5 py-1 text-xs font-medium text-fg-secondary"
+                            >
+                                {formatViewPropertyFilter(filter)}
+                            </span>
+                        ))}
+                        {tagNames.length === 0 && propertyFilters.length === 0 && (
+                            <span className="inline-flex items-center rounded-full border border-border-subtle bg-hover-subtle px-2.5 py-1 text-xs font-medium text-fg-secondary">
+                                All notes
+                            </span>
+                        )}
                     </div>
                 </div>
             }
@@ -81,7 +104,7 @@ function ViewNotesContent() {
                 fallback={
                     <Empty
                         title="No notes match this saved view"
-                        description="Adjust the section tags or keep writing until matching notes appear."
+                        description="Adjust this view's filters or keep writing until matching notes appear."
                     />
                 }
             >

--- a/packages/client/src/pages/Views.spec.tsx
+++ b/packages/client/src/pages/Views.spec.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 
+import { fetchNotePropertyKeys } from '~/apis/note.api';
 import { fetchTags } from '~/apis/tag.api';
 import { fetchViewWorkspace } from '~/apis/view.api';
 import { ConfirmProvider, ToastProvider } from '~/components/ui';
@@ -7,6 +8,7 @@ import { createQueryClientWrapper } from '~/test/test-utils';
 
 import Views from './Views';
 
+vi.mock('~/apis/note.api', () => ({ fetchNotePropertyKeys: vi.fn() }));
 vi.mock('~/apis/tag.api', () => ({ fetchTags: vi.fn() }));
 vi.mock('~/apis/view.api', () => ({
     createViewSection: vi.fn(),
@@ -23,6 +25,13 @@ vi.mock('~/apis/view.api', () => ({
 
 describe('<Views />', () => {
     beforeEach(() => {
+        vi.mocked(fetchNotePropertyKeys).mockResolvedValue({
+            type: 'success',
+            notePropertyKeys: {
+                totalCount: 0,
+                keys: [],
+            },
+        } as never);
         vi.mocked(fetchTags).mockResolvedValue({
             type: 'success',
             allTags: {

--- a/packages/client/src/pages/Views.tsx
+++ b/packages/client/src/pages/Views.tsx
@@ -13,6 +13,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import classNames from 'classnames';
 import { useState } from 'react';
 
+import { fetchNotePropertyKeys } from '~/apis/note.api';
 import { fetchTags } from '~/apis/tag.api';
 import {
     createViewSection,
@@ -29,7 +30,7 @@ import {
 import * as Icon from '~/components/icon';
 import { Button, Dropdown, Empty, PageLayout, Skeleton, SurfaceCard } from '~/components/shared';
 import { MoreButton, Text, useConfirm, useToast } from '~/components/ui';
-import { ViewSectionCard, ViewSectionDialog, ViewTabDialog } from '~/components/view';
+import { ViewSectionCard, ViewSectionDialog, type ViewSectionDialogDraft, ViewTabDialog } from '~/components/view';
 import type { ViewSection, ViewsWorkspace, ViewTab } from '~/models/view.model';
 import { queryKeys } from '~/modules/query-key-factory';
 import {
@@ -40,7 +41,7 @@ import {
     setActiveViewTabInWorkspace,
 } from '~/modules/view-dashboard';
 
-const pageDescription = 'Save tag-based views and switch between them without leaving your notes.';
+const pageDescription = 'Save reusable note queries with tags, shared properties, and sorting.';
 
 type ViewTabDialogState = { mode: 'create' } | { mode: 'edit'; tab: ViewTab } | null;
 type ViewSectionDialogState = { mode: 'create' } | { mode: 'edit'; section: ViewSection } | null;
@@ -203,6 +204,21 @@ export default function Views() {
 
     const availableTags = tagData?.tags ?? [];
 
+    const { data: propertyKeyData, isPending: isPropertiesLoading } = useQuery({
+        queryKey: queryKeys.notes.propertyKeys({ limit: 100 }),
+        async queryFn() {
+            const response = await fetchNotePropertyKeys({ limit: 100 });
+
+            if (response.type === 'error') {
+                throw response;
+            }
+
+            return response.notePropertyKeys;
+        },
+    });
+
+    const availableProperties = propertyKeyData?.keys ?? [];
+
     const syncWorkspace = (nextWorkspace: ViewsWorkspace) => {
         queryClient.setQueryData(queryKeys.views.workspace(), nextWorkspace);
     };
@@ -311,12 +327,7 @@ export default function Views() {
         await invalidateViews();
     };
 
-    const handleCreateSection = async (draft: {
-        title: string;
-        tagNames: string[];
-        mode: ViewSection['mode'];
-        limit: number;
-    }) => {
+    const handleCreateSection = async (draft: ViewSectionDialogDraft) => {
         if (!activeTab) {
             return;
         }
@@ -332,12 +343,7 @@ export default function Views() {
         setSectionDialogState(null);
     };
 
-    const handleUpdateSection = async (draft: {
-        title: string;
-        tagNames: string[];
-        mode: ViewSection['mode'];
-        limit: number;
-    }) => {
+    const handleUpdateSection = async (draft: ViewSectionDialogDraft) => {
         if (!activeTab || !sectionDialogState || sectionDialogState.mode !== 'edit') {
             return;
         }
@@ -401,7 +407,7 @@ export default function Views() {
                     <SurfaceCard className="px-6 py-8 sm:px-8 sm:py-10">
                         <Empty
                             title="Create your first view tab"
-                            description="Start with a saved view tab, then add tag-based sections inside it."
+                            description="Start with a saved view tab, then add sections that query notes by tags, properties, or both."
                         />
                         <div className="mt-6 flex justify-center">
                             <Button type="button" onClick={() => setTabDialogState({ mode: 'create' })}>
@@ -515,7 +521,7 @@ export default function Views() {
                                     <SurfaceCard className="px-6 py-8 sm:px-8 sm:py-10">
                                         <Empty
                                             title="Add the first section to this tab"
-                                            description="Sections pull notes by tag."
+                                            description="Sections can pull notes by tags, properties, or both."
                                         />
                                     </SurfaceCard>
                                 ) : (
@@ -572,7 +578,9 @@ export default function Views() {
                 mode={sectionDialogState?.mode ?? 'create'}
                 initialSection={sectionDialogState?.mode === 'edit' ? sectionDialogState.section : null}
                 availableTags={availableTags}
+                availableProperties={availableProperties}
                 isTagsLoading={isTagsLoading}
+                isPropertiesLoading={isPropertiesLoading}
                 onClose={() => setSectionDialogState(null)}
                 onSubmit={(draft) => {
                     if (sectionDialogState?.mode === 'edit') {

--- a/packages/server/prisma/migrations/20260531073000_0018_view_query/migration.sql
+++ b/packages/server/prisma/migrations/20260531073000_0018_view_query/migration.sql
@@ -1,0 +1,3 @@
+-- Add saved query metadata to existing view sections.
+ALTER TABLE "ViewSection" ADD COLUMN "displayType" TEXT NOT NULL DEFAULT 'list';
+ALTER TABLE "ViewSection" ADD COLUMN "query" TEXT;

--- a/packages/server/prisma/schema.prisma
+++ b/packages/server/prisma/schema.prisma
@@ -1,286 +1,292 @@
 generator client {
-    provider = "prisma-client-js"
+  provider = "prisma-client-js"
 }
 
 datasource db {
-    provider = "sqlite"
-    url      = env("DATABASE_URL")
+  provider = "sqlite"
+  url      = env("DATABASE_URL")
 }
 
 model Cache {
-    id        Int      @id @default(autoincrement())
-    key       String   @unique
-    value     String
-    createdAt DateTime @default(now())
-    updatedAt DateTime @updatedAt
+  id        Int      @id @default(autoincrement())
+  key       String   @unique
+  value     String
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 }
 
 model McpToken {
-    id         Int      @id @default(autoincrement())
-    tokenHash  String
-    createdAt  DateTime @default(now())
-    lastUsedAt DateTime?
-    revokedAt  DateTime?
+  id         Int       @id @default(autoincrement())
+  tokenHash  String
+  createdAt  DateTime  @default(now())
+  lastUsedAt DateTime?
+  revokedAt  DateTime?
 
-    @@index([revokedAt, createdAt])
+  @@index([revokedAt, createdAt])
 }
 
 model Note {
-    id                   Int        @id @default(autoincrement())
-    title                String
-    content              String
-    searchableText       String     @default("")
-    searchableTextVersion Int       @default(0)
-    createdAt            DateTime   @default(now())
-    updatedAt            DateTime   @updatedAt
-    pinned               Boolean    @default(false)
-    order                Int        @default(0)
-    layout               NoteLayout @default(wide)
-    tags                 Tag[]      @relation("NoteToTag")
-    reminders            Reminder[] @relation("NoteToReminder")
-    snapshots            NoteSnapshot[]
-    properties           NoteProperty[]
+  id                    Int            @id @default(autoincrement())
+  title                 String
+  content               String
+  searchableText        String         @default("")
+  searchableTextVersion Int            @default(0)
+  createdAt             DateTime       @default(now())
+  updatedAt             DateTime       @updatedAt
+  pinned                Boolean        @default(false)
+  order                 Int            @default(0)
+  layout                NoteLayout     @default(wide)
+  tags                  Tag[]          @relation("NoteToTag")
+  reminders             Reminder[]     @relation("NoteToReminder")
+  snapshots             NoteSnapshot[]
+  properties            NoteProperty[]
 
-    @@index([updatedAt, id])
-    @@index([createdAt, id])
-    @@index([pinned, updatedAt, id])
+  @@index([updatedAt, id])
+  @@index([createdAt, id])
+  @@index([pinned, updatedAt, id])
 }
 
 model PropertyDefinition {
-    id         Int               @id @default(autoincrement())
-    key        String            @unique
-    name       String
-    valueType  PropertyValueType
-    createdAt  DateTime          @default(now())
-    updatedAt  DateTime          @updatedAt
-    options    PropertyOption[]
-    properties NoteProperty[]
+  id         Int               @id @default(autoincrement())
+  key        String            @unique
+  name       String
+  valueType  PropertyValueType
+  createdAt  DateTime          @default(now())
+  updatedAt  DateTime          @updatedAt
+  options    PropertyOption[]
+  properties NoteProperty[]
 }
 
-
 model PropertyOption {
-    id                   Int                @id @default(autoincrement())
-    propertyDefinitionId Int
-    definition           PropertyDefinition @relation(fields: [propertyDefinitionId], references: [id], onDelete: Cascade)
-    label                String
-    value                String
-    color                String?
-    order                Int                @default(0)
-    properties           NoteProperty[]
-    createdAt            DateTime           @default(now())
-    updatedAt            DateTime           @updatedAt
+  id                   Int                @id @default(autoincrement())
+  propertyDefinitionId Int
+  definition           PropertyDefinition @relation(fields: [propertyDefinitionId], references: [id], onDelete: Cascade)
+  label                String
+  value                String
+  color                String?
+  order                Int                @default(0)
+  properties           NoteProperty[]
+  createdAt            DateTime           @default(now())
+  updatedAt            DateTime           @updatedAt
 
-    @@unique([propertyDefinitionId, value])
-    @@index([propertyDefinitionId, order])
+  @@unique([propertyDefinitionId, value])
+  @@index([propertyDefinitionId, order])
 }
 
 model NoteProperty {
-    id                   Int                @id @default(autoincrement())
-    noteId               Int
-    propertyDefinitionId Int
-    note                 Note               @relation(fields: [noteId], references: [id], onDelete: Cascade)
-    definition           PropertyDefinition @relation(fields: [propertyDefinitionId], references: [id], onDelete: Cascade)
-    optionId             Int?
-    option               PropertyOption?    @relation(fields: [optionId], references: [id], onDelete: SetNull)
-    textValue            String?
-    textValueNormalized  String?
-    numberValue          Float?
-    dateValue            DateTime?
-    boolValue            Boolean?
-    createdAt            DateTime           @default(now())
-    updatedAt            DateTime           @updatedAt
+  id                   Int                @id @default(autoincrement())
+  noteId               Int
+  propertyDefinitionId Int
+  note                 Note               @relation(fields: [noteId], references: [id], onDelete: Cascade)
+  definition           PropertyDefinition @relation(fields: [propertyDefinitionId], references: [id], onDelete: Cascade)
+  optionId             Int?
+  option               PropertyOption?    @relation(fields: [optionId], references: [id], onDelete: SetNull)
+  textValue            String?
+  textValueNormalized  String?
+  numberValue          Float?
+  dateValue            DateTime?
+  boolValue            Boolean?
+  createdAt            DateTime           @default(now())
+  updatedAt            DateTime           @updatedAt
 
-    @@unique([noteId, propertyDefinitionId])
-    @@index([propertyDefinitionId, noteId])
-    @@index([propertyDefinitionId, textValueNormalized, noteId])
-    @@index([propertyDefinitionId, numberValue, noteId])
-    @@index([propertyDefinitionId, dateValue, noteId])
-    @@index([propertyDefinitionId, boolValue, noteId])
-    @@index([propertyDefinitionId, optionId, noteId])
+  @@unique([noteId, propertyDefinitionId])
+  @@index([propertyDefinitionId, noteId])
+  @@index([propertyDefinitionId, textValueNormalized, noteId])
+  @@index([propertyDefinitionId, numberValue, noteId])
+  @@index([propertyDefinitionId, dateValue, noteId])
+  @@index([propertyDefinitionId, boolValue, noteId])
+  @@index([propertyDefinitionId, optionId, noteId])
 }
 
 model NoteSnapshot {
-    id            Int        @id @default(autoincrement())
-    noteId        Int
-    note          Note       @relation(fields: [noteId], references: [id], onDelete: Cascade)
-    title         String
-    payload       String
-    editSessionId String?
-    meta          String?
-    createdAt     DateTime   @default(now())
+  id            Int      @id @default(autoincrement())
+  noteId        Int
+  note          Note     @relation(fields: [noteId], references: [id], onDelete: Cascade)
+  title         String
+  payload       String
+  editSessionId String?
+  meta          String?
+  createdAt     DateTime @default(now())
 
-    @@index([noteId, createdAt])
-    @@unique([noteId, editSessionId])
+  @@unique([noteId, editSessionId])
+  @@index([noteId, createdAt])
 }
 
 model DeletedNote {
-    id         Int              @id
-    title      String
-    content    String
-    createdAt  DateTime
-    updatedAt  DateTime
-    deletedAt  DateTime         @default(now())
-    pinned     Boolean          @default(false)
-    order      Int              @default(0)
-    layout     NoteLayout       @default(wide)
-    tags       DeletedNoteTag[]
-    reminders  DeletedReminder[]
-    properties DeletedNoteProperty[]
+  id         Int                   @id
+  title      String
+  content    String
+  createdAt  DateTime
+  updatedAt  DateTime
+  deletedAt  DateTime              @default(now())
+  pinned     Boolean               @default(false)
+  order      Int                   @default(0)
+  layout     NoteLayout            @default(wide)
+  tags       DeletedNoteTag[]
+  reminders  DeletedReminder[]
+  properties DeletedNoteProperty[]
 
-    @@index([deletedAt, updatedAt])
+  @@index([deletedAt, updatedAt])
 }
 
 model DeletedNoteProperty {
-    id                  Int               @id @default(autoincrement())
-    deletedNoteId       Int
-    deletedNote         DeletedNote       @relation(fields: [deletedNoteId], references: [id], onDelete: Cascade)
-    key                 String
-    name                String
-    valueType           PropertyValueType
-    textValue           String?
-    textValueNormalized String?
-    numberValue         Float?
-    dateValue           DateTime?
-    boolValue           Boolean?
-    optionValue         String?
-    optionLabel         String?
-    optionColor         String?
-    createdAt           DateTime
-    updatedAt           DateTime
+  id                  Int               @id @default(autoincrement())
+  deletedNoteId       Int
+  deletedNote         DeletedNote       @relation(fields: [deletedNoteId], references: [id], onDelete: Cascade)
+  key                 String
+  name                String
+  valueType           PropertyValueType
+  textValue           String?
+  textValueNormalized String?
+  numberValue         Float?
+  dateValue           DateTime?
+  boolValue           Boolean?
+  optionValue         String?
+  optionLabel         String?
+  optionColor         String?
+  createdAt           DateTime
+  updatedAt           DateTime
 
-    @@unique([deletedNoteId, key])
-    @@index([deletedNoteId])
+  @@unique([deletedNoteId, key])
+  @@index([deletedNoteId])
 }
 
 model DeletedNoteTag {
-    id            Int         @id @default(autoincrement())
-    deletedNoteId Int
-    deletedNote   DeletedNote @relation(fields: [deletedNoteId], references: [id], onDelete: Cascade)
-    name          String
+  id            Int         @id @default(autoincrement())
+  deletedNoteId Int
+  deletedNote   DeletedNote @relation(fields: [deletedNoteId], references: [id], onDelete: Cascade)
+  name          String
 
-    @@index([deletedNoteId])
+  @@index([deletedNoteId])
 }
 
 model DeletedReminder {
-    id               Int              @id @default(autoincrement())
-    deletedNoteId    Int
-    deletedNote      DeletedNote      @relation(fields: [deletedNoteId], references: [id], onDelete: Cascade)
-    originalId       Int?
-    reminderDate     DateTime
-    completed        Boolean          @default(false)
-    priority         ReminderPriority @default(medium)
-    content          String?
-    createdAt        DateTime
-    updatedAt        DateTime
+  id            Int              @id @default(autoincrement())
+  deletedNoteId Int
+  deletedNote   DeletedNote      @relation(fields: [deletedNoteId], references: [id], onDelete: Cascade)
+  originalId    Int?
+  reminderDate  DateTime
+  completed     Boolean          @default(false)
+  priority      ReminderPriority @default(medium)
+  content       String?
+  createdAt     DateTime
+  updatedAt     DateTime
 
-    @@index([deletedNoteId])
+  @@index([deletedNoteId])
 }
 
 model Image {
-    id        Int      @id @default(autoincrement())
-    url       String
-    hash      String   @unique
-    createdAt DateTime @default(now())
-    updatedAt DateTime @updatedAt
+  id        Int      @id @default(autoincrement())
+  url       String
+  hash      String   @unique
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 }
 
 model Tag {
-    id        Int      @id @default(autoincrement())
-    name      String   @unique
-    createdAt DateTime @default(now())
-    updatedAt DateTime @updatedAt
-    notes     Note[]   @relation("NoteToTag")
+  id        Int      @id @default(autoincrement())
+  name      String   @unique
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  notes     Note[]   @relation("NoteToTag")
 }
 
 enum ReminderPriority {
-    low
-    medium
-    high
+  low
+  medium
+  high
 }
 
 enum NoteLayout {
-    narrow
-    wide
-    full
+  narrow
+  wide
+  full
 }
 
 enum PropertyValueType {
-    text
-    number
-    date
-    boolean
-    select
+  text
+  number
+  date
+  boolean
+  select
 }
 
 model Reminder {
-    id           Int              @id @default(autoincrement())
-    noteId       Int
-    note         Note             @relation("NoteToReminder", fields: [noteId], references: [id], onDelete: Cascade)
-    reminderDate DateTime
-    completed    Boolean          @default(false)
-    priority     ReminderPriority @default(medium)
-    content      String?
-    createdAt    DateTime         @default(now())
-    updatedAt    DateTime         @updatedAt
+  id           Int              @id @default(autoincrement())
+  noteId       Int
+  note         Note             @relation("NoteToReminder", fields: [noteId], references: [id], onDelete: Cascade)
+  reminderDate DateTime
+  completed    Boolean          @default(false)
+  priority     ReminderPriority @default(medium)
+  content      String?
+  createdAt    DateTime         @default(now())
+  updatedAt    DateTime         @updatedAt
 }
 
 model Placeholder {
-    id          Int      @id @default(autoincrement())
-    name        String   @unique
-    template    String
-    replacement String
-    createdAt   DateTime @default(now())
-    updatedAt   DateTime @updatedAt
+  id          Int      @id @default(autoincrement())
+  name        String   @unique
+  template    String
+  replacement String
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
 }
 
 model ViewWorkspace {
-    id         Int      @id
-    activeTabId Int?
-    activeTab  ViewTab? @relation("ActiveViewTab", fields: [activeTabId], references: [id], onDelete: SetNull)
-    createdAt  DateTime @default(now())
-    updatedAt  DateTime @updatedAt
+  id          Int      @id
+  activeTabId Int?
+  activeTab   ViewTab? @relation("ActiveViewTab", fields: [activeTabId], references: [id], onDelete: SetNull)
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
 }
 
 model ViewTab {
-    id               Int             @id @default(autoincrement())
-    title            String
-    order            Int             @default(0)
-    createdAt        DateTime        @default(now())
-    updatedAt        DateTime        @updatedAt
-    sections         ViewSection[]
-    activeWorkspaces ViewWorkspace[] @relation("ActiveViewTab")
+  id               Int             @id @default(autoincrement())
+  title            String
+  order            Int             @default(0)
+  createdAt        DateTime        @default(now())
+  updatedAt        DateTime        @updatedAt
+  sections         ViewSection[]
+  activeWorkspaces ViewWorkspace[] @relation("ActiveViewTab")
 
-    @@index([order, createdAt])
+  @@index([order, createdAt])
 }
 
 model ViewSection {
-    id        Int              @id @default(autoincrement())
-    tabId     Int
-    tab       ViewTab          @relation(fields: [tabId], references: [id], onDelete: Cascade)
-    title     String
-    mode      ViewTagMatchMode @default(and)
-    limit     Int              @default(5)
-    order     Int              @default(0)
-    createdAt DateTime         @default(now())
-    updatedAt DateTime         @updatedAt
-    tags      ViewSectionTag[]
+  id          Int              @id @default(autoincrement())
+  tabId       Int
+  tab         ViewTab          @relation(fields: [tabId], references: [id], onDelete: Cascade)
+  title       String
+  displayType ViewDisplayType  @default(list)
+  query       String?
+  mode        ViewTagMatchMode @default(and)
+  limit       Int              @default(5)
+  order       Int              @default(0)
+  createdAt   DateTime         @default(now())
+  updatedAt   DateTime         @updatedAt
+  tags        ViewSectionTag[]
 
-    @@index([tabId, order, createdAt])
+  @@index([tabId, order, createdAt])
 }
 
 model ViewSectionTag {
-    id        Int         @id @default(autoincrement())
-    sectionId Int
-    section   ViewSection @relation(fields: [sectionId], references: [id], onDelete: Cascade)
-    name      String
-    order     Int         @default(0)
-    createdAt DateTime    @default(now())
-    updatedAt DateTime    @updatedAt
+  id        Int         @id @default(autoincrement())
+  sectionId Int
+  section   ViewSection @relation(fields: [sectionId], references: [id], onDelete: Cascade)
+  name      String
+  order     Int         @default(0)
+  createdAt DateTime    @default(now())
+  updatedAt DateTime    @updatedAt
 
-    @@index([sectionId, order, createdAt])
+  @@index([sectionId, order, createdAt])
 }
 
 enum ViewTagMatchMode {
-    and
-    or
+  and
+  or
+}
+
+enum ViewDisplayType {
+  list
+  calendar
 }

--- a/packages/server/src/features/view/graphql/view.type-defs.ts
+++ b/packages/server/src/features/view/graphql/view.type-defs.ts
@@ -17,16 +17,63 @@ export const viewType = gql`
         id: ID!
         tabId: ID!
         title: String!
+        displayType: ViewDisplayType!
         tagNames: [String!]!
         mode: TagMatchMode!
+        propertyFilters: [ViewPropertyFilter!]!
+        sortBy: ViewSortBy!
+        sortOrder: ViewSortOrder!
         limit: Int!
         order: Int!
     }
 
+    type ViewPropertyFilter {
+        key: String!
+        name: String!
+        valueType: NotePropertyValueType!
+        operator: ViewPropertyFilterOperator!
+        value: String
+    }
+
+    enum ViewDisplayType {
+        list
+        calendar
+    }
+
+    enum ViewPropertyFilterOperator {
+        equals
+        before
+        after
+        exists
+        notExists
+    }
+
+    enum ViewSortBy {
+        updatedAt
+        createdAt
+        title
+    }
+
+    enum ViewSortOrder {
+        asc
+        desc
+    }
+
+    input ViewPropertyFilterInput {
+        key: String!
+        valueType: NotePropertyValueType!
+        operator: ViewPropertyFilterOperator!
+        value: String
+    }
+
     input ViewSectionInput {
         title: String
-        tagNames: [String!]!
+        displayType: ViewDisplayType
+        tagNames: [String!]
         mode: TagMatchMode
+        propertyFilters: [ViewPropertyFilterInput!]
+        sortBy: ViewSortBy
+        sortOrder: ViewSortOrder
         limit: Int
     }
 `;

--- a/packages/server/src/features/view/services/workspace.test.ts
+++ b/packages/server/src/features/view/services/workspace.test.ts
@@ -2,11 +2,16 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import {
+    buildPropertyFilterWhere,
+    buildViewSectionWhere,
     clampViewSectionLimit,
+    normalizeViewPropertyFilters,
     normalizeViewSectionInput,
     normalizeViewTabTitle,
     normalizeViewTagNames,
     pickNextActiveViewTabId,
+    type ViewPropertyFilterRecord,
+    type ViewSectionRecord,
 } from './workspace.js';
 
 test('normalizeViewTagNames trims values and canonicalizes plain or hash-prefixed tags', () => {
@@ -27,19 +32,232 @@ test('normalizeViewSectionInput derives a default title and clamps invalid limit
         }),
         {
             title: '@project + @review',
+            displayType: 'list',
             tagNames: ['@project', '@review'],
             mode: 'or',
+            propertyFilters: [],
+            sortBy: 'updatedAt',
+            sortOrder: 'desc',
             limit: 20,
         },
     );
 });
 
-test('normalizeViewSectionInput rejects sections without usable tags', () => {
-    assert.throws(() =>
+test('normalizeViewSectionInput allows all-note views without filters', () => {
+    assert.deepEqual(
         normalizeViewSectionInput({
-            title: 'Inbox',
+            title: '',
             tagNames: ['   ', ''],
         }),
+        {
+            title: 'All notes',
+            displayType: 'list',
+            tagNames: [],
+            mode: 'and',
+            propertyFilters: [],
+            sortBy: 'updatedAt',
+            sortOrder: 'desc',
+            limit: 5,
+        },
+    );
+});
+
+test('normalizeViewPropertyFilters validates typed filter values', () => {
+    assert.deepEqual(
+        normalizeViewPropertyFilters([{ key: ' State ', valueType: 'select', operator: 'equals', value: 'todo' }]),
+        [
+            {
+                key: 'state',
+                name: 'state',
+                valueType: 'select',
+                operator: 'equals',
+                value: 'todo',
+            },
+        ],
+    );
+
+    assert.throws(() =>
+        normalizeViewPropertyFilters([{ key: 'due', valueType: 'date', operator: 'equals', value: '2026-99-99' }]),
+    );
+});
+
+test('buildPropertyFilterWhere maps property filters to note relation filters', () => {
+    assert.deepEqual(
+        buildPropertyFilterWhere({
+            key: 'state',
+            name: 'State',
+            valueType: 'select',
+            operator: 'equals',
+            value: 'Todo',
+        }),
+        {
+            properties: {
+                some: {
+                    definition: {
+                        is: {
+                            key: 'state',
+                        },
+                    },
+                    option: {
+                        is: {
+                            value: 'todo',
+                        },
+                    },
+                },
+            },
+        },
+    );
+});
+
+test('buildPropertyFilterWhere maps existence operators', () => {
+    const baseFilter: ViewPropertyFilterRecord = {
+        key: 'state',
+        name: 'State',
+        valueType: 'select',
+        operator: 'exists',
+        value: null,
+    };
+
+    assert.deepEqual(buildPropertyFilterWhere(baseFilter), {
+        properties: {
+            some: {
+                definition: {
+                    is: {
+                        key: 'state',
+                    },
+                },
+            },
+        },
+    });
+
+    assert.deepEqual(buildPropertyFilterWhere({ ...baseFilter, operator: 'notExists' }), {
+        properties: {
+            none: {
+                definition: {
+                    is: {
+                        key: 'state',
+                    },
+                },
+            },
+        },
+    });
+});
+
+test('buildPropertyFilterWhere maps number and date range operators', () => {
+    assert.deepEqual(
+        buildPropertyFilterWhere({
+            key: 'priority',
+            name: 'Priority',
+            valueType: 'number',
+            operator: 'before',
+            value: '3',
+        }),
+        {
+            properties: {
+                some: {
+                    definition: {
+                        is: {
+                            key: 'priority',
+                        },
+                    },
+                    numberValue: {
+                        lt: 3,
+                    },
+                },
+            },
+        },
+    );
+
+    assert.deepEqual(
+        buildPropertyFilterWhere({
+            key: 'due',
+            name: 'Due',
+            valueType: 'date',
+            operator: 'after',
+            value: '2026-05-31',
+        }),
+        {
+            properties: {
+                some: {
+                    definition: {
+                        is: {
+                            key: 'due',
+                        },
+                    },
+                    dateValue: {
+                        gt: new Date('2026-05-31T00:00:00.000Z'),
+                    },
+                },
+            },
+        },
+    );
+});
+
+const createSectionRecord = (patch: Partial<ViewSectionRecord> = {}): ViewSectionRecord => ({
+    id: '1',
+    tabId: '1',
+    title: 'Doing',
+    displayType: 'list',
+    tagNames: [],
+    mode: 'and',
+    propertyFilters: [],
+    sortBy: 'updatedAt',
+    sortOrder: 'desc',
+    limit: 5,
+    order: 0,
+    ...patch,
+});
+
+test('buildViewSectionWhere returns an open query for all-note views', () => {
+    assert.deepEqual(buildViewSectionWhere(createSectionRecord()), {});
+});
+
+test('buildViewSectionWhere combines tag and property filters with AND', () => {
+    assert.deepEqual(
+        buildViewSectionWhere(
+            createSectionRecord({
+                tagNames: ['@ocean', '@ai'],
+                mode: 'or',
+                propertyFilters: [
+                    {
+                        key: 'state',
+                        name: 'State',
+                        valueType: 'select',
+                        operator: 'equals',
+                        value: 'doing',
+                    },
+                ],
+            }),
+        ),
+        {
+            AND: [
+                {
+                    tags: {
+                        some: {
+                            name: {
+                                in: ['@ocean', '@ai'],
+                            },
+                        },
+                    },
+                },
+                {
+                    properties: {
+                        some: {
+                            definition: {
+                                is: {
+                                    key: 'state',
+                                },
+                            },
+                            option: {
+                                is: {
+                                    value: 'doing',
+                                },
+                            },
+                        },
+                    },
+                },
+            ],
+        },
     );
 });
 

--- a/packages/server/src/features/view/services/workspace.ts
+++ b/packages/server/src/features/view/services/workspace.ts
@@ -1,15 +1,32 @@
-import type { Note, Prisma } from '@prisma/client';
+import type { Note, Prisma, PropertyValueType } from '@prisma/client';
+import { InvalidNotePropertyInputError, normalizePropertyKey } from '~/features/note/services/properties.js';
 import { buildNoteTagNamesWhere, type NoteTagMatchMode } from '~/features/note/services/tag-filter.js';
 import models from '~/models.js';
 
 export type ViewTagMatchMode = NoteTagMatchMode;
+export type ViewDisplayType = 'list' | 'calendar';
+export type ViewPropertyFilterOperator = 'equals' | 'before' | 'after' | 'exists' | 'notExists';
+export type ViewSortBy = 'updatedAt' | 'createdAt' | 'title';
+export type ViewSortOrder = 'asc' | 'desc';
+
+export interface ViewPropertyFilterRecord {
+    key: string;
+    name: string;
+    valueType: PropertyValueType;
+    operator: ViewPropertyFilterOperator;
+    value: string | null;
+}
 
 export interface ViewSectionRecord {
     id: string;
     tabId: string;
     title: string;
+    displayType: ViewDisplayType;
     tagNames: string[];
     mode: ViewTagMatchMode;
+    propertyFilters: ViewPropertyFilterRecord[];
+    sortBy: ViewSortBy;
+    sortOrder: ViewSortOrder;
     limit: number;
     order: number;
 }
@@ -28,9 +45,20 @@ export interface ViewWorkspaceRecord {
 
 export interface ViewSectionInput {
     title?: string;
-    tagNames: string[];
+    displayType?: ViewDisplayType;
+    tagNames?: string[] | null;
     mode?: ViewTagMatchMode;
+    propertyFilters?: ViewPropertyFilterInput[] | null;
+    sortBy?: ViewSortBy;
+    sortOrder?: ViewSortOrder;
     limit?: number;
+}
+
+export interface ViewPropertyFilterInput {
+    key: string;
+    operator: ViewPropertyFilterOperator;
+    value?: string | null;
+    valueType?: PropertyValueType | null;
 }
 
 export interface ViewSectionNotesResult {
@@ -43,6 +71,10 @@ const VIEW_WORKSPACE_ID = 1;
 export const DEFAULT_VIEW_SECTION_LIMIT = 5;
 export const MIN_VIEW_SECTION_LIMIT = 1;
 export const MAX_VIEW_SECTION_LIMIT = 20;
+const MAX_VIEW_PROPERTY_FILTERS = 10;
+const DEFAULT_VIEW_DISPLAY_TYPE: ViewDisplayType = 'list';
+const DEFAULT_VIEW_SORT_BY: ViewSortBy = 'updatedAt';
+const DEFAULT_VIEW_SORT_ORDER: ViewSortOrder = 'desc';
 
 type ViewDbClient = typeof models | Prisma.TransactionClient;
 
@@ -91,6 +123,151 @@ export const normalizeViewTagNames = (values: string[]) => {
     return Array.from(new Set(normalizedTagNames.map(normalizeTagName).filter(Boolean)));
 };
 
+interface StoredViewQuery {
+    propertyFilters?: ViewPropertyFilterRecord[];
+    sortBy?: ViewSortBy;
+    sortOrder?: ViewSortOrder;
+}
+
+const isViewPropertyFilterOperator = (value: unknown): value is ViewPropertyFilterOperator => {
+    return value === 'equals' || value === 'before' || value === 'after' || value === 'exists' || value === 'notExists';
+};
+
+const isPropertyValueType = (value: unknown): value is PropertyValueType => {
+    return value === 'text' || value === 'number' || value === 'date' || value === 'boolean' || value === 'select';
+};
+
+const normalizeViewDisplayType = (value: ViewDisplayType | undefined): ViewDisplayType => {
+    return value === 'calendar' ? 'calendar' : DEFAULT_VIEW_DISPLAY_TYPE;
+};
+
+const normalizeViewSortBy = (value: ViewSortBy | undefined): ViewSortBy => {
+    return value === 'createdAt' || value === 'title' ? value : DEFAULT_VIEW_SORT_BY;
+};
+
+const normalizeViewSortOrder = (value: ViewSortOrder | undefined): ViewSortOrder => {
+    return value === 'asc' ? 'asc' : DEFAULT_VIEW_SORT_ORDER;
+};
+
+const normalizeFilterValue = ({
+    value,
+    valueType,
+    operator,
+}: {
+    value?: string | null;
+    valueType: PropertyValueType;
+    operator: ViewPropertyFilterOperator;
+}) => {
+    if (operator === 'exists' || operator === 'notExists') {
+        return null;
+    }
+
+    const normalizedValue = String(value ?? '').trim();
+
+    if (!normalizedValue) {
+        throw new InvalidNotePropertyInputError('Property filter value is required.');
+    }
+
+    if (valueType === 'number' && !Number.isFinite(Number(normalizedValue))) {
+        throw new InvalidNotePropertyInputError('Number property filter value must be finite.');
+    }
+
+    if (valueType === 'boolean' && normalizedValue !== 'true' && normalizedValue !== 'false') {
+        throw new InvalidNotePropertyInputError('Boolean property filter value must be true or false.');
+    }
+
+    if (valueType === 'date') {
+        if (!/^\d{4}-\d{2}-\d{2}$/.test(normalizedValue)) {
+            throw new InvalidNotePropertyInputError('Date property filter values must use YYYY-MM-DD.');
+        }
+
+        const date = new Date(`${normalizedValue}T00:00:00.000Z`);
+
+        if (Number.isNaN(date.getTime()) || date.toISOString().slice(0, 10) !== normalizedValue) {
+            throw new InvalidNotePropertyInputError('Date property filter value is invalid.');
+        }
+    }
+
+    if ((operator === 'before' || operator === 'after') && valueType !== 'date' && valueType !== 'number') {
+        throw new InvalidNotePropertyInputError('Before and after filters require date or number properties.');
+    }
+
+    return normalizedValue;
+};
+
+export const normalizeViewPropertyFilters = (filters: ViewPropertyFilterInput[] | null | undefined) => {
+    const normalizedFilters = filters ?? [];
+
+    if (normalizedFilters.length > MAX_VIEW_PROPERTY_FILTERS) {
+        throw new InvalidNotePropertyInputError(`A view can have up to ${MAX_VIEW_PROPERTY_FILTERS} property filters.`);
+    }
+
+    return normalizedFilters
+        .map((filter): ViewPropertyFilterRecord | null => {
+            const key = normalizePropertyKey(filter.key);
+            const valueType = filter.valueType;
+            const operator = filter.operator;
+
+            if (!isPropertyValueType(valueType)) {
+                throw new InvalidNotePropertyInputError('Property filter value type is required.');
+            }
+
+            if (!isViewPropertyFilterOperator(operator)) {
+                throw new InvalidNotePropertyInputError('Property filter operator is invalid.');
+            }
+
+            const storedName = (filter as { name?: unknown }).name;
+            const name = typeof storedName === 'string' && storedName.trim() ? storedName.trim() : key;
+
+            return {
+                key,
+                name,
+                valueType,
+                operator,
+                value: normalizeFilterValue({
+                    value: filter.value,
+                    valueType,
+                    operator,
+                }),
+            };
+        })
+        .filter((filter): filter is ViewPropertyFilterRecord => filter !== null);
+};
+
+const parseStoredViewQuery = (value: string | null): Required<StoredViewQuery> => {
+    if (!value) {
+        return {
+            propertyFilters: [],
+            sortBy: DEFAULT_VIEW_SORT_BY,
+            sortOrder: DEFAULT_VIEW_SORT_ORDER,
+        };
+    }
+
+    try {
+        const parsed = JSON.parse(value) as Partial<StoredViewQuery>;
+
+        return {
+            propertyFilters: normalizeViewPropertyFilters(parsed.propertyFilters ?? []),
+            sortBy: normalizeViewSortBy(parsed.sortBy),
+            sortOrder: normalizeViewSortOrder(parsed.sortOrder),
+        };
+    } catch {
+        return {
+            propertyFilters: [],
+            sortBy: DEFAULT_VIEW_SORT_BY,
+            sortOrder: DEFAULT_VIEW_SORT_ORDER,
+        };
+    }
+};
+
+const serializeStoredViewQuery = ({ propertyFilters, sortBy, sortOrder }: Required<StoredViewQuery>) => {
+    return JSON.stringify({
+        propertyFilters,
+        sortBy,
+        sortOrder,
+    });
+};
+
 export const clampViewSectionLimit = (value: number | undefined) => {
     const numericValue = typeof value === 'number' ? value : Number.NaN;
 
@@ -107,32 +284,45 @@ export const normalizeViewTabTitle = (title: string) => {
     return trimmedTitle || 'Untitled View';
 };
 
-const buildDefaultSectionTitle = (tagNames: string[]) => {
-    if (tagNames.length === 0) {
-        return 'Tagged notes';
+const buildDefaultSectionTitle = (tagNames: string[], propertyFilters: ViewPropertyFilterRecord[]) => {
+    if (tagNames.length > 0) {
+        return tagNames.slice(0, 2).join(' + ');
     }
 
-    return tagNames.slice(0, 2).join(' + ');
+    if (propertyFilters.length > 0) {
+        return propertyFilters
+            .slice(0, 2)
+            .map((filter) => filter.name)
+            .join(' + ');
+    }
+
+    return 'All notes';
 };
 
 export const normalizeViewSectionInput = (input: ViewSectionInput) => {
-    const tagNames = normalizeViewTagNames(input.tagNames);
-
-    if (tagNames.length === 0) {
-        throw new Error('A view section requires at least one tag.');
-    }
-
+    const tagNames = normalizeViewTagNames(input.tagNames ?? []);
+    const propertyFilters = normalizeViewPropertyFilters(input.propertyFilters);
     const trimmedTitle = input.title?.trim() ?? '';
+    const sortBy = normalizeViewSortBy(input.sortBy);
+    const sortOrder = normalizeViewSortOrder(input.sortOrder);
 
     return {
-        title: trimmedTitle || buildDefaultSectionTitle(tagNames),
+        title: trimmedTitle || buildDefaultSectionTitle(tagNames, propertyFilters),
+        displayType: normalizeViewDisplayType(input.displayType),
         tagNames,
         mode: input.mode === 'or' ? 'or' : 'and',
+        propertyFilters,
+        sortBy,
+        sortOrder,
         limit: clampViewSectionLimit(input.limit),
     } satisfies {
         title: string;
+        displayType: ViewDisplayType;
         tagNames: string[];
         mode: ViewTagMatchMode;
+        propertyFilters: ViewPropertyFilterRecord[];
+        sortBy: ViewSortBy;
+        sortOrder: ViewSortOrder;
         limit: number;
     };
 };
@@ -180,15 +370,23 @@ const parseViewId = (id: string) => {
     return numericId;
 };
 
-const serializeViewSection = (section: DbViewSection): ViewSectionRecord => ({
-    id: String(section.id),
-    tabId: String(section.tabId),
-    title: section.title,
-    tagNames: section.tags.map((tag) => tag.name),
-    mode: section.mode as ViewTagMatchMode,
-    limit: section.limit,
-    order: section.order,
-});
+const serializeViewSection = (section: DbViewSection): ViewSectionRecord => {
+    const query = parseStoredViewQuery(section.query);
+
+    return {
+        id: String(section.id),
+        tabId: String(section.tabId),
+        title: section.title,
+        displayType: normalizeViewDisplayType(section.displayType as ViewDisplayType),
+        tagNames: section.tags.map((tag) => tag.name),
+        mode: section.mode as ViewTagMatchMode,
+        propertyFilters: query.propertyFilters,
+        sortBy: query.sortBy,
+        sortOrder: query.sortOrder,
+        limit: section.limit,
+        order: section.order,
+    };
+};
 
 const serializeViewTab = (tab: DbViewTab): ViewTabRecord => ({
     id: String(tab.id),
@@ -235,6 +433,45 @@ const readViewSection = async (db: ViewDbClient, id: number): Promise<ViewSectio
     });
 
     return section ? serializeViewSection(section) : null;
+};
+
+const hydratePropertyFilters = async (db: ViewDbClient, filters: ViewPropertyFilterRecord[]) => {
+    if (filters.length === 0) {
+        return [];
+    }
+
+    const definitions = await db.propertyDefinition.findMany({
+        where: { key: { in: filters.map((filter) => filter.key) } },
+        select: { key: true, name: true, valueType: true },
+    });
+    const definitionByKey = new Map(definitions.map((definition) => [definition.key, definition]));
+
+    return filters.map((filter) => {
+        const definition = definitionByKey.get(filter.key);
+
+        if (!definition) {
+            throw new InvalidNotePropertyInputError(`Property ${filter.key} is not defined.`);
+        }
+
+        if (definition.valueType !== filter.valueType) {
+            throw new InvalidNotePropertyInputError(`Property ${filter.key} uses ${definition.valueType} values.`);
+        }
+
+        return {
+            ...filter,
+            name: definition.name,
+        };
+    });
+};
+
+const buildStoredViewQuery = async (db: ViewDbClient, section: ReturnType<typeof normalizeViewSectionInput>) => {
+    const propertyFilters = await hydratePropertyFilters(db, section.propertyFilters);
+
+    return serializeStoredViewQuery({
+        propertyFilters,
+        sortBy: section.sortBy,
+        sortOrder: section.sortOrder,
+    });
 };
 
 const getNextTabOrder = async (db: ViewDbClient) => {
@@ -297,6 +534,105 @@ export const getViewSectionById = async (id: string) => {
     return readViewSection(models, parseViewId(id));
 };
 
+const normalizeSelectFilterValue = (value: string) => {
+    return value.trim().toLowerCase().replace(/\s+/g, '-');
+};
+
+const buildPropertyFilterValueWhere = (filter: ViewPropertyFilterRecord): Prisma.NotePropertyWhereInput => {
+    switch (filter.valueType) {
+        case 'number': {
+            const numberValue = Number(filter.value);
+
+            if (filter.operator === 'before') {
+                return { numberValue: { lt: numberValue } };
+            }
+
+            if (filter.operator === 'after') {
+                return { numberValue: { gt: numberValue } };
+            }
+
+            return { numberValue };
+        }
+        case 'date': {
+            const dateValue = new Date(`${filter.value}T00:00:00.000Z`);
+
+            if (filter.operator === 'before') {
+                return { dateValue: { lt: dateValue } };
+            }
+
+            if (filter.operator === 'after') {
+                return { dateValue: { gt: dateValue } };
+            }
+
+            return { dateValue };
+        }
+        case 'boolean':
+            return { boolValue: filter.value === 'true' };
+        case 'select':
+            return { option: { is: { value: normalizeSelectFilterValue(filter.value ?? '') } } };
+        case 'text':
+        default:
+            return { textValueNormalized: filter.value?.toLowerCase() ?? '' };
+    }
+};
+
+export const buildPropertyFilterWhere = (filter: ViewPropertyFilterRecord): Prisma.NoteWhereInput => {
+    const definitionWhere = {
+        definition: {
+            is: {
+                key: filter.key,
+            },
+        },
+    } satisfies Prisma.NotePropertyWhereInput;
+
+    if (filter.operator === 'notExists') {
+        return {
+            properties: {
+                none: definitionWhere,
+            },
+        };
+    }
+
+    if (filter.operator === 'exists') {
+        return {
+            properties: {
+                some: definitionWhere,
+            },
+        };
+    }
+
+    return {
+        properties: {
+            some: {
+                ...definitionWhere,
+                ...buildPropertyFilterValueWhere(filter),
+            },
+        },
+    };
+};
+
+export const buildViewSectionWhere = (section: ViewSectionRecord): Prisma.NoteWhereInput => {
+    const clauses: Prisma.NoteWhereInput[] = [];
+
+    if (section.tagNames.length > 0) {
+        clauses.push(buildNoteTagNamesWhere(section.tagNames, section.mode as NoteTagMatchMode));
+    }
+
+    for (const filter of section.propertyFilters) {
+        clauses.push(buildPropertyFilterWhere(filter));
+    }
+
+    if (clauses.length === 0) {
+        return {};
+    }
+
+    return { AND: clauses };
+};
+
+const buildViewSectionOrderBy = (section: ViewSectionRecord): Prisma.NoteOrderByWithRelationInput[] => {
+    return [{ [section.sortBy]: section.sortOrder }, { id: 'asc' }];
+};
+
 export const getViewSectionNotes = async (
     id: string,
     pagination: {
@@ -313,21 +649,13 @@ export const getViewSectionNotes = async (
         return null;
     }
 
-    const tagNames = section.tags.map((tag) => tag.name);
-
-    if (tagNames.length === 0) {
-        return {
-            totalCount: 0,
-            notes: [],
-        };
-    }
-
-    const where = buildNoteTagNamesWhere(tagNames, section.mode as NoteTagMatchMode);
+    const serializedSection = serializeViewSection(section);
+    const where = buildViewSectionWhere(serializedSection);
 
     const [totalCount, notes] = await Promise.all([
         models.note.count({ where }),
         models.note.findMany({
-            orderBy: { updatedAt: 'desc' },
+            orderBy: buildViewSectionOrderBy(serializedSection),
             where,
             take: Number(pagination.limit),
             skip: Number(pagination.offset),
@@ -471,11 +799,14 @@ export const createViewSection = async (tabId: string, input: ViewSectionInput) 
         }
 
         const nextSectionOrder = await getNextSectionOrder(tx, numericTabId);
+        const query = await buildStoredViewQuery(tx, nextSection);
 
         const createdSection = await tx.viewSection.create({
             data: {
                 tabId: numericTabId,
                 title: nextSection.title,
+                displayType: nextSection.displayType,
+                query,
                 mode: nextSection.mode,
                 limit: nextSection.limit,
                 order: nextSectionOrder,
@@ -497,24 +828,30 @@ export const updateViewSection = async (id: string, input: ViewSectionInput) => 
     const sectionId = parseViewId(id);
     const nextSection = normalizeViewSectionInput(input);
 
-    const updatedSection = await models.viewSection.update({
-        where: { id: sectionId },
-        data: {
-            title: nextSection.title,
-            mode: nextSection.mode,
-            limit: nextSection.limit,
-            tags: {
-                deleteMany: {},
-                create: nextSection.tagNames.map((tagName, index) => ({
-                    name: tagName,
-                    order: index,
-                })),
-            },
-        },
-        include: orderedViewSectionTagsInclude,
-    });
+    return models.$transaction(async (tx) => {
+        const query = await buildStoredViewQuery(tx, nextSection);
 
-    return serializeViewSection(updatedSection);
+        const updatedSection = await tx.viewSection.update({
+            where: { id: sectionId },
+            data: {
+                title: nextSection.title,
+                displayType: nextSection.displayType,
+                query,
+                mode: nextSection.mode,
+                limit: nextSection.limit,
+                tags: {
+                    deleteMany: {},
+                    create: nextSection.tagNames.map((tagName, index) => ({
+                        name: tagName,
+                        order: index,
+                    })),
+                },
+            },
+            include: orderedViewSectionTagsInclude,
+        });
+
+        return serializeViewSection(updatedSection);
+    });
 };
 
 export const deleteViewSection = async (id: string) => {


### PR DESCRIPTION
## :dart: Goal
- Add a reusable saved filter model to Views so users can create note lists from tags, shared properties, or both.
- Move Views beyond tag-only sections while keeping existing tag workflows intact.

## :hammer_and_wrench: Core Changes
- Adds saved query metadata to view sections with display type, property filters, sorting, and all-notes support.
- Extends server View GraphQL and query services to combine tag filters and property filters.
- Updates `/views` UX so filters can be created from shared properties, tags, both together, or no filters.
- Keeps existing `/calendar` unchanged while preparing the view model for future display modes.
- Adds migration `20260531073000_0018_view_query` for `ViewSection.displayType` and `ViewSection.query`.

## :brain: Key Decisions
- Treat tags and properties as first-class filter types in Views.
- Keep property filters combined with tag filters using AND for V1 to avoid complex query grouping.
- Keep rendering as list-only for this PR; calendar/board rendering can be layered on the same saved query model later.
- Store query metadata as JSON on `ViewSection` for V1 flexibility while preserving existing tag section compatibility.

## :test_tube: Verification Guide
### How to verify
1. Run `pnpm check:encoding`.
2. Run `pnpm lint`.
3. Run `pnpm type-check`.
4. Run `pnpm test:ci`.
5. Run `pnpm build`.
6. Start local dev with `pnpm dev` and open `/views`.
7. Create view sections for these cases:
   - tag-only filter
   - property-only filter
   - tag + property filters together
   - no filters / All notes
   - opened tag filter with no selected tag

### Expected result
- Encoding, lint, type-check, tests, and build pass.
- Tag-only, property-only, combined, and All notes views create successfully and show matching notes.
- An empty opened tag filter is blocked with a clear validation message.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)
