### PR TITLE
✨ Add MCP property query tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,8 +173,10 @@ Example Claude Code `.mcp.json`:
 | Tool | Description |
 |------|-------------|
 | `ocean_brain_search_notes` | Search notes by keyword |
-| `ocean_brain_read_note` | Read a note by ID |
+| `ocean_brain_read_note` | Read a note by ID, including tags, properties, and back references |
 | `ocean_brain_list_tags` | List tags with note counts |
+| `ocean_brain_list_properties` | List shared property definitions, types, and select options |
+| `ocean_brain_query_notes_by_properties` | Query notes with property filters |
 | `ocean_brain_list_recent_notes` | List recently updated notes |
 | `ocean_brain_create_note` / `ocean_brain_update_note` | Create or update notes |
 | `ocean_brain_create_tag` / `ocean_brain_delete_note` | Create tags or delete notes (safe write flow) |

--- a/packages/cli/src/mcp-note-output.ts
+++ b/packages/cli/src/mcp-note-output.ts
@@ -35,6 +35,14 @@ const formatBackReferenceLine = (backReference: McpReadNoteBackReference) => {
     return `- ${backReference.id}: ${backReference.title}`;
 };
 
+const formatPropertyLine = (property: McpReadNoteProperty) => {
+    const displayValue = (property.option?.label ?? property.value) || '(empty)';
+    const rawValue = property.option?.value ?? property.value;
+    const rawValueLabel = rawValue ? `, value=${rawValue}` : '';
+
+    return `- ${property.key} (${property.name}): ${displayValue} [${property.valueType}${rawValueLabel}]`;
+};
+
 export const formatMcpReadNoteOutput = ({
     note,
     backReferences,
@@ -56,7 +64,7 @@ export const formatMcpReadNoteOutput = ({
         ? backReferences.map(formatBackReferenceLine)
         : ['- (none)'];
     const propertyLines = note.properties && note.properties.length > 0
-        ? note.properties.map((property) => `- ${property.key}: ${property.option?.label ?? property.value} (${property.valueType})`)
+        ? note.properties.map(formatPropertyLine)
         : ['- (none)'];
 
     return [

--- a/packages/cli/src/mcp.ts
+++ b/packages/cli/src/mcp.ts
@@ -29,6 +29,8 @@ export const OCEAN_BRAIN_MCP_TOOLS = {
     updateNoteMetadata: 'ocean_brain_update_note_metadata',
     replaceNoteMarkdown: 'ocean_brain_replace_note_markdown',
     listTags: 'ocean_brain_list_tags',
+    listProperties: 'ocean_brain_list_properties',
+    queryNotesByProperties: 'ocean_brain_query_notes_by_properties',
     listNotesByTag: 'ocean_brain_list_notes_by_tag',
     listNotesByTags: 'ocean_brain_list_notes_by_tags',
     listRecentNotes: 'ocean_brain_list_recent_notes',
@@ -40,6 +42,16 @@ export const OCEAN_BRAIN_MCP_TOOLS = {
 
 const noteLayoutSchema = z.enum(['narrow', 'wide', 'full']);
 const tagMatchModeSchema = z.enum(['and', 'or']);
+const propertyValueTypeSchema = z.enum(['text', 'number', 'date', 'boolean', 'select']);
+const propertyFilterOperatorSchema = z.enum(['equals', 'before', 'after', 'exists', 'notExists']);
+const viewSortBySchema = z.enum(['updatedAt', 'createdAt', 'title']);
+const viewSortOrderSchema = z.enum(['asc', 'desc']);
+const propertyFilterSchema = z.object({
+    key: z.string().describe('Property key from ocean_brain_list_properties, e.g. state'),
+    valueType: propertyValueTypeSchema.describe('Property value type from the property definition'),
+    operator: propertyFilterOperatorSchema.describe('Filter operator. before/after are only valid for date or number properties.'),
+    value: z.string().nullable().optional().describe('Filter value. Required unless operator is exists or notExists. Select filters use option.value, not option.label.')
+});
 
 const normalizeOceanBrainTagName = (name: string) => {
     const trimmedName = name.trim();
@@ -233,7 +245,7 @@ export async function startMcpServer(
 
     server.tool(
         OCEAN_BRAIN_MCP_TOOLS.readNote,
-        'Read an Ocean Brain note by ID. Returns truncated content by default (1000 chars) and includes a back-reference summary. Set maxLength to 0 only when full content is necessary.',
+        'Read an Ocean Brain note by ID. Returns properties, tags, truncated content by default (1000 chars), and a back-reference summary. Set maxLength to 0 only when full content is necessary.',
         {
             id: z.string().describe('Note ID'),
             maxLength: z.number().optional().default(1000).describe('Max content length in characters. 0 for full content. (default: 1000)'),
@@ -248,7 +260,7 @@ export async function startMcpServer(
                         createdAt
                         updatedAt
                         tags { id name }
-                        properties { key name value valueType option { label value } }
+                        properties { key name value valueType option { id label value color order } }
                     }
                     backReferences(id: $id) {
                         id
@@ -264,7 +276,13 @@ export async function startMcpServer(
                 createdAt: string;
                 updatedAt: string;
                 tags: Array<{ id: string; name: string }>;
-                properties?: Array<{ key: string; name: string; value: string; valueType: string }>;
+                properties?: Array<{
+                    key: string;
+                    name: string;
+                    value: string;
+                    valueType: string;
+                    option?: { id: string; label: string; value: string; color?: string | null; order: number } | null;
+                }>;
             };
             const backReferences = (data?.backReferences as Array<{
                 id: string;
@@ -398,6 +416,64 @@ export async function startMcpServer(
                 }],
             };
         },
+    );
+
+    server.tool(
+        OCEAN_BRAIN_MCP_TOOLS.listProperties,
+        'List shared Ocean Brain property definitions. Use this before property queries so keys, value types, and select option values are valid.',
+        {
+            query: z.string().optional().default('').describe('Optional property key/name search query'),
+            limit: z.number().optional().default(50).describe('Max results (default: 50, server max: 100)'),
+            offset: z.number().optional().default(0).describe('Pagination offset (default: 0)')
+        },
+        async ({ query, limit, offset }) => {
+            const data = await graphql(serverUrl, token, `
+                query ($query: String, $pagination: PaginationInput) {
+                    notePropertyKeys(query: $query, pagination: $pagination) {
+                        totalCount
+                        keys {
+                            key
+                            name
+                            valueType
+                            noteCount
+                            updatedAt
+                            options { id label value color order }
+                        }
+                    }
+                }
+            `, {
+                query,
+                pagination: { limit, offset }
+            });
+
+            const result = data?.notePropertyKeys as {
+                totalCount: number;
+                keys: Array<{
+                    key: string;
+                    name: string;
+                    valueType: 'text' | 'number' | 'date' | 'boolean' | 'select';
+                    noteCount: number;
+                    updatedAt: string;
+                    options: Array<{
+                        id: string;
+                        label: string;
+                        value: string;
+                        color?: string | null;
+                        order: number;
+                    }>;
+                }>;
+            };
+
+            return {
+                content: [{
+                    type: 'text' as const,
+                    text: JSON.stringify({
+                        totalCount: result.totalCount,
+                        propertyKeys: result.keys
+                    }, null, 2),
+                }],
+            };
+        }
     );
 
     server.tool(
@@ -571,6 +647,96 @@ export async function startMcpServer(
                             title: note.title,
                             updatedAt: note.updatedAt,
                             tags: note.tags.map((item) => item.name)
+                        }))
+                    }, null, 2),
+                }],
+            };
+        }
+    );
+
+    server.tool(
+        OCEAN_BRAIN_MCP_TOOLS.queryNotesByProperties,
+        'Query Ocean Brain notes with property filters. Call ocean_brain_list_properties first; select filters must use option.value. Property filters are combined with AND, and optional tag filters use the provided tag match mode.',
+        {
+            propertyFilters: z.array(propertyFilterSchema).min(1).max(10).describe('Property filters to apply. Multiple property filters are combined with AND.'),
+            tagNames: z.array(z.string()).optional().default([]).describe('Optional tag filters. You can pass @project, #project, or project.'),
+            mode: tagMatchModeSchema.optional().default('and').describe('Tag match mode for tagNames only. Property filters are always combined with AND.'),
+            sortBy: viewSortBySchema.optional().default('updatedAt').describe('Sort field (default: updatedAt)'),
+            sortOrder: viewSortOrderSchema.optional().default('desc').describe('Sort order (default: desc)'),
+            limit: z.number().optional().default(20).describe('Max results (default: 20, server max: 50)'),
+            offset: z.number().optional().default(0).describe('Pagination offset (default: 0)')
+        },
+        async ({ propertyFilters, tagNames, mode, sortBy, sortOrder, limit, offset }) => {
+            const data = await graphql(serverUrl, token, `
+                query ($input: NotesByPropertiesInput!, $pagination: PaginationInput) {
+                    notesByProperties(input: $input, pagination: $pagination) {
+                        totalCount
+                        notes {
+                            id
+                            title
+                            createdAt
+                            updatedAt
+                            tags { id name }
+                            properties { key name value valueType option { id label value color order } }
+                        }
+                    }
+                }
+            `, {
+                input: {
+                    tagNames,
+                    mode,
+                    propertyFilters,
+                    sortBy,
+                    sortOrder
+                },
+                pagination: { limit, offset }
+            });
+
+            const result = data?.notesByProperties as {
+                totalCount: number;
+                notes: Array<{
+                    id: string;
+                    title: string;
+                    createdAt: string;
+                    updatedAt: string;
+                    tags: Array<{ id: string; name: string }>;
+                    properties: Array<{
+                        key: string;
+                        name: string;
+                        value: string;
+                        valueType: string;
+                        option?: {
+                            id: string;
+                            label: string;
+                            value: string;
+                            color?: string | null;
+                            order: number;
+                        } | null;
+                    }>;
+                }>;
+            };
+
+            return {
+                content: [{
+                    type: 'text' as const,
+                    text: JSON.stringify({
+                        query: {
+                            propertyFilters,
+                            tagNames,
+                            mode,
+                            sortBy,
+                            sortOrder,
+                            limit,
+                            offset
+                        },
+                        totalCount: result.totalCount,
+                        notes: result.notes.map((note) => ({
+                            id: note.id,
+                            title: note.title,
+                            createdAt: note.createdAt,
+                            updatedAt: note.updatedAt,
+                            tags: note.tags.map((item) => item.name),
+                            properties: note.properties
                         }))
                     }, null, 2),
                 }],

--- a/packages/cli/test/mcp-note-output.test.ts
+++ b/packages/cli/test/mcp-note-output.test.ts
@@ -44,3 +44,38 @@ test('formatMcpReadNoteOutput truncates markdown and shows an empty back referen
     assert.match(output, /Content: 10 chars \(showing first 5\)/);
     assert.match(output, /Back References:\n- \(none\)\n\nabcde\n\n\.\.\. \(truncated, use maxLength: 0 to read full content\)$/);
 });
+
+test('formatMcpReadNoteOutput includes property names, display labels, and raw values', () => {
+    const output = formatMcpReadNoteOutput({
+        note: {
+            id: '30',
+            title: 'Property Note',
+            contentAsMarkdown: 'Body',
+            createdAt: '2026-04-07T10:00:00.000Z',
+            updatedAt: '2026-04-07T11:00:00.000Z',
+            tags: [],
+            properties: [
+                {
+                    key: 'state',
+                    name: 'State',
+                    value: 'doing',
+                    valueType: 'select',
+                    option: {
+                        label: 'Doing',
+                        value: 'doing'
+                    }
+                },
+                {
+                    key: 'project',
+                    name: 'Project',
+                    value: 'ocean-brain',
+                    valueType: 'text'
+                }
+            ]
+        },
+        backReferences: [],
+        maxLength: 0
+    });
+
+    assert.match(output, /Properties:\n- state \(State\): Doing \[select, value=doing\]\n- project \(Project\): ocean-brain \[text, value=ocean-brain\]/);
+});

--- a/packages/cli/test/mcp-tool-names.test.ts
+++ b/packages/cli/test/mcp-tool-names.test.ts
@@ -14,6 +14,8 @@ test('Ocean Brain MCP tool names use explicit product-prefixed names', () => {
         updateNoteMetadata: 'ocean_brain_update_note_metadata',
         replaceNoteMarkdown: 'ocean_brain_replace_note_markdown',
         listTags: 'ocean_brain_list_tags',
+        listProperties: 'ocean_brain_list_properties',
+        queryNotesByProperties: 'ocean_brain_query_notes_by_properties',
         listNotesByTag: 'ocean_brain_list_notes_by_tag',
         listNotesByTags: 'ocean_brain_list_notes_by_tags',
         listRecentNotes: 'ocean_brain_list_recent_notes',

--- a/packages/server/src/features/view/graphql/view.query.resolver.ts
+++ b/packages/server/src/features/view/graphql/view.query.resolver.ts
@@ -1,5 +1,13 @@
 import type { IResolvers } from '@graphql-tools/utils';
-import { getViewSectionById, getViewSectionNotes, getViewWorkspace } from '~/features/view/services/workspace.js';
+import { GraphQLError } from 'graphql';
+import { InvalidNotePropertyInputError } from '~/features/note/services/properties.js';
+import {
+    getNotesByProperties,
+    getViewSectionById,
+    getViewSectionNotes,
+    getViewWorkspace,
+    type ViewNotesQueryInput,
+} from '~/features/view/services/workspace.js';
 import type { Pagination } from '~/types/index.js';
 
 type ViewQueryResolvers = NonNullable<IResolvers['Query']>;
@@ -34,5 +42,35 @@ export const viewQueryResolvers: ViewQueryResolvers = {
         }
 
         return sectionNotes;
+    },
+    notesByProperties: async (
+        _,
+        {
+            input,
+            pagination = {
+                limit: 20,
+                offset: 0,
+            },
+        }: {
+            input: ViewNotesQueryInput;
+            pagination: Pagination;
+        },
+    ) => {
+        try {
+            return await getNotesByProperties(input, {
+                limit: Number(pagination.limit),
+                offset: Number(pagination.offset),
+            });
+        } catch (error) {
+            if (error instanceof InvalidNotePropertyInputError) {
+                throw new GraphQLError(error.message, {
+                    extensions: {
+                        code: 'INVALID_NOTE_PROPERTY_INPUT',
+                    },
+                });
+            }
+
+            throw error;
+        }
     },
 };

--- a/packages/server/src/features/view/graphql/view.type-defs.ts
+++ b/packages/server/src/features/view/graphql/view.type-defs.ts
@@ -76,6 +76,14 @@ export const viewType = gql`
         sortOrder: ViewSortOrder
         limit: Int
     }
+
+    input NotesByPropertiesInput {
+        tagNames: [String!]
+        mode: TagMatchMode
+        propertyFilters: [ViewPropertyFilterInput!]!
+        sortBy: ViewSortBy
+        sortOrder: ViewSortOrder
+    }
 `;
 
 export const viewQuery = gql`
@@ -83,6 +91,7 @@ export const viewQuery = gql`
         viewWorkspace: ViewWorkspace!
         viewSection(id: ID!): ViewSection
         viewSectionNotes(id: ID!, pagination: PaginationInput): Notes!
+        notesByProperties(input: NotesByPropertiesInput!, pagination: PaginationInput): Notes!
     }
 `;
 

--- a/packages/server/src/features/view/services/workspace.test.ts
+++ b/packages/server/src/features/view/services/workspace.test.ts
@@ -5,6 +5,9 @@ import {
     buildPropertyFilterWhere,
     buildViewSectionWhere,
     clampViewSectionLimit,
+    hydratePropertyFilters,
+    normalizeViewNotesPagination,
+    normalizeViewNotesQueryInput,
     normalizeViewPropertyFilters,
     normalizeViewSectionInput,
     normalizeViewTabTitle,
@@ -79,6 +82,39 @@ test('normalizeViewPropertyFilters validates typed filter values', () => {
     assert.throws(() =>
         normalizeViewPropertyFilters([{ key: 'due', valueType: 'date', operator: 'equals', value: '2026-99-99' }]),
     );
+});
+
+test('normalizeViewNotesQueryInput normalizes property query filters without section-only fields', () => {
+    assert.deepEqual(
+        normalizeViewNotesQueryInput({
+            tagNames: ['project', '#doing'],
+            mode: 'or',
+            propertyFilters: [{ key: ' State ', valueType: 'select', operator: 'equals', value: 'doing' }],
+            sortBy: 'title',
+            sortOrder: 'asc',
+        }),
+        {
+            tagNames: ['@project', '@doing'],
+            mode: 'or',
+            propertyFilters: [
+                {
+                    key: 'state',
+                    name: 'state',
+                    valueType: 'select',
+                    operator: 'equals',
+                    value: 'doing',
+                },
+            ],
+            sortBy: 'title',
+            sortOrder: 'asc',
+        },
+    );
+});
+
+test('normalizeViewNotesPagination clamps property query pagination', () => {
+    assert.deepEqual(normalizeViewNotesPagination({ limit: 999, offset: -5 }), { limit: 50, offset: 0 });
+    assert.deepEqual(normalizeViewNotesPagination({ limit: 0, offset: 7 }), { limit: 1, offset: 7 });
+    assert.deepEqual(normalizeViewNotesPagination({ limit: Number.NaN, offset: Number.NaN }), { limit: 20, offset: 0 });
 });
 
 test('buildPropertyFilterWhere maps property filters to note relation filters', () => {
@@ -190,6 +226,106 @@ test('buildPropertyFilterWhere maps number and date range operators', () => {
                 },
             },
         },
+    );
+});
+
+test('hydratePropertyFilters validates property definitions and select options', async () => {
+    const db = {
+        propertyDefinition: {
+            findMany: async () => [
+                {
+                    key: 'state',
+                    name: 'State',
+                    valueType: 'select',
+                    options: [{ value: 'doing' }],
+                },
+                {
+                    key: 'priority',
+                    name: 'Priority',
+                    valueType: 'number',
+                    options: [],
+                },
+            ],
+        },
+    } as never;
+
+    assert.deepEqual(
+        await hydratePropertyFilters(
+            db,
+            [
+                {
+                    key: 'state',
+                    name: 'state',
+                    valueType: 'select',
+                    operator: 'equals',
+                    value: 'Doing',
+                },
+            ],
+            { validateSelectOptions: true },
+        ),
+        [
+            {
+                key: 'state',
+                name: 'State',
+                valueType: 'select',
+                operator: 'equals',
+                value: 'Doing',
+            },
+        ],
+    );
+
+    await assert.rejects(
+        () =>
+            hydratePropertyFilters(
+                db,
+                [
+                    {
+                        key: 'state',
+                        name: 'state',
+                        valueType: 'select',
+                        operator: 'equals',
+                        value: 'blocked',
+                    },
+                ],
+                { validateSelectOptions: true },
+            ),
+        /Property state option blocked is not defined/,
+    );
+
+    await assert.rejects(
+        () =>
+            hydratePropertyFilters(
+                db,
+                [
+                    {
+                        key: 'missing',
+                        name: 'missing',
+                        valueType: 'text',
+                        operator: 'notExists',
+                        value: null,
+                    },
+                ],
+                { validateSelectOptions: true },
+            ),
+        /Property missing is not defined/,
+    );
+
+    await assert.rejects(
+        () =>
+            hydratePropertyFilters(
+                db,
+                [
+                    {
+                        key: 'priority',
+                        name: 'priority',
+                        valueType: 'text',
+                        operator: 'equals',
+                        value: '1',
+                    },
+                ],
+                { validateSelectOptions: true },
+            ),
+        /Property priority uses number values/,
     );
 });
 

--- a/packages/server/src/features/view/services/workspace.ts
+++ b/packages/server/src/features/view/services/workspace.ts
@@ -54,6 +54,22 @@ export interface ViewSectionInput {
     limit?: number;
 }
 
+export interface ViewNotesQueryInput {
+    tagNames?: string[] | null;
+    mode?: ViewTagMatchMode;
+    propertyFilters?: ViewPropertyFilterInput[] | null;
+    sortBy?: ViewSortBy;
+    sortOrder?: ViewSortOrder;
+}
+
+export interface ViewNotesQueryRecord {
+    tagNames: string[];
+    mode: ViewTagMatchMode;
+    propertyFilters: ViewPropertyFilterRecord[];
+    sortBy: ViewSortBy;
+    sortOrder: ViewSortOrder;
+}
+
 export interface ViewPropertyFilterInput {
     key: string;
     operator: ViewPropertyFilterOperator;
@@ -71,6 +87,8 @@ const VIEW_WORKSPACE_ID = 1;
 export const DEFAULT_VIEW_SECTION_LIMIT = 5;
 export const MIN_VIEW_SECTION_LIMIT = 1;
 export const MAX_VIEW_SECTION_LIMIT = 20;
+export const DEFAULT_VIEW_NOTES_QUERY_LIMIT = 20;
+export const MAX_VIEW_NOTES_QUERY_LIMIT = 50;
 const MAX_VIEW_PROPERTY_FILTERS = 10;
 const DEFAULT_VIEW_DISPLAY_TYPE: ViewDisplayType = 'list';
 const DEFAULT_VIEW_SORT_BY: ViewSortBy = 'updatedAt';
@@ -327,6 +345,27 @@ export const normalizeViewSectionInput = (input: ViewSectionInput) => {
     };
 };
 
+export const normalizeViewNotesQueryInput = (input: ViewNotesQueryInput): ViewNotesQueryRecord => {
+    return {
+        tagNames: normalizeViewTagNames(input.tagNames ?? []),
+        mode: input.mode === 'or' ? 'or' : 'and',
+        propertyFilters: normalizeViewPropertyFilters(input.propertyFilters),
+        sortBy: normalizeViewSortBy(input.sortBy),
+        sortOrder: normalizeViewSortOrder(input.sortOrder),
+    };
+};
+
+export const normalizeViewNotesPagination = (pagination?: { limit?: number; offset?: number }) => {
+    const numericLimit = Number(pagination?.limit ?? DEFAULT_VIEW_NOTES_QUERY_LIMIT);
+    const limit = Number.isInteger(numericLimit)
+        ? Math.min(MAX_VIEW_NOTES_QUERY_LIMIT, Math.max(1, numericLimit))
+        : DEFAULT_VIEW_NOTES_QUERY_LIMIT;
+    const numericOffset = Number(pagination?.offset ?? 0);
+    const offset = Number.isInteger(numericOffset) ? Math.max(0, numericOffset) : 0;
+
+    return { limit, offset };
+};
+
 export const pickNextActiveViewTabId = (tabIds: number[], deletedTabId: number, currentActiveTabId: number | null) => {
     const remainingTabIds = tabIds.filter((tabId) => tabId !== deletedTabId);
 
@@ -435,14 +474,27 @@ const readViewSection = async (db: ViewDbClient, id: number): Promise<ViewSectio
     return section ? serializeViewSection(section) : null;
 };
 
-const hydratePropertyFilters = async (db: ViewDbClient, filters: ViewPropertyFilterRecord[]) => {
+export const hydratePropertyFilters = async (
+    db: ViewDbClient,
+    filters: ViewPropertyFilterRecord[],
+    options: { validateSelectOptions?: boolean } = {},
+) => {
     if (filters.length === 0) {
         return [];
     }
 
     const definitions = await db.propertyDefinition.findMany({
         where: { key: { in: filters.map((filter) => filter.key) } },
-        select: { key: true, name: true, valueType: true },
+        select: {
+            key: true,
+            name: true,
+            valueType: true,
+            options: {
+                select: {
+                    value: true,
+                },
+            },
+        },
     });
     const definitionByKey = new Map(definitions.map((definition) => [definition.key, definition]));
 
@@ -457,6 +509,19 @@ const hydratePropertyFilters = async (db: ViewDbClient, filters: ViewPropertyFil
             throw new InvalidNotePropertyInputError(`Property ${filter.key} uses ${definition.valueType} values.`);
         }
 
+        if (
+            options.validateSelectOptions &&
+            filter.valueType === 'select' &&
+            filter.operator !== 'exists' &&
+            filter.operator !== 'notExists'
+        ) {
+            const optionValue = normalizeSelectFilterValue(filter.value ?? '');
+
+            if (!definition.options.some((option) => option.value === optionValue)) {
+                throw new InvalidNotePropertyInputError(`Property ${filter.key} option ${optionValue} is not defined.`);
+            }
+        }
+
         return {
             ...filter,
             name: definition.name,
@@ -465,7 +530,7 @@ const hydratePropertyFilters = async (db: ViewDbClient, filters: ViewPropertyFil
 };
 
 const buildStoredViewQuery = async (db: ViewDbClient, section: ReturnType<typeof normalizeViewSectionInput>) => {
-    const propertyFilters = await hydratePropertyFilters(db, section.propertyFilters);
+    const propertyFilters = await hydratePropertyFilters(db, section.propertyFilters, { validateSelectOptions: true });
 
     return serializeStoredViewQuery({
         propertyFilters,
@@ -611,14 +676,16 @@ export const buildPropertyFilterWhere = (filter: ViewPropertyFilterRecord): Pris
     };
 };
 
-export const buildViewSectionWhere = (section: ViewSectionRecord): Prisma.NoteWhereInput => {
+export const buildViewNotesWhere = (
+    query: Pick<ViewNotesQueryRecord, 'tagNames' | 'mode' | 'propertyFilters'>,
+): Prisma.NoteWhereInput => {
     const clauses: Prisma.NoteWhereInput[] = [];
 
-    if (section.tagNames.length > 0) {
-        clauses.push(buildNoteTagNamesWhere(section.tagNames, section.mode as NoteTagMatchMode));
+    if (query.tagNames.length > 0) {
+        clauses.push(buildNoteTagNamesWhere(query.tagNames, query.mode as NoteTagMatchMode));
     }
 
-    for (const filter of section.propertyFilters) {
+    for (const filter of query.propertyFilters) {
         clauses.push(buildPropertyFilterWhere(filter));
     }
 
@@ -629,8 +696,18 @@ export const buildViewSectionWhere = (section: ViewSectionRecord): Prisma.NoteWh
     return { AND: clauses };
 };
 
+export const buildViewSectionWhere = (section: ViewSectionRecord): Prisma.NoteWhereInput => {
+    return buildViewNotesWhere(section);
+};
+
+const buildViewNotesOrderBy = (
+    query: Pick<ViewNotesQueryRecord, 'sortBy' | 'sortOrder'>,
+): Prisma.NoteOrderByWithRelationInput[] => {
+    return [{ [query.sortBy]: query.sortOrder }, { id: 'asc' }];
+};
+
 const buildViewSectionOrderBy = (section: ViewSectionRecord): Prisma.NoteOrderByWithRelationInput[] => {
-    return [{ [section.sortBy]: section.sortOrder }, { id: 'asc' }];
+    return buildViewNotesOrderBy(section);
 };
 
 export const getViewSectionNotes = async (
@@ -659,6 +736,44 @@ export const getViewSectionNotes = async (
             where,
             take: Number(pagination.limit),
             skip: Number(pagination.offset),
+        }),
+    ]);
+
+    return {
+        totalCount,
+        notes,
+    };
+};
+
+export const getNotesByProperties = async (
+    input: ViewNotesQueryInput,
+    pagination?: {
+        limit?: number;
+        offset?: number;
+    },
+): Promise<ViewSectionNotesResult> => {
+    const normalizedQuery = normalizeViewNotesQueryInput(input);
+
+    if (normalizedQuery.propertyFilters.length === 0) {
+        throw new InvalidNotePropertyInputError('At least one property filter is required.');
+    }
+
+    const query = {
+        ...normalizedQuery,
+        propertyFilters: await hydratePropertyFilters(models, normalizedQuery.propertyFilters, {
+            validateSelectOptions: true,
+        }),
+    };
+    const normalizedPagination = normalizeViewNotesPagination(pagination);
+    const where = buildViewNotesWhere(query);
+
+    const [totalCount, notes] = await Promise.all([
+        models.note.count({ where }),
+        models.note.findMany({
+            orderBy: buildViewNotesOrderBy(query),
+            where,
+            take: normalizedPagination.limit,
+            skip: normalizedPagination.offset,
         }),
     ]);
 


### PR DESCRIPTION
## :dart: Goal
- Let MCP clients discover Ocean Brain property definitions and use them for structured note queries.
- Make note reads expose enough property detail for agents to understand labels, raw select values, and property types.

## :hammer_and_wrench: Core Changes
- Added `ocean_brain_list_properties` to expose shared property keys, value types, note counts, and select options.
- Added `ocean_brain_query_notes_by_properties` for property-filtered note lookup with optional tag filters.
- Added a read-only GraphQL `notesByProperties` query that reuses the view property filter logic.
- Strengthened property query validation for missing keys, type mismatches, and invalid select option values.
- Improved `ocean_brain_read_note` property output and updated MCP README tool documentation.

## :brain: Key Decisions
- Kept this PR read-only for property support; property writes and schema management stay out of scope.
- Reused the existing view filter model instead of creating a separate MCP-only query language.
- Kept property filters as AND-only in V1 while allowing optional tag filters to use the existing tag mode.
- Kept existing list/search tools lightweight instead of adding properties to every listing response.

## :test_tube: Verification Guide
### How to verify
1. Run `pnpm check:encoding`.
2. Run `pnpm lint`.
3. Run `pnpm type-check`.
4. Run `pnpm test:ci`.
5. Run `pnpm build`.
6. Run `pnpm --filter ocean-brain build`.
7. Run `git diff --check`.
8. Optional smoke: start an isolated local server with a temporary SQLite DB, enable MCP, then call `ocean_brain_list_properties`, `ocean_brain_query_notes_by_properties`, and `ocean_brain_read_note` through the local MCP client.

### Expected result
- All checks pass.
- MCP clients can list property definitions, query notes by property filters, and read note properties from `ocean_brain_read_note`.
- Invalid select option values return `INVALID_NOTE_PROPERTY_INPUT`.
- `/graphql/mcp` remains read-only for mutations.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)
