### PR TITLE
🐛 Fix property settings edit flow

### DIFF
--- a/packages/client/src/apis/note.api.ts
+++ b/packages/client/src/apis/note.api.ts
@@ -341,6 +341,38 @@ export function createNotePropertyKey(input: CreateNotePropertyKeyRequestData) {
     );
 }
 
+export interface UpdateNotePropertyKeyRequestData {
+    key: string;
+    name?: string;
+    options?: Array<
+        NotePropertyOption | { id?: string; label: string; value?: string; color?: string | null; order?: number }
+    >;
+}
+
+export function updateNotePropertyKey({ key, ...input }: UpdateNotePropertyKeyRequestData) {
+    return graphQuery<
+        {
+            updateNotePropertyKey: NotePropertyKeySummary;
+        },
+        {
+            key: string;
+            input: Omit<UpdateNotePropertyKeyRequestData, 'key'>;
+        }
+    >(
+        `mutation UpdateNotePropertyKey($key: String!, $input: NotePropertyDefinitionUpdateInput!) {
+            updateNotePropertyKey(key: $key, input: $input) {
+                key
+                name
+                valueType
+                noteCount
+                options { id label value color order }
+                updatedAt
+            }
+        }`,
+        { key, input },
+    );
+}
+
 export interface DeleteNotePropertyKeyRequestData {
     key: string;
     confirmImpact?: boolean;

--- a/packages/client/src/components/ui/Button/variants.ts
+++ b/packages/client/src/components/ui/Button/variants.ts
@@ -6,6 +6,7 @@ export const buttonVariants = cva(
         'items-center',
         'justify-center',
         'gap-2',
+        'whitespace-nowrap',
         'font-medium',
         'transition-colors',
         'duration-200',

--- a/packages/client/src/modules/query-key-factory.ts
+++ b/packages/client/src/modules/query-key-factory.ts
@@ -100,6 +100,7 @@ export const queryKeys = {
         backReferencesAll: () => ['notes', 'back-references'] as const,
         backReferences: (noteId: string) => ['notes', 'back-references', { noteId }] as const,
         graph: () => ['notes', 'graph'] as const,
+        propertyKeysAll: () => ['notes', 'property-keys'] as const,
         propertyKeys: (params: FetchNotePropertyKeysParams = {}) =>
             [
                 'notes',

--- a/packages/client/src/pages/setting/properties.spec.tsx
+++ b/packages/client/src/pages/setting/properties.spec.tsx
@@ -1,0 +1,120 @@
+import { QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {
+    createNotePropertyKey,
+    deleteNotePropertyKey,
+    fetchNotePropertyKeys,
+    updateNotePropertyKey,
+} from '~/apis/note.api';
+import { ToastProvider } from '~/components/ui';
+import { createTestQueryClient } from '~/test/test-utils';
+import PropertiesSettings from './properties';
+
+vi.mock('@tanstack/react-router', () => ({
+    getRouteApi: () => ({
+        useSearch: () => ({ page: 1 }),
+    }),
+}));
+
+vi.mock('~/apis/note.api', () => ({
+    createNotePropertyKey: vi.fn(),
+    deleteNotePropertyKey: vi.fn(),
+    fetchNotePropertyKeys: vi.fn(),
+    updateNotePropertyKey: vi.fn(),
+}));
+
+const propertyKey = {
+    key: 'state',
+    name: 'State',
+    valueType: 'select' as const,
+    noteCount: 1,
+    options: [
+        {
+            id: '1',
+            label: 'Todo',
+            value: 'todo',
+            color: null,
+            order: 0,
+        },
+        {
+            id: '2',
+            label: 'Doing',
+            value: 'doing',
+            color: null,
+            order: 1,
+        },
+    ],
+    updatedAt: '2026-06-01T00:00:00.000Z',
+};
+
+const renderPage = () => {
+    const queryClient = createTestQueryClient();
+
+    render(
+        <QueryClientProvider client={queryClient}>
+            <ToastProvider>
+                <PropertiesSettings />
+            </ToastProvider>
+        </QueryClientProvider>,
+    );
+};
+
+describe('<PropertiesSettings />', () => {
+    beforeEach(() => {
+        vi.mocked(fetchNotePropertyKeys).mockResolvedValue({
+            type: 'success',
+            notePropertyKeys: {
+                totalCount: 1,
+                keys: [propertyKey],
+            },
+        } as never);
+        vi.mocked(updateNotePropertyKey).mockResolvedValue({
+            type: 'success',
+            updateNotePropertyKey: {
+                ...propertyKey,
+                name: 'Workflow state',
+            },
+        } as never);
+        vi.mocked(createNotePropertyKey).mockResolvedValue({
+            type: 'success',
+            createNotePropertyKey: propertyKey,
+        } as never);
+        vi.mocked(deleteNotePropertyKey).mockResolvedValue({
+            type: 'success',
+            deleteNotePropertyKey: {
+                key: propertyKey.key,
+                name: propertyKey.name,
+                valueType: propertyKey.valueType,
+                affectedNoteCount: 0,
+                deleted: true,
+            },
+        } as never);
+    });
+
+    it('edits a shared property definition from the settings page', async () => {
+        renderPage();
+
+        await screen.findByText('State');
+        await userEvent.click(screen.getByRole('button', { name: /edit/i }));
+
+        expect(screen.getByDisplayValue('todo')).toBeDisabled();
+        expect(screen.getAllByText('Locked')).toHaveLength(2);
+        expect(screen.getByRole('button', { name: /save changes/i })).toBeDisabled();
+        const nameInput = screen.getByLabelText(/name/i);
+        await userEvent.clear(nameInput);
+        await userEvent.type(nameInput, 'Workflow state');
+        await userEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+        await waitFor(() => {
+            expect(updateNotePropertyKey).toHaveBeenCalledWith({
+                key: 'state',
+                name: 'Workflow state',
+                options: [
+                    { id: '1', label: 'Todo', value: 'todo', color: null, order: 0 },
+                    { id: '2', label: 'Doing', value: 'doing', color: null, order: 1 },
+                ],
+            });
+        });
+    });
+});

--- a/packages/client/src/pages/setting/properties.tsx
+++ b/packages/client/src/pages/setting/properties.tsx
@@ -6,6 +6,7 @@ import {
     deleteNotePropertyKey,
     fetchNotePropertyKeys,
     type NotePropertyKeySummary,
+    updateNotePropertyKey,
 } from '~/apis/note.api';
 import { Button, Modal, ModalActionRow, PageLayout } from '~/components/shared';
 import { Input, Select, SelectItem, Text, useToast } from '~/components/ui';
@@ -23,6 +24,36 @@ const PROPERTY_TYPE_OPTIONS: { value: NotePropertyValueType; label: string; desc
     { value: 'select', label: 'Select', description: 'Choose one option from a controlled list.' },
 ];
 
+interface PropertyOptionDraft {
+    id?: string;
+    label: string;
+    value: string;
+    color?: string | null;
+    order?: number;
+}
+
+const isEmptyNewOptionDraft = (option: PropertyOptionDraft) => {
+    return !option.id && !option.label.trim() && !option.value.trim();
+};
+
+const normalizeDraftOptionValue = (option: PropertyOptionDraft) => {
+    return (option.value.trim() || option.label.trim()).toLowerCase().replace(/\s+/g, '-');
+};
+
+const isValidOptionValue = (value: string) => /^[a-z0-9][a-z0-9_-]*$/.test(value);
+
+const buildOptionPayload = (options: PropertyOptionDraft[]) => {
+    return options
+        .filter((option) => option.id || option.label.trim())
+        .map((option, index) => ({
+            ...(option.id ? { id: option.id } : {}),
+            label: option.label.trim(),
+            value: option.value.trim() || option.label.trim(),
+            color: option.color ?? null,
+            order: option.order ?? index,
+        }));
+};
+
 export default function PropertiesSettings() {
     const toast = useToast();
     const queryClient = useQueryClient();
@@ -33,8 +64,11 @@ export default function PropertiesSettings() {
     const [key, setKey] = useState('');
     const [name, setName] = useState('');
     const [valueType, setValueType] = useState<NotePropertyValueType>('text');
-    const [options, setOptions] = useState([{ label: '', value: '' }]);
+    const [options, setOptions] = useState<PropertyOptionDraft[]>([{ label: '', value: '' }]);
     const [propertyToDelete, setPropertyToDelete] = useState<NotePropertyKeySummary | null>(null);
+    const [propertyToEdit, setPropertyToEdit] = useState<NotePropertyKeySummary | null>(null);
+    const [editName, setEditName] = useState('');
+    const [editOptions, setEditOptions] = useState<PropertyOptionDraft[]>([{ label: '', value: '' }]);
     const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
 
     const resetCreateForm = () => {
@@ -42,6 +76,28 @@ export default function PropertiesSettings() {
         setName('');
         setValueType('text');
         setOptions([{ label: '', value: '' }]);
+    };
+
+    const openEditModal = (propertyKey: NotePropertyKeySummary) => {
+        setPropertyToEdit(propertyKey);
+        setEditName(propertyKey.name);
+        setEditOptions(
+            propertyKey.options.length > 0
+                ? propertyKey.options.map((option) => ({
+                      id: option.id,
+                      label: option.label,
+                      value: option.value,
+                      color: option.color,
+                      order: option.order,
+                  }))
+                : [{ label: '', value: '' }],
+        );
+    };
+
+    const closeEditModal = () => {
+        setPropertyToEdit(null);
+        setEditName('');
+        setEditOptions([{ label: '', value: '' }]);
     };
 
     const propertyKeysQuery = useQuery({
@@ -83,11 +139,44 @@ export default function PropertiesSettings() {
 
             resetCreateForm();
             setIsCreateModalOpen(false);
-            void queryClient.invalidateQueries({ queryKey: queryKeys.notes.propertyKeys() });
+            void queryClient.invalidateQueries({ queryKey: queryKeys.notes.propertyKeysAll(), exact: false });
             toast('Property created.');
         },
         onError: () => {
             toast('Failed to create property.');
+        },
+    });
+
+    const updateMutation = useMutation({
+        mutationFn: async () => {
+            if (!propertyToEdit) {
+                throw new Error('Property to edit is missing.');
+            }
+
+            return updateNotePropertyKey({
+                key: propertyToEdit.key,
+                name: editName || propertyToEdit.key,
+                ...(propertyToEdit.valueType === 'select'
+                    ? {
+                          options: buildOptionPayload(editOptions),
+                      }
+                    : {}),
+            });
+        },
+        onSuccess: (response) => {
+            if (response.type === 'error') {
+                toast(response.errors[0]?.message ?? 'Failed to update property.');
+                return;
+            }
+
+            closeEditModal();
+            void queryClient.invalidateQueries({ queryKey: queryKeys.notes.propertyKeysAll(), exact: false });
+            void queryClient.invalidateQueries({ queryKey: queryKeys.notes.all(), exact: false });
+            void queryClient.invalidateQueries({ queryKey: queryKeys.views.all(), exact: false });
+            toast('Property updated.');
+        },
+        onError: () => {
+            toast('Failed to update property.');
         },
     });
 
@@ -109,7 +198,9 @@ export default function PropertiesSettings() {
                 return;
             }
 
-            void queryClient.invalidateQueries({ queryKey: queryKeys.notes.all() });
+            void queryClient.invalidateQueries({ queryKey: queryKeys.notes.propertyKeysAll(), exact: false });
+            void queryClient.invalidateQueries({ queryKey: queryKeys.notes.all(), exact: false });
+            void queryClient.invalidateQueries({ queryKey: queryKeys.views.all(), exact: false });
             setPropertyToDelete(null);
             toast(
                 response.deleteNotePropertyKey.affectedNoteCount > 0
@@ -124,6 +215,46 @@ export default function PropertiesSettings() {
 
     const propertyKeys = propertyKeysQuery.data?.keys ?? [];
     const hasValidSelectOption = valueType !== 'select' || options.some((option) => option.label.trim());
+    const editableEditOptions =
+        propertyToEdit?.valueType === 'select' ? editOptions.filter((option) => !isEmptyNewOptionDraft(option)) : [];
+    const editOptionValues = editableEditOptions.map(normalizeDraftOptionValue);
+    const duplicateEditOptionValue = editOptionValues.find((value, index) => editOptionValues.indexOf(value) !== index);
+    const invalidEditOptionValue = editOptionValues.find((value) => !isValidOptionValue(value));
+    const hasBlankExistingOptionLabel = editableEditOptions.some(
+        (option) => Boolean(option.id) && !option.label.trim(),
+    );
+    const hasIncompleteNewOption = editableEditOptions.some((option) => !option.id && !option.label.trim());
+    const hasValidEditSelectOption =
+        !propertyToEdit ||
+        propertyToEdit.valueType !== 'select' ||
+        (editableEditOptions.length > 0 &&
+            !hasBlankExistingOptionLabel &&
+            !hasIncompleteNewOption &&
+            !duplicateEditOptionValue &&
+            !invalidEditOptionValue);
+    const hasEditNameChanged = Boolean(propertyToEdit) && editName.trim() !== propertyToEdit?.name;
+    const hasEditOptionsChanged =
+        propertyToEdit?.valueType === 'select' &&
+        JSON.stringify(buildOptionPayload(editOptions)) !==
+            JSON.stringify(
+                propertyToEdit.options.map((option) => ({
+                    id: option.id,
+                    label: option.label,
+                    value: option.value,
+                    color: option.color ?? null,
+                    order: option.order,
+                })),
+            );
+    const hasEditChanges = hasEditNameChanged || Boolean(hasEditOptionsChanged);
+    const editValidationMessage = hasBlankExistingOptionLabel
+        ? 'Existing option labels cannot be empty.'
+        : hasIncompleteNewOption
+          ? 'New options need a label.'
+          : duplicateEditOptionValue
+            ? `Option value “${duplicateEditOptionValue}” is duplicated.`
+            : invalidEditOptionValue
+              ? 'Option values must use letters, numbers, dashes, or underscores.'
+              : '';
     const handleConfirmDeleteProperty = () => {
         if (!propertyToDelete) return;
 
@@ -228,16 +359,26 @@ export default function PropertiesSettings() {
                                         {propertyKey.noteCount} note{propertyKey.noteCount === 1 ? '' : 's'}
                                     </Text>
                                 </div>
-                                <Button
-                                    type="button"
-                                    size="sm"
-                                    variant="soft-danger"
-                                    className="justify-self-start md:justify-self-end"
-                                    disabled={deleteMutation.isPending}
-                                    onClick={() => setPropertyToDelete(propertyKey)}
-                                >
-                                    Delete
-                                </Button>
+                                <div className="flex flex-wrap gap-2 justify-self-start md:justify-self-end">
+                                    <Button
+                                        type="button"
+                                        size="sm"
+                                        variant="subtle"
+                                        disabled={updateMutation.isPending || deleteMutation.isPending}
+                                        onClick={() => openEditModal(propertyKey)}
+                                    >
+                                        Edit
+                                    </Button>
+                                    <Button
+                                        type="button"
+                                        size="sm"
+                                        variant="soft-danger"
+                                        disabled={deleteMutation.isPending || updateMutation.isPending}
+                                        onClick={() => setPropertyToDelete(propertyKey)}
+                                    >
+                                        Delete
+                                    </Button>
+                                </div>
                             </article>
                         ))}
                     </div>
@@ -305,7 +446,7 @@ export default function PropertiesSettings() {
                         </label>
                         {valueType === 'select' && (
                             <div className="rounded-[14px] border border-border-subtle bg-subtle/50 p-3">
-                                <div className="mb-2 flex items-center justify-between gap-2">
+                                <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
                                     <Text as="span" variant="label" weight="semibold">
                                         Options
                                     </Text>
@@ -394,6 +535,179 @@ export default function PropertiesSettings() {
                             onClick={() => createMutation.mutate()}
                         >
                             Create property
+                        </Button>
+                    </ModalActionRow>
+                </Modal.Footer>
+            </Modal>
+
+            <Modal
+                isOpen={Boolean(propertyToEdit)}
+                onClose={() => {
+                    if (!updateMutation.isPending) closeEditModal();
+                }}
+                variant="form"
+            >
+                <Modal.Header
+                    title="Edit property"
+                    onClose={() => {
+                        if (!updateMutation.isPending) closeEditModal();
+                    }}
+                />
+                <Modal.Body>
+                    {propertyToEdit && (
+                        <div className="flex flex-col gap-3">
+                            <Text as="p" variant="label" tone="tertiary">
+                                Rename the display label or add select options. Key, type, and existing option values
+                                stay fixed so notes and views remain stable.
+                            </Text>
+                            <div className="grid gap-2 sm:grid-cols-2">
+                                <div className="rounded-[14px] border border-border-subtle bg-subtle/50 px-3 py-2">
+                                    <Text as="span" variant="micro" tone="tertiary" className="block">
+                                        Key
+                                    </Text>
+                                    <Text as="span" variant="label" weight="medium" className="font-mono">
+                                        {propertyToEdit.key}
+                                    </Text>
+                                </div>
+                                <div className="rounded-[14px] border border-border-subtle bg-subtle/50 px-3 py-2">
+                                    <Text as="span" variant="micro" tone="tertiary" className="block">
+                                        Type
+                                    </Text>
+                                    <Text as="span" variant="label" weight="medium" className="capitalize">
+                                        {propertyToEdit.valueType}
+                                    </Text>
+                                </div>
+                            </div>
+                            <label className="flex flex-col gap-1.5">
+                                <Text as="span" variant="label" weight="medium">
+                                    Display name
+                                </Text>
+                                <Input
+                                    size="md"
+                                    placeholder="Workflow state"
+                                    value={editName}
+                                    onChange={(event) => setEditName(event.target.value)}
+                                />
+                            </label>
+                            {propertyToEdit.valueType === 'select' && (
+                                <div className="rounded-[14px] border border-border-subtle bg-subtle/50 p-3">
+                                    <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+                                        <div>
+                                            <Text as="span" variant="label" weight="semibold">
+                                                Options
+                                            </Text>
+                                            <Text as="p" variant="micro" tone="tertiary" className="mt-0.5">
+                                                Existing option values are locked. Removing existing options needs an
+                                                impact-aware delete flow.
+                                            </Text>
+                                        </div>
+                                        <Button
+                                            type="button"
+                                            size="sm"
+                                            variant="subtle"
+                                            onClick={() =>
+                                                setEditOptions((current) => [...current, { label: '', value: '' }])
+                                            }
+                                        >
+                                            Add option
+                                        </Button>
+                                    </div>
+                                    <div className="flex flex-col gap-2">
+                                        {editOptions.map((option, index) => (
+                                            <div
+                                                key={option.id ?? `new-${index}`}
+                                                className="grid gap-2 sm:grid-cols-[1fr_1fr_auto]"
+                                            >
+                                                <Input
+                                                    size="sm"
+                                                    placeholder="Label"
+                                                    value={option.label}
+                                                    onChange={(event) =>
+                                                        setEditOptions((current) =>
+                                                            current.map((item, itemIndex) =>
+                                                                itemIndex === index
+                                                                    ? { ...item, label: event.target.value }
+                                                                    : item,
+                                                            ),
+                                                        )
+                                                    }
+                                                />
+                                                <Input
+                                                    size="sm"
+                                                    placeholder={option.id ? 'Locked value' : 'value'}
+                                                    value={option.value}
+                                                    disabled={Boolean(option.id)}
+                                                    onChange={(event) =>
+                                                        setEditOptions((current) =>
+                                                            current.map((item, itemIndex) =>
+                                                                itemIndex === index
+                                                                    ? { ...item, value: event.target.value }
+                                                                    : item,
+                                                            ),
+                                                        )
+                                                    }
+                                                />
+                                                {option.id ? (
+                                                    <Text
+                                                        as="span"
+                                                        variant="meta"
+                                                        tone="tertiary"
+                                                        className="flex h-8 items-center px-3"
+                                                    >
+                                                        Locked
+                                                    </Text>
+                                                ) : (
+                                                    <Button
+                                                        type="button"
+                                                        size="sm"
+                                                        variant="soft-danger"
+                                                        onClick={() =>
+                                                            setEditOptions((current) =>
+                                                                current.filter((_, itemIndex) => itemIndex !== index),
+                                                            )
+                                                        }
+                                                    >
+                                                        Remove
+                                                    </Button>
+                                                )}
+                                            </div>
+                                        ))}
+                                    </div>
+                                    {editValidationMessage && (
+                                        <Text as="p" variant="micro" tone="error" className="mt-2">
+                                            {editValidationMessage}
+                                        </Text>
+                                    )}
+                                </div>
+                            )}
+                        </div>
+                    )}
+                </Modal.Body>
+                <Modal.Footer>
+                    <ModalActionRow>
+                        <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            disabled={updateMutation.isPending}
+                            onClick={closeEditModal}
+                        >
+                            Cancel
+                        </Button>
+                        <Button
+                            type="button"
+                            variant="primary"
+                            size="sm"
+                            disabled={
+                                !editName.trim() ||
+                                !hasEditChanges ||
+                                !hasValidEditSelectOption ||
+                                updateMutation.isPending
+                            }
+                            isLoading={updateMutation.isPending}
+                            onClick={() => updateMutation.mutate()}
+                        >
+                            Save changes
                         </Button>
                     </ModalActionRow>
                 </Modal.Footer>

--- a/packages/server/src/features/note/graphql/note.mutation.resolver.ts
+++ b/packages/server/src/features/note/graphql/note.mutation.resolver.ts
@@ -8,8 +8,10 @@ import {
     InvalidNotePropertyInputError,
     type NotePropertiesPatchInput,
     type NotePropertyDefinitionInput,
+    type NotePropertyDefinitionUpdateInput,
     NotePropertyDeleteConfirmationRequiredError,
     updateNotePropertiesWithVersionGuard,
+    updateNotePropertyDefinition,
 } from '~/features/note/services/properties.js';
 import { buildNoteSearchProjection } from '~/features/note/services/search.js';
 import { createSnapshotMetaFromUserAgent, restoreNoteSnapshot } from '~/features/note/services/snapshot.js';
@@ -224,6 +226,27 @@ export const noteMutationResolvers: NoteMutationResolvers = {
     createNotePropertyKey: async (_, { input }: { input: NotePropertyDefinitionInput }) => {
         try {
             return await createNotePropertyDefinition(input);
+        } catch (error) {
+            if (error instanceof InvalidNotePropertyInputError) {
+                throw new GraphQLError(error.message, {
+                    extensions: {
+                        code: 'INVALID_NOTE_PROPERTY_INPUT',
+                    },
+                });
+            }
+
+            throw error;
+        }
+    },
+    updateNotePropertyKey: async (_, { key, input }: { key: string; input: NotePropertyDefinitionUpdateInput }) => {
+        try {
+            const result = await updateNotePropertyDefinition({ key, input });
+
+            if (!result) {
+                throw 'NOT FOUND';
+            }
+
+            return result;
         } catch (error) {
             if (error instanceof InvalidNotePropertyInputError) {
                 throw new GraphQLError(error.message, {

--- a/packages/server/src/features/note/graphql/note.type-defs.ts
+++ b/packages/server/src/features/note/graphql/note.type-defs.ts
@@ -57,11 +57,24 @@ export const noteType = gql`
         order: Int
     }
 
+    input NotePropertyOptionUpdateInput {
+        id: ID
+        label: String!
+        value: String
+        color: String
+        order: Int
+    }
+
     input NotePropertyDefinitionInput {
         key: String!
         name: String
         valueType: NotePropertyValueType!
         options: [NotePropertyOptionInput!]
+    }
+
+    input NotePropertyDefinitionUpdateInput {
+        name: String
+        options: [NotePropertyOptionUpdateInput!]
     }
 
     input NotePropertiesPatchInput {
@@ -252,6 +265,7 @@ export const noteMutation = gql`
         restoreTrashedNote(id: ID!): Note!
         purgeTrashedNote(id: ID!): Boolean!
         createNotePropertyKey(input: NotePropertyDefinitionInput!): NotePropertyKey!
+        updateNotePropertyKey(key: String!, input: NotePropertyDefinitionUpdateInput!): NotePropertyKey!
         deleteNotePropertyKey(key: String!, confirmImpact: Boolean): NotePropertyDeleteResult!
         updateNoteProperties(
             id: ID!

--- a/packages/server/src/features/note/services/properties.test.ts
+++ b/packages/server/src/features/note/services/properties.test.ts
@@ -2,9 +2,12 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import {
+    assertPropertyOptionUpdateKeepsUsedValues,
     createNotePropertyDefinition,
+    findReferencedRemovedPropertyOptionValue,
     InvalidNotePropertyInputError,
     normalizePropertyKey,
+    renamePropertyFiltersInViewQuery,
     updateNotePropertiesWithVersionGuard,
 } from './properties.js';
 import { MissingNoteVersionError } from './write-conflict.js';
@@ -57,6 +60,103 @@ test('property definitions require valid select option datasets before write', a
         (error: unknown) =>
             error instanceof InvalidNotePropertyInputError &&
             error.message === 'Only select properties can have options.',
+    );
+});
+
+test('property definition option updates keep used option values', () => {
+    assert.doesNotThrow(() =>
+        assertPropertyOptionUpdateKeepsUsedValues({
+            existingOptions: [
+                { value: 'todo', _count: { properties: 0 } },
+                { value: 'doing', _count: { properties: 2 } },
+            ],
+            nextOptions: [{ value: 'doing' }],
+        }),
+    );
+
+    assert.throws(
+        () =>
+            assertPropertyOptionUpdateKeepsUsedValues({
+                existingOptions: [{ value: 'doing', _count: { properties: 2 } }],
+                nextOptions: [{ value: 'done' }],
+            }),
+        InvalidNotePropertyInputError,
+    );
+});
+
+test('property option updates keep values referenced by saved views', () => {
+    const query = JSON.stringify({
+        propertyFilters: [
+            {
+                key: 'state',
+                name: 'State',
+                valueType: 'select',
+                operator: 'equals',
+                value: 'doing',
+            },
+        ],
+        sortBy: 'updatedAt',
+        sortOrder: 'desc',
+    });
+
+    assert.equal(
+        findReferencedRemovedPropertyOptionValue({
+            query,
+            key: 'state',
+            removedValues: new Set(['doing']),
+        }),
+        'doing',
+    );
+
+    assert.equal(
+        findReferencedRemovedPropertyOptionValue({
+            query,
+            key: 'state',
+            removedValues: new Set(['done']),
+        }),
+        null,
+    );
+});
+
+test('property definition rename refreshes saved view filter labels', () => {
+    const query = JSON.stringify({
+        propertyFilters: [
+            {
+                key: 'state',
+                name: 'State',
+                valueType: 'select',
+                operator: 'equals',
+                value: 'doing',
+            },
+            {
+                key: 'project',
+                name: 'Project',
+                valueType: 'text',
+                operator: 'equals',
+                value: 'ocean',
+            },
+        ],
+        sortBy: 'updatedAt',
+        sortOrder: 'desc',
+    });
+
+    const updatedQuery = renamePropertyFiltersInViewQuery({
+        query,
+        key: 'state',
+        name: 'Workflow state',
+    });
+
+    assert.ok(updatedQuery);
+    const parsed = JSON.parse(updatedQuery) as {
+        propertyFilters: Array<{ key: string; name: string }>;
+    };
+
+    assert.deepEqual(
+        parsed.propertyFilters.map((filter) => [filter.key, filter.name]),
+        [
+            ['state', 'Workflow state'],
+            ['project', 'Project'],
+        ],
     );
 });
 

--- a/packages/server/src/features/note/services/properties.ts
+++ b/packages/server/src/features/note/services/properties.ts
@@ -61,11 +61,20 @@ export interface NotePropertyOptionInput {
     order?: number | null;
 }
 
+export interface NotePropertyOptionUpdateInput extends NotePropertyOptionInput {
+    id?: string | number | null;
+}
+
 export interface NotePropertyDefinitionInput {
     key: string;
     name?: string | null;
     valueType: PropertyValueType;
     options?: NotePropertyOptionInput[] | null;
+}
+
+export interface NotePropertyDefinitionUpdateInput {
+    name?: string | null;
+    options?: NotePropertyOptionUpdateInput[] | null;
 }
 
 type NotePropertyWithDefinition = Prisma.NotePropertyGetPayload<{
@@ -203,6 +212,52 @@ const normalizePropertyOptions = (options: NotePropertyOptionInput[] | null | un
     });
 };
 
+const normalizePropertyOptionUpdates = (
+    options: NotePropertyOptionUpdateInput[] | null | undefined,
+    existingOptions: Array<{ id: number; value: string }>,
+) => {
+    const normalizedOptions = options ?? [];
+
+    if (normalizedOptions.length > PROPERTY_OPTION_LIMIT) {
+        throw new InvalidNotePropertyInputError(`Select properties can have up to ${PROPERTY_OPTION_LIMIT} options.`);
+    }
+
+    const existingOptionById = new Map(existingOptions.map((option) => [String(option.id), option]));
+    const seenValues = new Set<string>();
+
+    return normalizedOptions.map((option, index) => {
+        const label = normalizeOptionLabel(option.label);
+        const existingOption =
+            option.id === undefined || option.id === null ? null : existingOptionById.get(String(option.id));
+
+        if (option.id !== undefined && option.id !== null && !existingOption) {
+            throw new InvalidNotePropertyInputError('Property option does not belong to this property.');
+        }
+
+        const value = normalizeOptionValue(option.value ?? existingOption?.value ?? label);
+
+        if (existingOption && value !== existingOption.value) {
+            throw new InvalidNotePropertyInputError(
+                `Property option ${existingOption.value} value cannot be changed. Create a new option instead.`,
+            );
+        }
+
+        if (seenValues.has(value)) {
+            throw new InvalidNotePropertyInputError('Property options contain duplicate values.');
+        }
+
+        seenValues.add(value);
+
+        return {
+            id: existingOption?.id,
+            label,
+            value,
+            color: option.color?.trim() || null,
+            order: Number.isFinite(Number(option.order)) ? Number(option.order) : index,
+        };
+    });
+};
+
 const normalizeTextValue = (value: string) => {
     if (value.length > PROPERTY_TEXT_VALUE_MAX_LENGTH) {
         throw new InvalidNotePropertyInputError(
@@ -305,6 +360,135 @@ const serializePropertyDefinition = (definition: PropertyDefinitionWithOptions):
     options: definition.options.sort((left, right) => left.order - right.order).map(serializeDefinitionOption),
     updatedAt: definition.updatedAt.toISOString(),
 });
+
+export const assertPropertyOptionUpdateKeepsUsedValues = ({
+    existingOptions,
+    nextOptions,
+}: {
+    existingOptions: Array<{ value: string; _count: { properties: number } }>;
+    nextOptions: Array<{ value: string }>;
+}) => {
+    const nextValues = new Set(nextOptions.map((option) => option.value));
+    const removedUsedOption = existingOptions.find(
+        (option) => option._count.properties > 0 && !nextValues.has(option.value),
+    );
+
+    if (removedUsedOption) {
+        throw new InvalidNotePropertyInputError(
+            `Property option ${removedUsedOption.value} is used by notes and cannot be removed.`,
+        );
+    }
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+};
+
+const parseViewQueryRecord = (value: string | null) => {
+    if (!value) {
+        return null;
+    }
+
+    try {
+        const parsed = JSON.parse(value) as unknown;
+        return isRecord(parsed) ? parsed : null;
+    } catch {
+        return null;
+    }
+};
+
+const getNormalizedViewFilterKey = (filter: Record<string, unknown>) => {
+    if (typeof filter.key !== 'string') {
+        return null;
+    }
+
+    try {
+        return normalizePropertyKey(filter.key);
+    } catch {
+        return null;
+    }
+};
+
+export const renamePropertyFiltersInViewQuery = ({
+    query,
+    key,
+    name,
+}: {
+    query: string | null;
+    key: string;
+    name: string;
+}) => {
+    const parsed = parseViewQueryRecord(query);
+
+    if (!parsed || !Array.isArray(parsed.propertyFilters)) {
+        return null;
+    }
+
+    let changed = false;
+    const propertyFilters = parsed.propertyFilters.map((filter) => {
+        if (!isRecord(filter) || getNormalizedViewFilterKey(filter) !== key) {
+            return filter;
+        }
+
+        changed = true;
+        return {
+            ...filter,
+            key,
+            name,
+        };
+    });
+
+    if (!changed) {
+        return null;
+    }
+
+    return JSON.stringify({
+        ...parsed,
+        propertyFilters,
+    });
+};
+
+const normalizeReferencedOptionValue = (value: unknown) => {
+    return typeof value === 'string' ? normalizeOptionValue(value) : null;
+};
+
+export const findReferencedRemovedPropertyOptionValue = ({
+    query,
+    key,
+    removedValues,
+}: {
+    query: string | null;
+    key: string;
+    removedValues: Set<string>;
+}) => {
+    const parsed = parseViewQueryRecord(query);
+
+    if (!parsed || !Array.isArray(parsed.propertyFilters)) {
+        return null;
+    }
+
+    for (const filter of parsed.propertyFilters) {
+        if (!isRecord(filter) || getNormalizedViewFilterKey(filter) !== key) {
+            continue;
+        }
+
+        if (filter.valueType !== 'select' || filter.operator === 'exists' || filter.operator === 'notExists') {
+            continue;
+        }
+
+        try {
+            const optionValue = normalizeReferencedOptionValue(filter.value);
+
+            if (optionValue && removedValues.has(optionValue)) {
+                return optionValue;
+            }
+        } catch {
+            continue;
+        }
+    }
+
+    return null;
+};
 
 const buildTypedValueData = async (
     input: NotePropertySetInput,
@@ -480,6 +664,156 @@ export const createNotePropertyDefinition = async (input: NotePropertyDefinition
 
         throw error;
     }
+};
+
+export const updateNotePropertyDefinition = async ({
+    key,
+    input,
+}: {
+    key: string;
+    input: NotePropertyDefinitionUpdateInput;
+}): Promise<SerializedNotePropertyKey | null> => {
+    const normalizedKey = normalizePropertyKey(key);
+
+    return models.$transaction(async (tx) => {
+        const definition = await tx.propertyDefinition.findUnique({
+            where: { key: normalizedKey },
+            include: {
+                options: {
+                    orderBy: { order: 'asc' },
+                    include: { _count: { select: { properties: true } } },
+                },
+                _count: { select: { properties: true } },
+            },
+        });
+
+        if (!definition) {
+            return null;
+        }
+
+        const nextName = input.name !== undefined ? normalizePropertyName(input.name, definition.key) : definition.name;
+        const shouldUpdateOptions = input.options !== undefined;
+        let nextOptions: ReturnType<typeof normalizePropertyOptionUpdates> | null = null;
+
+        if (shouldUpdateOptions) {
+            nextOptions = normalizePropertyOptionUpdates(input.options, definition.options);
+
+            if (definition.valueType !== 'select' && nextOptions.length > 0) {
+                throw new InvalidNotePropertyInputError('Only select properties can have options.');
+            }
+
+            if (definition.valueType === 'select' && nextOptions.length === 0) {
+                throw new InvalidNotePropertyInputError('Select properties require at least one option.');
+            }
+
+            assertPropertyOptionUpdateKeepsUsedValues({
+                existingOptions: definition.options,
+                nextOptions,
+            });
+
+            const nextValues = new Set(nextOptions.map((option) => option.value));
+            const removedValues = new Set(
+                definition.options.filter((option) => !nextValues.has(option.value)).map((option) => option.value),
+            );
+
+            if (removedValues.size > 0) {
+                const referencingViewSections = await tx.viewSection.findMany({
+                    where: { query: { contains: definition.key } },
+                    select: { title: true, query: true },
+                });
+
+                for (const section of referencingViewSections) {
+                    const removedReferencedValue = findReferencedRemovedPropertyOptionValue({
+                        query: section.query,
+                        key: definition.key,
+                        removedValues,
+                    });
+
+                    if (removedReferencedValue) {
+                        throw new InvalidNotePropertyInputError(
+                            `Property option ${removedReferencedValue} is used by view ${section.title} and cannot be removed.`,
+                        );
+                    }
+                }
+            }
+        }
+
+        await tx.propertyDefinition.update({
+            where: { id: definition.id },
+            data: { name: nextName },
+        });
+
+        if (nextName !== definition.name) {
+            const referencingViewSections = await tx.viewSection.findMany({
+                where: { query: { contains: definition.key } },
+                select: { id: true, query: true },
+            });
+
+            for (const section of referencingViewSections) {
+                const nextQuery = renamePropertyFiltersInViewQuery({
+                    query: section.query,
+                    key: definition.key,
+                    name: nextName,
+                });
+
+                if (nextQuery) {
+                    await tx.viewSection.update({
+                        where: { id: section.id },
+                        data: { query: nextQuery },
+                    });
+                }
+            }
+        }
+
+        if (nextOptions) {
+            const existingOptionByValue = new Map(definition.options.map((option) => [option.value, option]));
+            const nextValues = new Set(nextOptions.map((option) => option.value));
+            const removableOptionIds = definition.options
+                .filter((option) => !nextValues.has(option.value) && option._count.properties === 0)
+                .map((option) => option.id);
+
+            if (removableOptionIds.length > 0) {
+                await tx.propertyOption.deleteMany({
+                    where: {
+                        id: { in: removableOptionIds },
+                    },
+                });
+            }
+
+            for (const option of nextOptions) {
+                const existingOption = existingOptionByValue.get(option.value);
+
+                if (existingOption) {
+                    await tx.propertyOption.update({
+                        where: { id: existingOption.id },
+                        data: {
+                            label: option.label,
+                            color: option.color,
+                            order: option.order,
+                        },
+                    });
+                    continue;
+                }
+
+                await tx.propertyOption.create({
+                    data: {
+                        propertyDefinitionId: definition.id,
+                        label: option.label,
+                        value: option.value,
+                        color: option.color,
+                        order: option.order,
+                    },
+                });
+            }
+        }
+
+        const updatedDefinition = await tx.propertyDefinition.findUniqueOrThrow({
+            where: { id: definition.id },
+            include: { options: { orderBy: { order: 'asc' } }, _count: { select: { properties: true } } },
+        });
+
+        return serializePropertyDefinition(updatedDefinition);
+    });
 };
 
 export const deleteNotePropertyDefinition = async ({


### PR DESCRIPTION
## :dart: Goal

Fix the property settings edit flow so shared property definitions can be safely renamed and select options can be managed without breaking existing notes or saved views.

## :hammer_and_wrench: Core Changes

- Add `updateNotePropertyKey` GraphQL mutation and client API support.
- Allow editing property display names while keeping keys and types immutable.
- Lock existing select option values and allow label updates without changing stored note values.
- Preserve option metadata and block unsafe option removal when notes or views still reference the option.
- Refresh property, note, and view queries after property updates/deletes.
- Prevent button label wrapping in the shared button style.
- Add client and server coverage for the property edit path and safety guards.

## :brain: Key Decisions

- Existing property keys and value types remain immutable to avoid data migration ambiguity.
- Existing select option values remain immutable because notes and view filters depend on raw values.
- Existing option deletion is intentionally deferred to a separate impact-aware flow; this PR only prevents accidental destructive changes.
- Property display name changes update saved view filter labels so the UI does not show stale names.

## :test_tube: Verification Guide

- `pnpm lint`
- `pnpm type-check`
- `pnpm test:ci`
- `pnpm check:encoding`
- `pnpm build`
- `git diff --check`

## :white_check_mark: Checklist

- [x] Team-agent review completed with no merge-blocking issues.
- [x] Property edit UX keeps name editable and key/type/value immutable.
- [x] Server guards protect existing note values and saved view filters.
- [x] Full local validation passed.
