### PR TITLE
✨ Add URL property type

### DIFF
--- a/packages/cli/src/mcp.ts
+++ b/packages/cli/src/mcp.ts
@@ -42,7 +42,7 @@ export const OCEAN_BRAIN_MCP_TOOLS = {
 
 const noteLayoutSchema = z.enum(['narrow', 'wide', 'full']);
 const tagMatchModeSchema = z.enum(['and', 'or']);
-const propertyValueTypeSchema = z.enum(['text', 'number', 'date', 'boolean', 'select']);
+const propertyValueTypeSchema = z.enum(['text', 'url', 'number', 'date', 'boolean', 'select']);
 const propertyFilterOperatorSchema = z.enum(['equals', 'before', 'after', 'exists', 'notExists']);
 const viewSortBySchema = z.enum(['updatedAt', 'createdAt', 'title']);
 const viewSortOrderSchema = z.enum(['asc', 'desc']);
@@ -50,7 +50,7 @@ const propertyFilterSchema = z.object({
     key: z.string().describe('Property key from ocean_brain_list_properties, e.g. state'),
     valueType: propertyValueTypeSchema.describe('Property value type from the property definition'),
     operator: propertyFilterOperatorSchema.describe('Filter operator. before/after are only valid for date or number properties.'),
-    value: z.string().nullable().optional().describe('Filter value. Required unless operator is exists or notExists. Select filters use option.value, not option.label.')
+    value: z.string().nullable().optional().describe('Filter value. Required unless operator is exists or notExists. Select filters use option.value, not option.label. URL filters require an http(s) URL.')
 });
 
 const normalizeOceanBrainTagName = (name: string) => {
@@ -451,7 +451,7 @@ export async function startMcpServer(
                 keys: Array<{
                     key: string;
                     name: string;
-                    valueType: 'text' | 'number' | 'date' | 'boolean' | 'select';
+                    valueType: 'text' | 'url' | 'number' | 'date' | 'boolean' | 'select';
                     noteCount: number;
                     updatedAt: string;
                     options: Array<{

--- a/packages/client/src/components/view/ViewSectionDialog.tsx
+++ b/packages/client/src/components/view/ViewSectionDialog.tsx
@@ -402,14 +402,20 @@ export default function ViewSectionDialog({
                                                                 ? 'date'
                                                                 : property.valueType === 'number'
                                                                   ? 'number'
-                                                                  : 'text'
+                                                                  : property.valueType === 'url'
+                                                                    ? 'url'
+                                                                    : 'text'
                                                         }
                                                         value={filter.value}
                                                         onChange={(event) =>
                                                             updateFilter(filter.id, { value: event.target.value })
                                                         }
                                                         placeholder={
-                                                            property.valueType === 'text' ? 'Value' : undefined
+                                                            property.valueType === 'url'
+                                                                ? 'https://example.com'
+                                                                : property.valueType === 'text'
+                                                                  ? 'Value'
+                                                                  : undefined
                                                         }
                                                     />
                                                 )

--- a/packages/client/src/models/note.model.ts
+++ b/packages/client/src/models/note.model.ts
@@ -1,5 +1,5 @@
 export type NoteLayout = 'narrow' | 'wide' | 'full';
-export type NotePropertyValueType = 'text' | 'number' | 'date' | 'boolean' | 'select';
+export type NotePropertyValueType = 'text' | 'url' | 'number' | 'date' | 'boolean' | 'select';
 
 export interface NotePropertyOption {
     id: string;

--- a/packages/client/src/models/view.model.ts
+++ b/packages/client/src/models/view.model.ts
@@ -7,7 +7,7 @@ export type ViewSortOrder = 'asc' | 'desc';
 export interface ViewPropertyFilter {
     key: string;
     name: string;
-    valueType: 'text' | 'number' | 'date' | 'boolean' | 'select';
+    valueType: 'text' | 'url' | 'number' | 'date' | 'boolean' | 'select';
     operator: ViewPropertyFilterOperator;
     value?: string | null;
 }

--- a/packages/client/src/pages/Note.tsx
+++ b/packages/client/src/pages/Note.tsx
@@ -98,6 +98,21 @@ const compareNoteVersions = (left: string, right: string) => {
     return leftTime - rightTime;
 };
 
+const getSafeExternalUrl = (value: string) => {
+    const trimmedValue = value.trim();
+
+    if (!trimmedValue) {
+        return null;
+    }
+
+    try {
+        const url = new URL(trimmedValue);
+        return url.protocol === 'http:' || url.protocol === 'https:' ? url.toString() : null;
+    } catch {
+        return null;
+    }
+};
+
 const NOTE_LAYOUT_WIDTH: Record<NoteLayout, string> = {
     narrow: 'max-w-[640px]',
     wide: 'max-w-[896px]',
@@ -172,7 +187,10 @@ const getPropertyRowsPatchDraft = (
         const value = row.value.trim();
         const shouldDeleteBlankPersistedValue =
             Boolean(row.persistedKey) &&
-            (row.valueType === 'number' || row.valueType === 'date' || row.valueType === 'select');
+            (row.valueType === 'number' ||
+                row.valueType === 'date' ||
+                row.valueType === 'select' ||
+                row.valueType === 'url');
 
         if (!value && shouldDeleteBlankPersistedValue) {
             deleteKeySet.add(row.persistedKey as string);
@@ -426,84 +444,120 @@ const NotePropertiesPanel = ({
                 </Text>
             ) : (
                 <div className="divide-y divide-border-subtle">
-                    {rows.map((row) => (
-                        <div
-                            key={row.id}
-                            className="group grid gap-2 py-2 sm:grid-cols-[minmax(0,180px)_minmax(0,1fr)_auto] sm:items-center"
-                        >
-                            <div className="flex min-w-0 items-center gap-2 px-1">
-                                <Text as="span" variant="label" tone="secondary" className="truncate">
-                                    {row.name}
-                                </Text>
-                                <Text
-                                    as="span"
-                                    variant="micro"
-                                    tone="tertiary"
-                                    className="hidden truncate font-mono sm:inline"
-                                >
-                                    {row.key}
-                                </Text>
-                            </div>
-                            {row.valueType === 'boolean' ? (
-                                <Select
-                                    size="sm"
-                                    variant="ghost"
-                                    value={row.value || 'false'}
-                                    disabled={disabled}
-                                    onValueChange={(value) => updateRow(row.id, { value })}
-                                >
-                                    <SelectItem value="false">False</SelectItem>
-                                    <SelectItem value="true">True</SelectItem>
-                                </Select>
-                            ) : row.valueType === 'select' ? (
-                                <Select
-                                    size="sm"
-                                    variant="ghost"
-                                    value={row.value}
-                                    placeholder="Select option"
-                                    disabled={disabled}
-                                    onValueChange={(value) => updateRow(row.id, { value })}
-                                >
-                                    {(
-                                        propertyKeySummaries.find((propertyKey) => propertyKey.key === row.key)
-                                            ?.options ?? []
-                                    ).map((option) => (
-                                        <SelectItem key={option.id} value={option.value}>
-                                            {option.label}
-                                        </SelectItem>
-                                    ))}
-                                </Select>
-                            ) : (
-                                <Input
-                                    size="sm"
-                                    variant="ghost"
-                                    type={
-                                        row.valueType === 'date'
-                                            ? 'date'
-                                            : row.valueType === 'number'
-                                              ? 'number'
-                                              : 'text'
-                                    }
-                                    aria-label="Property value"
-                                    placeholder="Value"
-                                    value={row.value}
-                                    disabled={disabled}
-                                    onChange={(event) => updateRow(row.id, { value: event.target.value })}
-                                />
-                            )}
-                            <Button
-                                type="button"
-                                size="icon-sm"
-                                variant="ghost"
-                                aria-label={`Remove ${row.name}`}
-                                disabled={disabled}
-                                className="justify-self-end text-fg-tertiary sm:opacity-0 sm:group-hover:opacity-100 sm:focus-visible:opacity-100"
-                                onClick={() => removeRow(row)}
+                    {rows.map((row) => {
+                        const safeExternalUrl = row.valueType === 'url' ? getSafeExternalUrl(row.value) : null;
+
+                        return (
+                            <div
+                                key={row.id}
+                                className="group grid gap-2 py-2 sm:grid-cols-[minmax(0,180px)_minmax(0,1fr)_auto] sm:items-center"
                             >
-                                <Icon.Close className="h-4 w-4" />
-                            </Button>
-                        </div>
-                    ))}
+                                <div className="flex min-w-0 items-center gap-2 px-1">
+                                    <Text as="span" variant="label" tone="secondary" className="truncate">
+                                        {row.name}
+                                    </Text>
+                                    <Text
+                                        as="span"
+                                        variant="micro"
+                                        tone="tertiary"
+                                        className="hidden truncate font-mono sm:inline"
+                                    >
+                                        {row.key}
+                                    </Text>
+                                </div>
+                                {row.valueType === 'boolean' ? (
+                                    <Select
+                                        size="sm"
+                                        variant="ghost"
+                                        value={row.value || 'false'}
+                                        disabled={disabled}
+                                        onValueChange={(value) => updateRow(row.id, { value })}
+                                    >
+                                        <SelectItem value="false">False</SelectItem>
+                                        <SelectItem value="true">True</SelectItem>
+                                    </Select>
+                                ) : row.valueType === 'select' ? (
+                                    <Select
+                                        size="sm"
+                                        variant="ghost"
+                                        value={row.value}
+                                        placeholder="Select option"
+                                        disabled={disabled}
+                                        onValueChange={(value) => updateRow(row.id, { value })}
+                                    >
+                                        {(
+                                            propertyKeySummaries.find((propertyKey) => propertyKey.key === row.key)
+                                                ?.options ?? []
+                                        ).map((option) => (
+                                            <SelectItem key={option.id} value={option.value}>
+                                                {option.label}
+                                            </SelectItem>
+                                        ))}
+                                    </Select>
+                                ) : row.valueType === 'url' ? (
+                                    <div className="flex min-w-0 items-center gap-1">
+                                        <Input
+                                            className="min-w-0"
+                                            size="sm"
+                                            variant="ghost"
+                                            type="url"
+                                            aria-label="Property value"
+                                            placeholder="https://example.com"
+                                            value={row.value}
+                                            disabled={disabled}
+                                            onChange={(event) => updateRow(row.id, { value: event.target.value })}
+                                        />
+                                        {safeExternalUrl ? (
+                                            <Button
+                                                asChild
+                                                size="icon-sm"
+                                                variant="ghost"
+                                                aria-label={`Open ${row.name}`}
+                                                className="shrink-0 text-fg-tertiary"
+                                            >
+                                                <a
+                                                    href={safeExternalUrl}
+                                                    target="_blank"
+                                                    rel="noopener noreferrer"
+                                                    title={safeExternalUrl}
+                                                >
+                                                    <Icon.LinkSimple className="h-4 w-4" />
+                                                </a>
+                                            </Button>
+                                        ) : null}
+                                    </div>
+                                ) : (
+                                    <Input
+                                        size="sm"
+                                        variant="ghost"
+                                        type={
+                                            row.valueType === 'date'
+                                                ? 'date'
+                                                : row.valueType === 'number'
+                                                  ? 'number'
+                                                  : 'text'
+                                        }
+                                        aria-label="Property value"
+                                        placeholder="Value"
+                                        value={row.value}
+                                        disabled={disabled}
+                                        onChange={(event) => updateRow(row.id, { value: event.target.value })}
+                                    />
+                                )}
+                                <Button
+                                    type="button"
+                                    size="icon-sm"
+                                    variant="ghost"
+                                    aria-label={`Remove ${row.name}`}
+                                    disabled={disabled}
+                                    className="justify-self-end text-fg-tertiary sm:opacity-0 sm:group-hover:opacity-100 sm:focus-visible:opacity-100"
+                                    onClick={() => removeRow(row)}
+                                >
+                                    <Icon.Close className="h-4 w-4" />
+                                </Button>
+                            </div>
+                        );
+                    })}
                 </div>
             )}
 

--- a/packages/client/src/pages/setting/properties.tsx
+++ b/packages/client/src/pages/setting/properties.tsx
@@ -18,6 +18,7 @@ const Route = getRouteApi(SETTINGS_PROPERTIES_ROUTE);
 
 const PROPERTY_TYPE_OPTIONS: { value: NotePropertyValueType; label: string; description: string }[] = [
     { value: 'text', label: 'Text', description: 'Short status or label values.' },
+    { value: 'url', label: 'URL', description: 'External sources, issues, docs, or references.' },
     { value: 'number', label: 'Number', description: 'Priority, score, or count values.' },
     { value: 'date', label: 'Date', description: 'Due dates and milestones.' },
     { value: 'boolean', label: 'Boolean', description: 'True or false flags.' },

--- a/packages/server/prisma/schema.prisma
+++ b/packages/server/prisma/schema.prisma
@@ -205,6 +205,7 @@ enum NoteLayout {
 
 enum PropertyValueType {
   text
+  url
   number
   date
   boolean

--- a/packages/server/src/features/note/graphql/note.type-defs.ts
+++ b/packages/server/src/features/note/graphql/note.type-defs.ts
@@ -31,6 +31,7 @@ export const noteType = gql`
 
     enum NotePropertyValueType {
         text
+        url
         number
         date
         boolean

--- a/packages/server/src/features/note/services/properties.test.ts
+++ b/packages/server/src/features/note/services/properties.test.ts
@@ -7,6 +7,7 @@ import {
     findReferencedRemovedPropertyOptionValue,
     InvalidNotePropertyInputError,
     normalizePropertyKey,
+    normalizeUrlValue,
     renamePropertyFiltersInViewQuery,
     updateNotePropertiesWithVersionGuard,
 } from './properties.js';
@@ -20,6 +21,12 @@ test('normalizePropertyKey normalizes user input into a stable query key', () =>
 test('normalizePropertyKey rejects empty or unsupported keys', () => {
     assert.throws(() => normalizePropertyKey('   '), InvalidNotePropertyInputError);
     assert.throws(() => normalizePropertyKey('#state'), InvalidNotePropertyInputError);
+});
+
+test('normalizeUrlValue accepts only http(s) URLs', () => {
+    assert.equal(normalizeUrlValue(' https://example.com/docs '), 'https://example.com/docs');
+    assert.throws(() => normalizeUrlValue('example.com'), InvalidNotePropertyInputError);
+    assert.throws(() => normalizeUrlValue('javascript:alert(1)'), InvalidNotePropertyInputError);
 });
 
 test('property definitions require valid select option datasets before write', async () => {

--- a/packages/server/src/features/note/services/properties.ts
+++ b/packages/server/src/features/note/services/properties.ts
@@ -268,6 +268,28 @@ const normalizeTextValue = (value: string) => {
     return value;
 };
 
+export const normalizeUrlValue = (value: string) => {
+    const trimmedValue = normalizeTextValue(value.trim());
+
+    if (!trimmedValue) {
+        throw new InvalidNotePropertyInputError('URL property value is required.');
+    }
+
+    let url: URL;
+
+    try {
+        url = new URL(trimmedValue);
+    } catch {
+        throw new InvalidNotePropertyInputError('URL property values must be valid http(s) URLs.');
+    }
+
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+        throw new InvalidNotePropertyInputError('URL property values must use http or https.');
+    }
+
+    return url.toString();
+};
+
 const normalizeDateValue = (value: string) => {
     if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
         throw new InvalidNotePropertyInputError('Date property values must use YYYY-MM-DD.');
@@ -332,6 +354,7 @@ const serializePropertyValue = (property: NotePropertyWithDefinition) => {
             return property.boolValue === null ? '' : String(property.boolValue);
         case 'select':
             return property.option?.value ?? '';
+        case 'url':
         case 'text':
         default:
             return property.textValue ?? '';
@@ -533,6 +556,10 @@ const buildTypedValueData = async (
             }
 
             return { ...resetValues, optionId: option.id };
+        }
+        case 'url': {
+            const urlValue = normalizeUrlValue(input.value);
+            return { ...resetValues, textValue: urlValue, textValueNormalized: urlValue.toLowerCase() };
         }
         case 'text': {
             const textValue = normalizeTextValue(input.value);

--- a/packages/server/src/features/view/services/workspace.test.ts
+++ b/packages/server/src/features/view/services/workspace.test.ts
@@ -82,6 +82,25 @@ test('normalizeViewPropertyFilters validates typed filter values', () => {
     assert.throws(() =>
         normalizeViewPropertyFilters([{ key: 'due', valueType: 'date', operator: 'equals', value: '2026-99-99' }]),
     );
+
+    assert.deepEqual(
+        normalizeViewPropertyFilters([
+            { key: 'source', valueType: 'url', operator: 'equals', value: 'https://example.com/docs' },
+        ]),
+        [
+            {
+                key: 'source',
+                name: 'source',
+                valueType: 'url',
+                operator: 'equals',
+                value: 'https://example.com/docs',
+            },
+        ],
+    );
+
+    assert.throws(() =>
+        normalizeViewPropertyFilters([{ key: 'source', valueType: 'url', operator: 'equals', value: 'not-a-url' }]),
+    );
 });
 
 test('normalizeViewNotesQueryInput normalizes property query filters without section-only fields', () => {
@@ -223,6 +242,30 @@ test('buildPropertyFilterWhere maps number and date range operators', () => {
                     dateValue: {
                         gt: new Date('2026-05-31T00:00:00.000Z'),
                     },
+                },
+            },
+        },
+    );
+});
+
+test('buildPropertyFilterWhere maps URL filters through normalized text storage', () => {
+    assert.deepEqual(
+        buildPropertyFilterWhere({
+            key: 'source',
+            name: 'Source',
+            valueType: 'url',
+            operator: 'equals',
+            value: 'https://example.com/docs',
+        }),
+        {
+            properties: {
+                some: {
+                    definition: {
+                        is: {
+                            key: 'source',
+                        },
+                    },
+                    textValueNormalized: 'https://example.com/docs',
                 },
             },
         },

--- a/packages/server/src/features/view/services/workspace.ts
+++ b/packages/server/src/features/view/services/workspace.ts
@@ -1,5 +1,9 @@
 import type { Note, Prisma, PropertyValueType } from '@prisma/client';
-import { InvalidNotePropertyInputError, normalizePropertyKey } from '~/features/note/services/properties.js';
+import {
+    InvalidNotePropertyInputError,
+    normalizePropertyKey,
+    normalizeUrlValue,
+} from '~/features/note/services/properties.js';
 import { buildNoteTagNamesWhere, type NoteTagMatchMode } from '~/features/note/services/tag-filter.js';
 import models from '~/models.js';
 
@@ -152,7 +156,14 @@ const isViewPropertyFilterOperator = (value: unknown): value is ViewPropertyFilt
 };
 
 const isPropertyValueType = (value: unknown): value is PropertyValueType => {
-    return value === 'text' || value === 'number' || value === 'date' || value === 'boolean' || value === 'select';
+    return (
+        value === 'text' ||
+        value === 'url' ||
+        value === 'number' ||
+        value === 'date' ||
+        value === 'boolean' ||
+        value === 'select'
+    );
 };
 
 const normalizeViewDisplayType = (value: ViewDisplayType | undefined): ViewDisplayType => {
@@ -208,6 +219,10 @@ const normalizeFilterValue = ({
 
     if ((operator === 'before' || operator === 'after') && valueType !== 'date' && valueType !== 'number') {
         throw new InvalidNotePropertyInputError('Before and after filters require date or number properties.');
+    }
+
+    if (valueType === 'url') {
+        return normalizeUrlValue(normalizedValue);
     }
 
     return normalizedValue;
@@ -635,6 +650,7 @@ const buildPropertyFilterValueWhere = (filter: ViewPropertyFilterRecord): Prisma
             return { boolValue: filter.value === 'true' };
         case 'select':
             return { option: { is: { value: normalizeSelectFilterValue(filter.value ?? '') } } };
+        case 'url':
         case 'text':
         default:
             return { textValueNormalized: filter.value?.toLowerCase() ?? '' };


### PR DESCRIPTION
## :dart: Goal

Add a dedicated URL property type for external sources, issues, docs, and references without overloading free-form text properties.

## :hammer_and_wrench: Core Changes

- Add `url` to Prisma, GraphQL, client, view, and MCP property value type models.
- Validate URL property values on the server and accept only `http` and `https` URLs.
- Store URL values in the existing normalized text storage path so property filters continue to use existing indexes.
- Add URL property creation in settings and URL-aware input rendering in note properties.
- Show a safe external link action when a note URL property has a valid URL.
- Support URL values in saved view filters and MCP property query schema.
- Add server tests for URL value validation and URL filter mapping.

## :brain: Key Decisions

- Use `url` rather than generic `link` to avoid confusion with Ocean Brain internal note links/backlinks.
- Require explicit `http` or `https` URLs instead of auto-prefixing scheme-less values.
- Reuse text storage for URL values because this release only needs exact URL filtering and display.
- No SQLite migration file is needed because property value types are stored as text and Prisma enum expansion has no DB-level schema change.

## :test_tube: Verification Guide

- `pnpm lint`
- `pnpm type-check`
- `pnpm test:ci`
- `pnpm check:encoding`
- `pnpm build`
- `git diff --check`

## :white_check_mark: Checklist

- [x] Team-agent review completed with no merge-blocking issues.
- [x] URL property values are server-validated as `http` or `https`.
- [x] Note property UI supports URL input and safe external opening.
- [x] View filters and MCP property query schema accept the URL type.
- [x] Full local validation passed.
