### PR TITLE
✨ Add MCP note property metadata writes

### DIFF
--- a/packages/cli/src/mcp-intent-write-tools.ts
+++ b/packages/cli/src/mcp-intent-write-tools.ts
@@ -99,6 +99,14 @@ const markdownWritePolicySchema = z.object({
     preserveReferences: z.union([z.boolean(), z.literal('warn')]).optional()
 }).optional();
 
+const metadataPropertyPatchSchema = z.object({
+    set: z.array(z.object({
+        key: z.string().describe('Property key from ocean_brain_list_properties.'),
+        value: z.string().describe('Property value as a string. The server resolves the property value type by key.')
+    })).optional().describe('Property values to set. Use deleteKeys to remove a property value.'),
+    deleteKeys: z.array(z.string()).optional().describe('Property keys to remove from this note.')
+}).optional();
+
 const sha256 = (value: string) => crypto.createHash('sha256').update(value).digest('hex');
 
 const normalizeServerUrl = (serverUrl: string) => {
@@ -369,23 +377,25 @@ export const registerIntentWriteTools = (
 
     server.tool(
         tools.updateNoteMetadata,
-        'Update note metadata only. Supports title and layout; tags are markdown body tokens and are not handled here.',
+        'Update note metadata only. Supports title, layout, and note properties. Call ocean_brain_list_properties before setting properties; the server resolves value types by key. Tags are markdown body tokens and are not handled here.',
         {
             id: z.string().describe('Note ID to update'),
             expectedUpdatedAt: z.string().describe('Expected note updatedAt from a prior read.'),
             title: z.string().optional().describe('New note title'),
             layout: z.enum(['narrow', 'wide', 'full']).optional().describe('New note layout'),
+            properties: metadataPropertyPatchSchema.describe('Optional note property patch. Set values by key, or remove values with deleteKeys.'),
             ...confirmedMcpWriteFields
         },
-        async ({ id, expectedUpdatedAt, title, layout, dryRun, operationId, confirmToken }) => {
+        async ({ id, expectedUpdatedAt, title, layout, properties, dryRun, operationId, confirmToken }) => {
             const writeToken = requireWriteToken(token, tools.updateNoteMetadata);
             const payload = {
                 id,
                 expectedUpdatedAt,
                 ...(title !== undefined ? { title } : {}),
-                ...(layout ? { layout } : {})
+                ...(layout ? { layout } : {}),
+                ...(properties ? { properties } : {})
             };
-            const summary = `Update note ${id} metadata`;
+            const summary = properties ? `Update note ${id} metadata and properties` : `Update note ${id} metadata`;
             const operationFingerprint = createIntentWriteOperationFingerprint(serverUrl, writeToken, tools.updateNoteMetadata, payload);
 
             if (dryRun) {

--- a/packages/cli/src/mcp.ts
+++ b/packages/cli/src/mcp.ts
@@ -656,19 +656,22 @@ export async function startMcpServer(
 
     server.tool(
         OCEAN_BRAIN_MCP_TOOLS.queryNotesByProperties,
-        'Query Ocean Brain notes with property filters. Call ocean_brain_list_properties first; select filters must use option.value. Property filters are combined with AND, and optional tag filters use the provided tag match mode.',
+        'Query Ocean Brain notes with property filters. Call ocean_brain_list_properties first; select filters must use option.value. Property filters are combined with AND, and optional tag filters use the provided tag match mode. Returns note summaries by default to reduce token use; set includeProperties or propertyKeys when property details are needed.',
         {
             propertyFilters: z.array(propertyFilterSchema).min(1).max(10).describe('Property filters to apply. Multiple property filters are combined with AND.'),
             tagNames: z.array(z.string()).optional().default([]).describe('Optional tag filters. You can pass @project, #project, or project.'),
             mode: tagMatchModeSchema.optional().default('and').describe('Tag match mode for tagNames only. Property filters are always combined with AND.'),
             sortBy: viewSortBySchema.optional().default('updatedAt').describe('Sort field (default: updatedAt)'),
             sortOrder: viewSortOrderSchema.optional().default('desc').describe('Sort order (default: desc)'),
+            includeProperties: z.boolean().optional().default(false).describe('Include returned note properties. Defaults to false to reduce tokens.'),
+            propertyKeys: z.array(z.string()).optional().default([]).describe('Optional property keys to include in the response. Passing keys automatically includes properties.'),
             limit: z.number().optional().default(20).describe('Max results (default: 20, server max: 50)'),
             offset: z.number().optional().default(0).describe('Pagination offset (default: 0)')
         },
-        async ({ propertyFilters, tagNames, mode, sortBy, sortOrder, limit, offset }) => {
+        async ({ propertyFilters, tagNames, mode, sortBy, sortOrder, includeProperties, propertyKeys, limit, offset }) => {
+            const shouldIncludeProperties = includeProperties || propertyKeys.length > 0;
             const data = await graphql(serverUrl, token, `
-                query ($input: NotesByPropertiesInput!, $pagination: PaginationInput) {
+                query ($input: NotesByPropertiesInput!, $pagination: PaginationInput, $includeProperties: Boolean!) {
                     notesByProperties(input: $input, pagination: $pagination) {
                         totalCount
                         notes {
@@ -677,7 +680,7 @@ export async function startMcpServer(
                             createdAt
                             updatedAt
                             tags { id name }
-                            properties { key name value valueType option { id label value color order } }
+                            properties @include(if: $includeProperties) { key name value valueType option { id label value color order } }
                         }
                     }
                 }
@@ -689,7 +692,8 @@ export async function startMcpServer(
                     sortBy,
                     sortOrder
                 },
-                pagination: { limit, offset }
+                pagination: { limit, offset },
+                includeProperties: shouldIncludeProperties
             });
 
             const result = data?.notesByProperties as {
@@ -700,7 +704,7 @@ export async function startMcpServer(
                     createdAt: string;
                     updatedAt: string;
                     tags: Array<{ id: string; name: string }>;
-                    properties: Array<{
+                    properties?: Array<{
                         key: string;
                         name: string;
                         value: string;
@@ -726,6 +730,8 @@ export async function startMcpServer(
                             mode,
                             sortBy,
                             sortOrder,
+                            includeProperties: shouldIncludeProperties,
+                            propertyKeys,
                             limit,
                             offset
                         },
@@ -736,7 +742,13 @@ export async function startMcpServer(
                             createdAt: note.createdAt,
                             updatedAt: note.updatedAt,
                             tags: note.tags.map((item) => item.name),
-                            properties: note.properties
+                            ...(shouldIncludeProperties
+                                ? {
+                                    properties: propertyKeys.length > 0
+                                        ? (note.properties ?? []).filter((property) => propertyKeys.includes(property.key))
+                                        : (note.properties ?? [])
+                                }
+                                : {})
                         }))
                     }, null, 2),
                 }],

--- a/packages/server/src/features/note/http/mcp-authoring.test.ts
+++ b/packages/server/src/features/note/http/mcp-authoring.test.ts
@@ -601,3 +601,50 @@ test('mcp update note metadata handler requires a baseline and does not emit eve
     });
     assert.deepEqual(emittedEvents, []);
 });
+
+test('mcp update note metadata handler forwards property patches without value types', async () => {
+    let receivedInput: unknown;
+    const handler = createMcpUpdateNoteMetadataHandler(async (input) => {
+        receivedInput = input;
+        return {
+            status: 'dry_run',
+            note: {
+                id: '7',
+                title: 'Old title',
+                updatedAt: '2026-04-01T00:00:00.000Z',
+            },
+            proposed: {
+                properties: {
+                    set: [{ key: 'state', name: 'State', value: 'todo', valueType: 'select' }],
+                    deleteKeys: ['project'],
+                },
+            },
+            warnings: [],
+        };
+    });
+
+    await handler(
+        {
+            body: {
+                id: '7',
+                expectedUpdatedAt: '2026-04-01T00:00:00.000Z',
+                properties: {
+                    set: [{ key: 'state', value: 'todo' }],
+                    deleteKeys: ['project'],
+                },
+                dryRun: true,
+            },
+        } as never,
+        createResponse() as never,
+    );
+
+    assert.deepEqual(receivedInput, {
+        id: 7,
+        expectedUpdatedAt: '2026-04-01T00:00:00.000Z',
+        properties: {
+            set: [{ key: 'state', value: 'todo' }],
+            deleteKeys: ['project'],
+        },
+        dryRun: true,
+    });
+});

--- a/packages/server/src/features/note/http/mcp.ts
+++ b/packages/server/src/features/note/http/mcp.ts
@@ -16,6 +16,7 @@ import type {
     MarkdownPatchOperation,
     MarkdownPatchSelector,
 } from '~/features/note/services/markdown-patch.js';
+import type { NotePropertiesByKeyPatchInput } from '~/features/note/services/properties.js';
 import { MCP_SNAPSHOT_META } from '~/features/note/services/snapshot.js';
 import type { NoteLayout } from '~/models.js';
 import { createAppError } from '~/modules/error-handler.js';
@@ -65,6 +66,62 @@ const resolveOptionalBoolean = (value: unknown, code: string, message: string) =
     }
 
     throw createAppError(400, code, message);
+};
+
+const resolveMetadataPropertyPatch = (value: unknown): NotePropertiesByKeyPatchInput | undefined => {
+    if (value === undefined) {
+        return undefined;
+    }
+
+    if (!isRecord(value)) {
+        throw createAppError(400, 'INVALID_NOTE_PROPERTIES', 'Properties patch must be an object.');
+    }
+
+    const set =
+        value.set === undefined
+            ? undefined
+            : Array.isArray(value.set)
+              ? value.set.map((item) => {
+                    if (!isRecord(item) || typeof item.key !== 'string' || typeof item.value !== 'string') {
+                        throw createAppError(
+                            400,
+                            'INVALID_NOTE_PROPERTIES',
+                            'Property set items must include string key and value fields.',
+                        );
+                    }
+
+                    return {
+                        key: item.key,
+                        value: item.value,
+                    };
+                })
+              : null;
+
+    if (set === null) {
+        throw createAppError(400, 'INVALID_NOTE_PROPERTIES', 'Property set must be an array.');
+    }
+
+    const deleteKeys =
+        value.deleteKeys === undefined
+            ? undefined
+            : Array.isArray(value.deleteKeys)
+              ? value.deleteKeys.map((key) => {
+                    if (typeof key !== 'string') {
+                        throw createAppError(400, 'INVALID_NOTE_PROPERTIES', 'Property deleteKeys must be strings.');
+                    }
+
+                    return key;
+                })
+              : null;
+
+    if (deleteKeys === null) {
+        throw createAppError(400, 'INVALID_NOTE_PROPERTIES', 'Property deleteKeys must be an array.');
+    }
+
+    return {
+        ...(set !== undefined ? { set } : {}),
+        ...(deleteKeys !== undefined ? { deleteKeys } : {}),
+    };
 };
 
 const resolvePositiveNoteId = (value: unknown) => {
@@ -557,9 +614,10 @@ export const createMcpUpdateNoteMetadataHandler = (
     emitEvent: EmitServerEvent = emitServerEvent,
 ): Controller => {
     return async (req, res) => {
-        const { id, expectedUpdatedAt, title, layout, dryRun } = req.body ?? {};
+        const { id, expectedUpdatedAt, title, layout, properties, dryRun } = req.body ?? {};
         const noteId = resolvePositiveNoteId(id);
         const resolvedLayout = resolveNoteLayout(layout);
+        const resolvedProperties = resolveMetadataPropertyPatch(properties);
         const resolvedDryRun = resolveOptionalBoolean(dryRun, 'INVALID_DRY_RUN', 'dryRun must be a boolean.');
 
         if (typeof expectedUpdatedAt !== 'string') {
@@ -574,7 +632,7 @@ export const createMcpUpdateNoteMetadataHandler = (
             throw createAppError(400, 'INVALID_NOTE_LAYOUT', 'Note layout must be one of narrow, wide, or full.');
         }
 
-        if (title === undefined && layout === undefined) {
+        if (title === undefined && layout === undefined && resolvedProperties === undefined) {
             throw createAppError(400, 'INVALID_NOTE_INPUT', 'At least one metadata field must be provided.');
         }
 
@@ -583,6 +641,7 @@ export const createMcpUpdateNoteMetadataHandler = (
             expectedUpdatedAt,
             ...(title !== undefined ? { title } : {}),
             ...(resolvedLayout ? { layout: resolvedLayout } : {}),
+            ...(resolvedProperties !== undefined ? { properties: resolvedProperties } : {}),
             dryRun: resolvedDryRun,
         });
 

--- a/packages/server/src/features/note/services/markdown-intent-write.test.ts
+++ b/packages/server/src/features/note/services/markdown-intent-write.test.ts
@@ -296,3 +296,70 @@ test('metadata update applies title and layout without content data', async () =
         },
     ]);
 });
+
+test('metadata update applies property patches through the property write path', async () => {
+    const propertyUpdates: unknown[] = [];
+    const service = createMarkdownIntentWriteService({
+        findNoteById: async () => createNote(),
+        renderMarkdown: async (content) => content,
+        parseMarkdownToContentJson: async () => {
+            throw new Error('should not parse markdown for metadata');
+        },
+        extractTagIds: () => [],
+        updateNote: async () => {
+            throw new Error('should not use note update for property metadata');
+        },
+        resolvePropertyPatch: async (patch) => ({
+            set: (patch.set ?? []).map((item) => ({
+                key: item.key,
+                name: 'State',
+                value: item.value,
+                valueType: 'select' as const,
+            })),
+            deleteKeys: patch.deleteKeys ?? [],
+        }),
+        validatePropertyPatch: async (patch) => patch,
+        updateProperties: async (input) => {
+            propertyUpdates.push(input);
+            return {
+                note: {
+                    id: input.id,
+                    title: input.noteData?.title ?? 'Existing',
+                    layout: input.noteData?.layout ?? 'wide',
+                    updatedAt: new Date('2026-05-28T00:00:01.000Z'),
+                },
+                snapshot: {
+                    id: '13',
+                    createdAt: '2026-05-28T00:00:00.500Z',
+                    meta: { label: 'MCP' },
+                },
+            };
+        },
+    });
+
+    const result = await service.applyNoteMetadata({
+        id: 7,
+        expectedUpdatedAt: '2026-05-28T00:00:00.000Z',
+        title: 'Renamed',
+        properties: {
+            set: [{ key: 'state', value: 'todo' }],
+            deleteKeys: ['project'],
+        },
+    });
+
+    assert.equal(result.status, 'applied');
+    assert.deepEqual(propertyUpdates, [
+        {
+            id: 7,
+            patch: {
+                set: [{ key: 'state', name: 'State', value: 'todo', valueType: 'select' }],
+                deleteKeys: ['project'],
+            },
+            expectedUpdatedAt: '2026-05-28T00:00:00.000Z',
+            noteData: {
+                title: 'Renamed',
+            },
+            snapshotMeta: '{"entrypoint":"mcp","label":"MCP"}',
+        },
+    ]);
+});

--- a/packages/server/src/features/note/services/markdown-intent-write.ts
+++ b/packages/server/src/features/note/services/markdown-intent-write.ts
@@ -22,6 +22,14 @@ import {
     buildMarkdownReplacePlan,
     calculateMarkdownSha256,
 } from './markdown-patch.js';
+import {
+    InvalidNotePropertyInputError,
+    type NotePropertiesByKeyPatchInput,
+    type NotePropertiesPatchInput,
+    resolveNotePropertiesPatchValueTypes,
+    updateNotePropertiesWithVersionGuardAndSnapshot,
+    validateNotePropertiesPatchValues,
+} from './properties.js';
 import { MCP_SNAPSHOT_META } from './snapshot.js';
 import { type GuardedNoteWriteResult, updateNoteWithVersionGuardAndSnapshot } from './write.js';
 import {
@@ -58,6 +66,26 @@ interface MarkdownIntentWriteDeps {
         snapshotMeta?: string;
         force?: boolean;
     }) => Promise<GuardedNoteWriteResult | null>;
+    resolvePropertyPatch?: (patch: NotePropertiesByKeyPatchInput) => Promise<NotePropertiesPatchInput>;
+    validatePropertyPatch?: (patch: NotePropertiesPatchInput) => Promise<NotePropertiesPatchInput>;
+    updateProperties?: (input: {
+        id: number;
+        patch: NotePropertiesPatchInput;
+        expectedUpdatedAt: string;
+        noteData?: {
+            title?: string;
+            layout?: NoteLayout;
+        };
+        snapshotMeta?: string;
+    }) => Promise<{
+        note: {
+            id: number;
+            title: string;
+            layout: NoteLayout;
+            updatedAt: Date;
+        };
+        snapshot: unknown;
+    } | null>;
 }
 
 export interface MarkdownWritePolicy {
@@ -114,6 +142,7 @@ export interface UpdateNoteMetadataInput {
     expectedUpdatedAt: string;
     title?: string;
     layout?: NoteLayout;
+    properties?: NotePropertiesByKeyPatchInput;
 }
 
 export interface AppliedMarkdownWriteResult {
@@ -144,6 +173,7 @@ export interface MetadataUpdatePreview {
     proposed: {
         title?: string;
         layout?: NoteLayout;
+        properties?: NotePropertiesPatchInput;
     };
     warnings: string[];
 }
@@ -235,6 +265,12 @@ const referenceStructureFailure = (): MarkdownChangeFailure => ({
     message: 'The markdown write would reduce structured note reference links.',
 });
 
+const invalidPropertyInputFailure = (error: InvalidNotePropertyInputError): MarkdownChangeFailure => ({
+    status: 'failed',
+    reason: 'INVALID_PROPERTY_INPUT',
+    message: error.message,
+});
+
 const mapGuardedWriteError = (error: unknown): MarkdownChangeFailure | null => {
     if (isNoteVersionConflictError(error) || isInvalidNoteVersionError(error)) {
         return baselineMismatchFailure();
@@ -245,6 +281,30 @@ const mapGuardedWriteError = (error: unknown): MarkdownChangeFailure | null => {
     }
 
     return null;
+};
+
+const resolveMetadataPropertyPatch = async (
+    deps: MarkdownIntentWriteDeps,
+    patch: NotePropertiesByKeyPatchInput | undefined,
+): Promise<NotePropertiesPatchInput | MarkdownChangeFailure | undefined> => {
+    if (patch === undefined) {
+        return undefined;
+    }
+
+    if (!deps.resolvePropertyPatch || !deps.validatePropertyPatch) {
+        throw new Error('Metadata property patch dependencies are not configured.');
+    }
+
+    try {
+        const resolvedPatch = await deps.resolvePropertyPatch(patch);
+        return deps.validatePropertyPatch(resolvedPatch);
+    } catch (error) {
+        if (error instanceof InvalidNotePropertyInputError) {
+            return invalidPropertyInputFailure(error);
+        }
+
+        throw error;
+    }
 };
 
 const noteVersionMatches = (expectedUpdatedAt: string | undefined, currentUpdatedAt: Date) => {
@@ -508,6 +568,11 @@ export const createMarkdownIntentWriteService = (deps: MarkdownIntentWriteDeps) 
         }
 
         const nextTitle = input.title?.trim();
+        const resolvedPropertyPatch = await resolveMetadataPropertyPatch(deps, input.properties);
+
+        if (resolvedPropertyPatch && 'status' in resolvedPropertyPatch) {
+            return resolvedPropertyPatch;
+        }
 
         if (input.title !== undefined && !nextTitle) {
             return {
@@ -517,7 +582,11 @@ export const createMarkdownIntentWriteService = (deps: MarkdownIntentWriteDeps) 
             };
         }
 
-        if (nextTitle === note.title && (input.layout === undefined || input.layout === note.layout)) {
+        if (
+            nextTitle === note.title &&
+            (input.layout === undefined || input.layout === note.layout) &&
+            resolvedPropertyPatch === undefined
+        ) {
             return {
                 status: 'failed',
                 reason: 'NOOP',
@@ -535,6 +604,7 @@ export const createMarkdownIntentWriteService = (deps: MarkdownIntentWriteDeps) 
             proposed: {
                 ...(nextTitle !== undefined ? { title: nextTitle } : {}),
                 ...(input.layout !== undefined ? { layout: input.layout } : {}),
+                ...(resolvedPropertyPatch ? { properties: resolvedPropertyPatch } : {}),
             },
             warnings: [],
         };
@@ -545,6 +615,58 @@ export const createMarkdownIntentWriteService = (deps: MarkdownIntentWriteDeps) 
 
         if (preview.status !== 'dry_run') {
             return preview;
+        }
+
+        if (input.properties !== undefined) {
+            if (!deps.updateProperties) {
+                throw new Error('Metadata property write dependency is not configured.');
+            }
+
+            let updateResult: Awaited<ReturnType<NonNullable<MarkdownIntentWriteDeps['updateProperties']>>>;
+
+            try {
+                updateResult = await deps.updateProperties({
+                    id: input.id,
+                    patch: preview.proposed.properties ?? { set: [], deleteKeys: [] },
+                    expectedUpdatedAt: input.expectedUpdatedAt,
+                    noteData: {
+                        ...(preview.proposed.title !== undefined ? { title: preview.proposed.title } : {}),
+                        ...(preview.proposed.layout !== undefined ? { layout: preview.proposed.layout } : {}),
+                    },
+                    snapshotMeta: MCP_SNAPSHOT_META,
+                });
+            } catch (error) {
+                const mappedError = mapGuardedWriteError(error);
+
+                if (mappedError) {
+                    return mappedError;
+                }
+
+                if (error instanceof InvalidNotePropertyInputError) {
+                    return invalidPropertyInputFailure(error);
+                }
+
+                throw error;
+            }
+
+            if (!updateResult) {
+                return {
+                    status: 'failed',
+                    reason: 'TARGET_NOT_FOUND',
+                    message: 'The requested note was not found.',
+                };
+            }
+
+            return {
+                status: 'applied',
+                note: {
+                    id: String(updateResult.note.id),
+                    title: updateResult.note.title,
+                    layout: updateResult.note.layout,
+                    updatedAt: updateResult.note.updatedAt.toISOString(),
+                },
+                snapshot: serializeSnapshot(updateResult.snapshot),
+            };
         }
 
         let updateResult: GuardedNoteWriteResult | null;
@@ -608,6 +730,9 @@ export const defaultMarkdownIntentWriteService = createMarkdownIntentWriteServic
     countReferenceInlines: countReferenceInlinesFromContentJson,
     hasUnsupportedMarkdownBlocks,
     updateNote: updateNoteWithVersionGuardAndSnapshot,
+    resolvePropertyPatch: resolveNotePropertiesPatchValueTypes,
+    validatePropertyPatch: validateNotePropertiesPatchValues,
+    updateProperties: updateNotePropertiesWithVersionGuardAndSnapshot,
 });
 
 export const patchNoteMarkdown = async (input: PatchNoteMarkdownInput) => {

--- a/packages/server/src/features/note/services/markdown-patch.ts
+++ b/packages/server/src/features/note/services/markdown-patch.ts
@@ -161,6 +161,7 @@ export interface MarkdownChangeFailure {
         | 'HEADING_AMBIGUOUS'
         | 'HEADING_NOT_FOUND'
         | 'INVALID_HEADING_LEVEL'
+        | 'INVALID_PROPERTY_INPUT'
         | 'MISSING_BASELINE'
         | 'NOOP'
         | 'REFERENCE_STRUCTURE_DECREASED'

--- a/packages/server/src/features/note/services/properties.test.ts
+++ b/packages/server/src/features/note/services/properties.test.ts
@@ -9,6 +9,7 @@ import {
     normalizePropertyKey,
     normalizeUrlValue,
     renamePropertyFiltersInViewQuery,
+    resolveNotePropertiesPatchValueTypes,
     updateNotePropertiesWithVersionGuard,
 } from './properties.js';
 import { MissingNoteVersionError } from './write-conflict.js';
@@ -27,6 +28,50 @@ test('normalizeUrlValue accepts only http(s) URLs', () => {
     assert.equal(normalizeUrlValue(' https://example.com/docs '), 'https://example.com/docs');
     assert.throws(() => normalizeUrlValue('example.com'), InvalidNotePropertyInputError);
     assert.throws(() => normalizeUrlValue('javascript:alert(1)'), InvalidNotePropertyInputError);
+});
+
+test('resolveNotePropertiesPatchValueTypes fills value types from shared definitions', async () => {
+    const patch = await resolveNotePropertiesPatchValueTypes(
+        {
+            set: [{ key: ' State ', value: 'todo' }],
+            deleteKeys: [' Project '],
+        },
+        {
+            propertyDefinition: {
+                findMany: async () => [
+                    {
+                        key: 'state',
+                        name: 'State',
+                        valueType: 'select' as const,
+                    },
+                ],
+            },
+        } as never,
+    );
+
+    assert.deepEqual(patch, {
+        set: [{ key: 'state', name: 'State', value: 'todo', valueType: 'select' }],
+        deleteKeys: ['project'],
+    });
+});
+
+test('resolveNotePropertiesPatchValueTypes rejects unknown property keys', async () => {
+    await assert.rejects(
+        () =>
+            resolveNotePropertiesPatchValueTypes(
+                {
+                    set: [{ key: 'state', value: 'todo' }],
+                },
+                {
+                    propertyDefinition: {
+                        findMany: async () => [],
+                    },
+                } as never,
+            ),
+        (error: unknown) =>
+            error instanceof InvalidNotePropertyInputError &&
+            error.message === 'Property state is not defined. Create it in property settings first.',
+    );
 });
 
 test('property definitions require valid select option datasets before write', async () => {

--- a/packages/server/src/features/note/services/properties.ts
+++ b/packages/server/src/features/note/services/properties.ts
@@ -1,4 +1,5 @@
-import models, { type Note, Prisma, type PropertyValueType } from '~/models.js';
+import models, { type Note, type NoteLayout, Prisma, type PropertyValueType } from '~/models.js';
+import { buildNoteSearchProjection } from './search.js';
 import { captureNoteBaseline } from './snapshot.js';
 import { createNoteVersionConflictError, MissingNoteVersionError, parseNoteVersion } from './write-conflict.js';
 
@@ -54,6 +55,16 @@ export interface NotePropertiesPatchInput {
     deleteKeys?: string[] | null;
 }
 
+export interface NotePropertySetByKeyInput {
+    key: string;
+    value: string;
+}
+
+export interface NotePropertiesByKeyPatchInput {
+    set?: NotePropertySetByKeyInput[] | null;
+    deleteKeys?: string[] | null;
+}
+
 export interface NotePropertyOptionInput {
     label: string;
     value?: string | null;
@@ -84,6 +95,9 @@ type NotePropertyWithDefinition = Prisma.NotePropertyGetPayload<{
 type PropertyDefinitionWithOptions = Prisma.PropertyDefinitionGetPayload<{
     include: { options: true; _count: { select: { properties: true } } };
 }>;
+
+type PropertyPatchDefinitionLookupClient = Pick<typeof models, 'propertyDefinition'>;
+type PropertyPatchValueValidationClient = Pick<typeof models, 'propertyDefinition' | 'propertyOption'>;
 
 const PROPERTY_KEY_MAX_LENGTH = 80;
 const PROPERTY_NAME_MAX_LENGTH = 120;
@@ -617,6 +631,117 @@ const normalizePatch = (patch: NotePropertiesPatchInput) => {
     return { set: normalizedSet, deleteKeys: normalizedDeleteKeys };
 };
 
+const normalizePatchByKey = (patch: NotePropertiesByKeyPatchInput) => {
+    const set = patch.set ?? [];
+    const deleteKeys = patch.deleteKeys ?? [];
+
+    if (set.length === 0 && deleteKeys.length === 0) {
+        throw new InvalidNotePropertyInputError('At least one property change is required.');
+    }
+
+    if (set.length > PROPERTY_PATCH_SET_LIMIT || deleteKeys.length > PROPERTY_PATCH_DELETE_LIMIT) {
+        throw new InvalidNotePropertyInputError('Too many property changes in one request.');
+    }
+
+    const normalizedSet = set.map((item) => ({
+        key: normalizePropertyKey(item.key),
+        value: item.value,
+    }));
+    const normalizedDeleteKeys = deleteKeys.map(normalizePropertyKey);
+    const seenSetKeys = new Set<string>();
+    const seenDeleteKeys = new Set<string>();
+
+    for (const item of normalizedSet) {
+        if (seenSetKeys.has(item.key)) {
+            throw new InvalidNotePropertyInputError('Property patch contains duplicate keys.');
+        }
+
+        seenSetKeys.add(item.key);
+    }
+
+    for (const key of normalizedDeleteKeys) {
+        if (seenDeleteKeys.has(key)) {
+            throw new InvalidNotePropertyInputError('Property patch contains duplicate delete keys.');
+        }
+
+        if (seenSetKeys.has(key)) {
+            throw new InvalidNotePropertyInputError('Property patch cannot set and delete the same key.');
+        }
+
+        seenDeleteKeys.add(key);
+    }
+
+    return { set: normalizedSet, deleteKeys: normalizedDeleteKeys };
+};
+
+export const resolveNotePropertiesPatchValueTypes = async (
+    patch: NotePropertiesByKeyPatchInput,
+    tx: PropertyPatchDefinitionLookupClient = models,
+): Promise<NotePropertiesPatchInput> => {
+    const normalizedPatch = normalizePatchByKey(patch);
+
+    if (normalizedPatch.set.length === 0) {
+        return normalizePatch({ deleteKeys: normalizedPatch.deleteKeys });
+    }
+
+    const definitions = await tx.propertyDefinition.findMany({
+        where: { key: { in: normalizedPatch.set.map((item) => item.key) } },
+        select: {
+            key: true,
+            name: true,
+            valueType: true,
+        },
+    });
+    const definitionByKey = new Map(definitions.map((definition) => [definition.key, definition]));
+
+    return normalizePatch({
+        set: normalizedPatch.set.map((item) => {
+            const definition = definitionByKey.get(item.key);
+
+            if (!definition) {
+                throw new InvalidNotePropertyInputError(
+                    `Property ${item.key} is not defined. Create it in property settings first.`,
+                );
+            }
+
+            return {
+                key: item.key,
+                name: definition.name,
+                value: item.value,
+                valueType: definition.valueType,
+            };
+        }),
+        deleteKeys: normalizedPatch.deleteKeys,
+    });
+};
+
+export const validateNotePropertiesPatchValues = async (
+    patch: NotePropertiesPatchInput,
+    tx: PropertyPatchValueValidationClient = models,
+) => {
+    const normalizedPatch = normalizePatch(patch);
+
+    for (const item of normalizedPatch.set) {
+        const definition = await tx.propertyDefinition.findUnique({ where: { key: item.key } });
+
+        if (!definition) {
+            throw new InvalidNotePropertyInputError(
+                `Property ${item.key} is not defined. Create it in property settings first.`,
+            );
+        }
+
+        if (definition.valueType !== item.valueType) {
+            throw new InvalidNotePropertyInputError(
+                `Property ${item.key} already uses ${definition.valueType} values.`,
+            );
+        }
+
+        await buildTypedValueData(item, definition.id, tx);
+    }
+
+    return normalizedPatch;
+};
+
 export const listNoteProperties = async (noteId: number) => {
     const properties = await models.noteProperty.findMany({
         where: { noteId },
@@ -897,19 +1022,33 @@ export const deleteNotePropertyDefinition = async ({
     });
 };
 
-export const updateNotePropertiesWithVersionGuard = async ({
-    id,
-    patch,
-    editSessionId,
-    expectedUpdatedAt,
-    force = false,
-}: {
+interface UpdateNotePropertiesWithVersionGuardInput {
     id: number;
     patch: NotePropertiesPatchInput;
     editSessionId?: string;
     expectedUpdatedAt?: string;
     force?: boolean;
-}): Promise<Note | null> => {
+    noteData?: {
+        title?: string;
+        layout?: NoteLayout;
+    };
+    snapshotMeta?: string;
+}
+
+export interface GuardedNotePropertiesWriteResult {
+    note: Note;
+    snapshot: unknown;
+}
+
+export const updateNotePropertiesWithVersionGuardAndSnapshot = async ({
+    id,
+    patch,
+    editSessionId,
+    expectedUpdatedAt,
+    force = false,
+    noteData,
+    snapshotMeta,
+}: UpdateNotePropertiesWithVersionGuardInput): Promise<GuardedNotePropertiesWriteResult | null> => {
     const normalizedPatch = normalizePatch(patch);
     const expectedTimestamp = parseNoteVersion(expectedUpdatedAt);
 
@@ -1003,7 +1142,17 @@ export const updateNotePropertiesWithVersionGuard = async ({
 
             const updatedNote = await tx.note.update({
                 where: { id },
-                data: { updatedAt: new Date() },
+                data: {
+                    ...(noteData?.title !== undefined ? { title: noteData.title } : {}),
+                    ...(noteData?.layout !== undefined ? { layout: noteData.layout } : {}),
+                    ...(noteData?.title !== undefined
+                        ? buildNoteSearchProjection({
+                              title: noteData.title,
+                              content: existingNote.content,
+                          })
+                        : {}),
+                    updatedAt: new Date(),
+                },
             });
 
             return { updatedNote, baseline };
@@ -1013,14 +1162,18 @@ export const updateNotePropertiesWithVersionGuard = async ({
             return null;
         }
 
-        await captureNoteBaseline({
+        const snapshot = await captureNoteBaseline({
             noteId: id,
             baseline: result.baseline,
             ...(editSessionId && !force ? { editSessionId } : {}),
+            ...(snapshotMeta ? { meta: snapshotMeta } : {}),
             ...(force ? { force: true } : {}),
         });
 
-        return result.updatedNote;
+        return {
+            note: result.updatedNote,
+            snapshot,
+        };
     } catch (error) {
         if (isRecordNotFoundError(error)) {
             return null;
@@ -1028,4 +1181,9 @@ export const updateNotePropertiesWithVersionGuard = async ({
 
         throw error;
     }
+};
+
+export const updateNotePropertiesWithVersionGuard = async (input: UpdateNotePropertiesWithVersionGuardInput) => {
+    const result = await updateNotePropertiesWithVersionGuardAndSnapshot(input);
+    return result?.note ?? null;
 };


### PR DESCRIPTION
## :dart: Goal

Allow MCP agents to update existing note property values without adding another MCP tool, while keeping property query responses lightweight by default.

## :hammer_and_wrench: Core Changes

- Extended `ocean_brain_update_note_metadata` with an optional `properties` patch:
  - `properties.set`: set values by property key and string value
  - `properties.deleteKeys`: remove property values from a note
- Added server-side property key resolution so MCP callers do not send `valueType`; the server uses shared property definitions.
- Reused the existing guarded metadata write flow, dry-run confirmation flow, and snapshot path for MCP property writes.
- Added optional `includeProperties` and `propertyKeys` controls to `ocean_brain_query_notes_by_properties` so property query results return summaries by default.
- Added server tests for MCP metadata property forwarding, property patch resolution, and property metadata application.

## :brain: Key Decisions

- Did not add a separate `ocean_brain_set_note_property` tool to avoid MCP tool sprawl.
- Kept property definition creation/update/delete out of MCP write tools for now.
- Required callers to use `ocean_brain_list_properties` before writing properties, then send only keys and string values.
- Kept `ocean_brain_read_note` as the detail path that includes note properties; property queries now avoid returning full property lists unless requested.

## :test_tube: Verification Guide

Expected result: all commands pass.

```bash
pnpm check:encoding
pnpm lint
pnpm type-check
pnpm --filter ocean-brain type-check
pnpm test:ci
pnpm build
pnpm --filter ocean-brain build
git diff --check
```

## :white_check_mark: Checklist

- [x] Commit title follows `<emoji> <English verb...>`.
- [x] PR title follows `<emoji> <English verb...>`.
- [x] MCP property writes reuse an existing tool instead of adding a new one.
- [x] Query response token use is reduced by default.
- [x] Local validation completed.
