### PR TITLE
🛠 Refine MCP property tool guidance

### DIFF
--- a/packages/cli/src/mcp-intent-write-tools.ts
+++ b/packages/cli/src/mcp-intent-write-tools.ts
@@ -99,12 +99,62 @@ const markdownWritePolicySchema = z.object({
     preserveReferences: z.union([z.boolean(), z.literal('warn')]).optional()
 }).optional();
 
-const metadataPropertyPatchSchema = z.object({
+export const MCP_METADATA_PROPERTY_PATCH_LIMIT = 50;
+
+const normalizeMetadataPropertyKey = (key: string) => key.trim().toLowerCase().replace(/\s+/g, '-');
+
+export const metadataPropertyPatchSchema = z.object({
     set: z.array(z.object({
-        key: z.string().describe('Property key from ocean_brain_list_properties.'),
-        value: z.string().describe('Property value as a string. The server resolves the property value type by key.')
-    })).optional().describe('Property values to set. Use deleteKeys to remove a property value.'),
-    deleteKeys: z.array(z.string()).optional().describe('Property keys to remove from this note.')
+        key: z.string().min(1).describe('Property key from ocean_brain_list_properties.'),
+        value: z.string().describe('String value: select option.value, date YYYY-MM-DD, boolean true/false, number finite string, url http(s).')
+    })).max(MCP_METADATA_PROPERTY_PATCH_LIMIT).optional().describe('Set up to 50 property values. Keys must be unique.'),
+    deleteKeys: z.array(z.string().min(1)).max(MCP_METADATA_PROPERTY_PATCH_LIMIT).optional()
+        .describe('Remove up to 50 property values from this note. Keys must be unique and not also in set.')
+}).superRefine((patch, context) => {
+    if ((patch.set?.length ?? 0) === 0 && (patch.deleteKeys?.length ?? 0) === 0) {
+        context.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: 'properties must include set or deleteKeys.'
+        });
+        return;
+    }
+
+    const setKeys = new Set<string>();
+
+    for (const item of patch.set ?? []) {
+        const key = normalizeMetadataPropertyKey(item.key);
+
+        if (setKeys.has(key)) {
+            context.addIssue({
+                code: z.ZodIssueCode.custom,
+                message: `properties.set contains duplicate key ${key}.`
+            });
+        }
+
+        setKeys.add(key);
+    }
+
+    const deleteKeys = new Set<string>();
+
+    for (const rawKey of patch.deleteKeys ?? []) {
+        const key = normalizeMetadataPropertyKey(rawKey);
+
+        if (deleteKeys.has(key)) {
+            context.addIssue({
+                code: z.ZodIssueCode.custom,
+                message: `properties.deleteKeys contains duplicate key ${key}.`
+            });
+        }
+
+        if (setKeys.has(key)) {
+            context.addIssue({
+                code: z.ZodIssueCode.custom,
+                message: `properties cannot set and delete ${key} in one request.`
+            });
+        }
+
+        deleteKeys.add(key);
+    }
 }).optional();
 
 const sha256 = (value: string) => crypto.createHash('sha256').update(value).digest('hex');
@@ -377,13 +427,13 @@ export const registerIntentWriteTools = (
 
     server.tool(
         tools.updateNoteMetadata,
-        'Update note metadata only. Supports title, layout, and note properties. Call ocean_brain_list_properties before setting properties; the server resolves value types by key. Tags are markdown body tokens and are not handled here.',
+        'Update note title/layout/properties. For properties, call ocean_brain_list_properties first. Use existing property key and string value only; do not send valueType. select=option.value, date=YYYY-MM-DD, boolean=true/false, number=finite string, url=http(s). Use deleteKeys to remove values. Definitions are not created.',
         {
             id: z.string().describe('Note ID to update'),
             expectedUpdatedAt: z.string().describe('Expected note updatedAt from a prior read.'),
             title: z.string().optional().describe('New note title'),
             layout: z.enum(['narrow', 'wide', 'full']).optional().describe('New note layout'),
-            properties: metadataPropertyPatchSchema.describe('Optional note property patch. Set values by key, or remove values with deleteKeys.'),
+            properties: metadataPropertyPatchSchema.describe('Patch existing shared property values. Include set and/or deleteKeys; empty patches are rejected.'),
             ...confirmedMcpWriteFields
         },
         async ({ id, expectedUpdatedAt, title, layout, properties, dryRun, operationId, confirmToken }) => {

--- a/packages/cli/src/mcp-property-query-output.ts
+++ b/packages/cli/src/mcp-property-query-output.ts
@@ -1,0 +1,60 @@
+export interface PropertyQueryNoteProperty {
+    key: string;
+    name: string;
+    value: string;
+    valueType: string;
+    option?: {
+        id: string;
+        label: string;
+        value: string;
+        color?: string | null;
+        order: number;
+    } | null;
+}
+
+export interface PropertyQueryNote {
+    id: string;
+    title: string;
+    createdAt: string;
+    updatedAt: string;
+    tags: Array<{ id: string; name: string }>;
+    properties?: PropertyQueryNoteProperty[];
+}
+
+export interface PropertyQueryResult {
+    totalCount: number;
+    notes: PropertyQueryNote[];
+}
+
+export const formatPropertyQueryResponse = ({
+    result,
+    query,
+    includeProperties,
+    propertyKeys
+}: {
+    result: PropertyQueryResult;
+    query: Record<string, unknown>;
+    includeProperties: boolean;
+    propertyKeys: string[];
+}) => ({
+    query: {
+        ...query,
+        includeProperties,
+        propertyKeys
+    },
+    totalCount: result.totalCount,
+    notes: result.notes.map((note) => ({
+        id: note.id,
+        title: note.title,
+        createdAt: note.createdAt,
+        updatedAt: note.updatedAt,
+        tags: note.tags.map((item) => item.name),
+        ...(includeProperties
+            ? {
+                properties: propertyKeys.length > 0
+                    ? (note.properties ?? []).filter((property) => propertyKeys.includes(property.key))
+                    : (note.properties ?? [])
+            }
+            : {})
+    }))
+});

--- a/packages/cli/src/mcp-write-safety.ts
+++ b/packages/cli/src/mcp-write-safety.ts
@@ -9,22 +9,22 @@ export type McpWriteLogPhase = 'prepared' | 'confirmed' | 'executed' | 'failed' 
 
 export const destructiveMcpWriteFields = {
     dryRun: z.boolean().optional().default(true)
-        .describe('Preview the destructive change first. Set dryRun to false only after you receive an operationId and confirmToken.'),
+        .describe('Preview the destructive change first. Commit only after dry-run returns operation.operationId and operation.confirmToken.'),
     operationId: z.string().optional()
-        .describe('Operation id returned by the dry-run response. Required when dryRun is false.'),
+        .describe('Dry-run response operation.operationId. Required when dryRun is false.'),
     confirmToken: z.string().optional()
-        .describe('Confirmation token returned by the dry-run response. Required when dryRun is false.'),
+        .describe('Dry-run response operation.confirmToken. Required when dryRun is false.'),
     force: z.boolean().optional().default(false)
         .describe('Explicitly confirm a bulk destructive change when the preview says force is required.')
 };
 
 export const confirmedMcpWriteFields = {
     dryRun: z.boolean().optional().default(true)
-        .describe('Preview the write first. Set dryRun to false only after you receive an operationId and confirmToken.'),
+        .describe('Preview the write first. Commit only after dry-run returns operation.operationId and operation.confirmToken.'),
     operationId: z.string().optional()
-        .describe('Operation id returned by the dry-run response. Required when dryRun is false.'),
+        .describe('Dry-run response operation.operationId. Required when dryRun is false.'),
     confirmToken: z.string().optional()
-        .describe('Confirmation token returned by the dry-run response. Required when dryRun is false.')
+        .describe('Dry-run response operation.confirmToken. Required when dryRun is false.')
 };
 
 export interface DestructiveWriteRequest {

--- a/packages/cli/src/mcp.ts
+++ b/packages/cli/src/mcp.ts
@@ -13,6 +13,7 @@ import {
 } from './mcp-write-safety.js';
 import { formatMcpReadNoteOutput } from './mcp-note-output.js';
 import { registerIntentWriteTools } from './mcp-intent-write-tools.js';
+import { formatPropertyQueryResponse, type PropertyQueryResult } from './mcp-property-query-output.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(
@@ -50,7 +51,7 @@ const propertyFilterSchema = z.object({
     key: z.string().describe('Property key from ocean_brain_list_properties, e.g. state'),
     valueType: propertyValueTypeSchema.describe('Property value type from the property definition'),
     operator: propertyFilterOperatorSchema.describe('Filter operator. before/after are only valid for date or number properties.'),
-    value: z.string().nullable().optional().describe('Filter value. Required unless operator is exists or notExists. Select filters use option.value, not option.label. URL filters require an http(s) URL.')
+    value: z.string().nullable().optional().describe('Filter value. Required unless operator is exists or notExists. select=option.value, date=YYYY-MM-DD, boolean=true/false, number=finite, url=http(s).')
 });
 
 const normalizeOceanBrainTagName = (name: string) => {
@@ -656,15 +657,15 @@ export async function startMcpServer(
 
     server.tool(
         OCEAN_BRAIN_MCP_TOOLS.queryNotesByProperties,
-        'Query Ocean Brain notes with property filters. Call ocean_brain_list_properties first; select filters must use option.value. Property filters are combined with AND, and optional tag filters use the provided tag match mode. Returns note summaries by default to reduce token use; set includeProperties or propertyKeys when property details are needed.',
+        'Call ocean_brain_list_properties first. Requires >=1 propertyFilter; use search/recent for broad lists. Use key/valueType from the property definition. Values are strings: select=option.value, date=YYYY-MM-DD, boolean=true/false, number=finite, url=http(s). exists/notExists need no value. Property filters use AND; tagNames use mode. Summaries are returned by default; use propertyKeys for needed property details.',
         {
-            propertyFilters: z.array(propertyFilterSchema).min(1).max(10).describe('Property filters to apply. Multiple property filters are combined with AND.'),
+            propertyFilters: z.array(propertyFilterSchema).min(1).max(10).describe('Required property filters. Multiple property filters are combined with AND.'),
             tagNames: z.array(z.string()).optional().default([]).describe('Optional tag filters. You can pass @project, #project, or project.'),
             mode: tagMatchModeSchema.optional().default('and').describe('Tag match mode for tagNames only. Property filters are always combined with AND.'),
             sortBy: viewSortBySchema.optional().default('updatedAt').describe('Sort field (default: updatedAt)'),
             sortOrder: viewSortOrderSchema.optional().default('desc').describe('Sort order (default: desc)'),
             includeProperties: z.boolean().optional().default(false).describe('Include returned note properties. Defaults to false to reduce tokens.'),
-            propertyKeys: z.array(z.string()).optional().default([]).describe('Optional property keys to include in the response. Passing keys automatically includes properties.'),
+            propertyKeys: z.array(z.string()).optional().default([]).describe('Property keys to include in output; automatically includes properties.'),
             limit: z.number().optional().default(20).describe('Max results (default: 20, server max: 50)'),
             offset: z.number().optional().default(0).describe('Pagination offset (default: 0)')
         },
@@ -696,61 +697,29 @@ export async function startMcpServer(
                 includeProperties: shouldIncludeProperties
             });
 
-            const result = data?.notesByProperties as {
-                totalCount: number;
-                notes: Array<{
-                    id: string;
-                    title: string;
-                    createdAt: string;
-                    updatedAt: string;
-                    tags: Array<{ id: string; name: string }>;
-                    properties?: Array<{
-                        key: string;
-                        name: string;
-                        value: string;
-                        valueType: string;
-                        option?: {
-                            id: string;
-                            label: string;
-                            value: string;
-                            color?: string | null;
-                            order: number;
-                        } | null;
-                    }>;
-                }>;
-            };
+            const result = data?.notesByProperties as PropertyQueryResult;
 
             return {
                 content: [{
                     type: 'text' as const,
-                    text: JSON.stringify({
-                        query: {
-                            propertyFilters,
-                            tagNames,
-                            mode,
-                            sortBy,
-                            sortOrder,
+                    text: JSON.stringify(
+                        formatPropertyQueryResponse({
+                            result,
+                            query: {
+                                propertyFilters,
+                                tagNames,
+                                mode,
+                                sortBy,
+                                sortOrder,
+                                limit,
+                                offset
+                            },
                             includeProperties: shouldIncludeProperties,
-                            propertyKeys,
-                            limit,
-                            offset
-                        },
-                        totalCount: result.totalCount,
-                        notes: result.notes.map((note) => ({
-                            id: note.id,
-                            title: note.title,
-                            createdAt: note.createdAt,
-                            updatedAt: note.updatedAt,
-                            tags: note.tags.map((item) => item.name),
-                            ...(shouldIncludeProperties
-                                ? {
-                                    properties: propertyKeys.length > 0
-                                        ? (note.properties ?? []).filter((property) => propertyKeys.includes(property.key))
-                                        : (note.properties ?? [])
-                                }
-                                : {})
-                        }))
-                    }, null, 2),
+                            propertyKeys
+                        }),
+                        null,
+                        2
+                    ),
                 }],
             };
         }

--- a/packages/cli/test/mcp-intent-write-tools.test.ts
+++ b/packages/cli/test/mcp-intent-write-tools.test.ts
@@ -1,7 +1,11 @@
 import assert from 'node:assert/strict';
-import test from 'node:test';
+import { describe, test } from 'node:test';
 
-import { createIntentWriteOperationFingerprint } from '../src/mcp-intent-write-tools.js';
+import {
+    MCP_METADATA_PROPERTY_PATCH_LIMIT,
+    createIntentWriteOperationFingerprint,
+    metadataPropertyPatchSchema
+} from '../src/mcp-intent-write-tools.js';
 
 const payload = {
     id: '7',
@@ -16,30 +20,124 @@ const payload = {
     }
 };
 
-test('intent write fingerprints are bound to the server URL and bearer token', () => {
-    const base = createIntentWriteOperationFingerprint(
-        'http://localhost:6683',
-        'token-a',
-        'ocean_brain_patch_note_markdown',
-        payload
-    );
+describe('createIntentWriteOperationFingerprint', () => {
+    test('binds fingerprints to the server URL and bearer token', () => {
+        // Arrange
+        const base = createIntentWriteOperationFingerprint(
+            'http://localhost:6683',
+            'token-a',
+            'ocean_brain_patch_note_markdown',
+            payload
+        );
 
-    assert.notEqual(
-        createIntentWriteOperationFingerprint(
+        // Act
+        const differentServerUrl = createIntentWriteOperationFingerprint(
             'http://localhost:6684',
             'token-a',
             'ocean_brain_patch_note_markdown',
             payload
-        ),
-        base
-    );
-    assert.notEqual(
-        createIntentWriteOperationFingerprint(
+        );
+        const differentToken = createIntentWriteOperationFingerprint(
             'http://localhost:6683',
             'token-b',
             'ocean_brain_patch_note_markdown',
             payload
-        ),
-        base
-    );
+        );
+
+        // Assert
+        assert.notEqual(differentServerUrl, base);
+        assert.notEqual(differentToken, base);
+    });
+});
+
+describe('metadataPropertyPatchSchema', () => {
+    test('accepts concise set and delete patches', () => {
+        // Arrange
+        const patch = {
+            set: [{ key: 'state', value: 'todo' }],
+            deleteKeys: ['project']
+        };
+
+        // Act
+        const result = metadataPropertyPatchSchema.safeParse(patch);
+
+        // Assert
+        assert.equal(result.success, true);
+    });
+
+    test('rejects empty patches', () => {
+        // Arrange
+        const patch = {};
+
+        // Act
+        const result = metadataPropertyPatchSchema.safeParse(patch);
+
+        // Assert
+        assert.equal(result.success, false);
+    });
+
+    test('rejects duplicate normalized set keys', () => {
+        // Arrange
+        const patch = {
+            set: [
+                { key: 'state', value: 'todo' },
+                { key: ' State ', value: 'doing' }
+            ]
+        };
+
+        // Act
+        const result = metadataPropertyPatchSchema.safeParse(patch);
+
+        // Assert
+        assert.equal(result.success, false);
+    });
+
+    test('rejects duplicate normalized delete keys', () => {
+        // Arrange
+        const patch = {
+            deleteKeys: ['state', ' State ']
+        };
+
+        // Act
+        const result = metadataPropertyPatchSchema.safeParse(patch);
+
+        // Assert
+        assert.equal(result.success, false);
+    });
+
+    test('rejects setting and deleting the same key', () => {
+        // Arrange
+        const patch = {
+            set: [{ key: 'state', value: 'todo' }],
+            deleteKeys: ['state']
+        };
+
+        // Act
+        const result = metadataPropertyPatchSchema.safeParse(patch);
+
+        // Assert
+        assert.equal(result.success, false);
+    });
+
+    test('rejects more than 50 set or delete entries', () => {
+        // Arrange
+        const overLimit = MCP_METADATA_PROPERTY_PATCH_LIMIT + 1;
+        const setPatch = {
+            set: Array.from({ length: overLimit }, (_, index) => ({
+                key: `field-${index}`,
+                value: 'value'
+            }))
+        };
+        const deletePatch = {
+            deleteKeys: Array.from({ length: overLimit }, (_, index) => `field-${index}`)
+        };
+
+        // Act
+        const setResult = metadataPropertyPatchSchema.safeParse(setPatch);
+        const deleteResult = metadataPropertyPatchSchema.safeParse(deletePatch);
+
+        // Assert
+        assert.equal(setResult.success, false);
+        assert.equal(deleteResult.success, false);
+    });
 });

--- a/packages/cli/test/mcp-property-query-output.test.ts
+++ b/packages/cli/test/mcp-property-query-output.test.ts
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+import { formatPropertyQueryResponse } from '../src/mcp-property-query-output.js';
+
+const createPropertyQueryFixture = () => ({
+    query: {
+        propertyFilters: [{ key: 'state', valueType: 'select', operator: 'equals', value: 'todo' }],
+        tagNames: [],
+        mode: 'and',
+        sortBy: 'updatedAt',
+        sortOrder: 'desc',
+        limit: 20,
+        offset: 0
+    },
+    result: {
+        totalCount: 1,
+        notes: [
+            {
+                id: '7',
+                title: 'Project note',
+                createdAt: '2026-06-01T00:00:00.000Z',
+                updatedAt: '2026-06-02T00:00:00.000Z',
+                tags: [{ id: '1', name: '@project' }],
+                properties: [
+                    { key: 'state', name: 'State', value: 'todo', valueType: 'select' },
+                    { key: 'project', name: 'Project', value: 'ocean', valueType: 'text' }
+                ]
+            }
+        ]
+    }
+});
+
+describe('formatPropertyQueryResponse', () => {
+    test('omits properties unless requested', () => {
+        // Arrange
+        const { result, query } = createPropertyQueryFixture();
+
+        // Act
+        const output = formatPropertyQueryResponse({
+            result,
+            query,
+            includeProperties: false,
+            propertyKeys: []
+        });
+
+        // Assert
+        assert.deepEqual(output.notes[0], {
+            id: '7',
+            title: 'Project note',
+            createdAt: '2026-06-01T00:00:00.000Z',
+            updatedAt: '2026-06-02T00:00:00.000Z',
+            tags: ['@project']
+        });
+    });
+
+    test('includes only requested property keys', () => {
+        // Arrange
+        const { result, query } = createPropertyQueryFixture();
+
+        // Act
+        const output = formatPropertyQueryResponse({
+            result,
+            query,
+            includeProperties: true,
+            propertyKeys: ['state']
+        });
+
+        // Assert
+        assert.deepEqual(output.notes[0]?.properties, [
+            { key: 'state', name: 'State', value: 'todo', valueType: 'select' }
+        ]);
+    });
+});

--- a/packages/client/src/modules/server-event-invalidation.spec.ts
+++ b/packages/client/src/modules/server-event-invalidation.spec.ts
@@ -11,8 +11,10 @@ const createQueryClientMock = () => {
 
 describe('server-event-invalidation', () => {
     it('invalidates note collection queries for MCP note updates', async () => {
+        // Arrange
         const queryClient = createQueryClientMock();
 
+        // Act
         await invalidateQueriesForServerEvent(queryClient, {
             type: 'mcp.note.updated',
             source: 'mcp',
@@ -20,6 +22,7 @@ describe('server-event-invalidation', () => {
             updatedAt: '2026-04-14T00:00:00.000Z',
         });
 
+        // Assert
         expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
             queryKey: queryKeys.notes.listAll(),
             exact: false,
@@ -45,6 +48,10 @@ describe('server-event-invalidation', () => {
             exact: true,
         });
         expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+            queryKey: queryKeys.notes.propertyKeysAll(),
+            exact: false,
+        });
+        expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
             queryKey: queryKeys.views.sectionNotesAll(),
             exact: false,
         });
@@ -55,8 +62,10 @@ describe('server-event-invalidation', () => {
     });
 
     it('invalidates note collection queries for web note updates', async () => {
+        // Arrange
         const queryClient = createQueryClientMock();
 
+        // Act
         await invalidateQueriesForServerEvent(queryClient, {
             type: 'web.note.updated',
             source: 'web',
@@ -65,6 +74,7 @@ describe('server-event-invalidation', () => {
             editSessionId: 'editor-a',
         });
 
+        // Assert
         expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
             queryKey: queryKeys.notes.listAll(),
             exact: false,
@@ -73,23 +83,34 @@ describe('server-event-invalidation', () => {
             queryKey: queryKeys.views.sectionNotesAll(),
             exact: false,
         });
+        expect(queryClient.invalidateQueries).not.toHaveBeenCalledWith({
+            queryKey: queryKeys.notes.propertyKeysAll(),
+            exact: false,
+        });
     });
 
     it('invalidates trash-related queries for MCP note deletes', async () => {
+        // Arrange
         const queryClient = createQueryClientMock();
 
+        // Act
         await invalidateQueriesForServerEvent(queryClient, {
             type: 'mcp.note.deleted',
             source: 'mcp',
             noteId: '11',
         });
 
+        // Assert
         expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
             queryKey: queryKeys.notes.trashAll(),
             exact: false,
         });
         expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
             queryKey: queryKeys.notes.tagNameListAll(),
+            exact: false,
+        });
+        expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+            queryKey: queryKeys.notes.propertyKeysAll(),
             exact: false,
         });
         expect(queryClient.invalidateQueries).toHaveBeenCalledWith({

--- a/packages/client/src/modules/server-event-invalidation.ts
+++ b/packages/client/src/modules/server-event-invalidation.ts
@@ -2,97 +2,84 @@ import type { QueryClient } from '@tanstack/react-query';
 import { queryKeys } from './query-key-factory';
 import type { ServerEvent } from './server-events';
 
+type QueryInvalidation = Parameters<QueryClient['invalidateQueries']>[0];
+
+const noteChangeInvalidations: QueryInvalidation[] = [
+    {
+        queryKey: queryKeys.notes.listAll(),
+        exact: false,
+    },
+    {
+        queryKey: queryKeys.notes.tagListAll(),
+        exact: false,
+    },
+    {
+        queryKey: queryKeys.notes.tagNameListAll(),
+        exact: false,
+    },
+    {
+        queryKey: queryKeys.notes.pinned(),
+        exact: true,
+    },
+    {
+        queryKey: queryKeys.notes.backReferencesAll(),
+        exact: false,
+    },
+    {
+        queryKey: queryKeys.notes.graph(),
+        exact: true,
+    },
+    {
+        queryKey: queryKeys.views.sectionNotesAll(),
+        exact: false,
+    },
+    {
+        queryKey: queryKeys.tags.all(),
+        exact: false,
+    },
+];
+
+const propertyKeysInvalidation: QueryInvalidation = {
+    queryKey: queryKeys.notes.propertyKeysAll(),
+    exact: false,
+};
+
+const noteDeleteInvalidations: QueryInvalidation[] = [
+    ...noteChangeInvalidations,
+    propertyKeysInvalidation,
+    {
+        queryKey: queryKeys.notes.trashAll(),
+        exact: false,
+    },
+    {
+        queryKey: queryKeys.reminders.all(),
+        exact: false,
+    },
+    {
+        queryKey: queryKeys.images.all(),
+        exact: false,
+    },
+    {
+        queryKey: queryKeys.calendar.all(),
+        exact: false,
+    },
+];
+
+const invalidateMany = async (queryClient: QueryClient, invalidations: QueryInvalidation[]) => {
+    await Promise.all(invalidations.map((invalidation) => queryClient.invalidateQueries(invalidation)));
+};
+
 export const invalidateQueriesForServerEvent = async (queryClient: QueryClient, event: ServerEvent) => {
     switch (event.type) {
         case 'mcp.note.created':
-        case 'mcp.note.updated':
         case 'web.note.updated':
-            await Promise.all([
-                queryClient.invalidateQueries({
-                    queryKey: queryKeys.notes.listAll(),
-                    exact: false,
-                }),
-                queryClient.invalidateQueries({
-                    queryKey: queryKeys.notes.tagListAll(),
-                    exact: false,
-                }),
-                queryClient.invalidateQueries({
-                    queryKey: queryKeys.notes.tagNameListAll(),
-                    exact: false,
-                }),
-                queryClient.invalidateQueries({
-                    queryKey: queryKeys.notes.pinned(),
-                    exact: true,
-                }),
-                queryClient.invalidateQueries({
-                    queryKey: queryKeys.notes.backReferencesAll(),
-                    exact: false,
-                }),
-                queryClient.invalidateQueries({
-                    queryKey: queryKeys.notes.graph(),
-                    exact: true,
-                }),
-                queryClient.invalidateQueries({
-                    queryKey: queryKeys.views.sectionNotesAll(),
-                    exact: false,
-                }),
-                queryClient.invalidateQueries({
-                    queryKey: queryKeys.tags.all(),
-                    exact: false,
-                }),
-            ]);
+            await invalidateMany(queryClient, noteChangeInvalidations);
+            return;
+        case 'mcp.note.updated':
+            await invalidateMany(queryClient, [...noteChangeInvalidations, propertyKeysInvalidation]);
             return;
         case 'mcp.note.deleted':
-            await Promise.all([
-                queryClient.invalidateQueries({
-                    queryKey: queryKeys.notes.listAll(),
-                    exact: false,
-                }),
-                queryClient.invalidateQueries({
-                    queryKey: queryKeys.notes.tagListAll(),
-                    exact: false,
-                }),
-                queryClient.invalidateQueries({
-                    queryKey: queryKeys.notes.tagNameListAll(),
-                    exact: false,
-                }),
-                queryClient.invalidateQueries({
-                    queryKey: queryKeys.notes.trashAll(),
-                    exact: false,
-                }),
-                queryClient.invalidateQueries({
-                    queryKey: queryKeys.notes.pinned(),
-                    exact: true,
-                }),
-                queryClient.invalidateQueries({
-                    queryKey: queryKeys.notes.backReferencesAll(),
-                    exact: false,
-                }),
-                queryClient.invalidateQueries({
-                    queryKey: queryKeys.notes.graph(),
-                    exact: true,
-                }),
-                queryClient.invalidateQueries({
-                    queryKey: queryKeys.views.sectionNotesAll(),
-                    exact: false,
-                }),
-                queryClient.invalidateQueries({
-                    queryKey: queryKeys.tags.all(),
-                    exact: false,
-                }),
-                queryClient.invalidateQueries({
-                    queryKey: queryKeys.reminders.all(),
-                    exact: false,
-                }),
-                queryClient.invalidateQueries({
-                    queryKey: queryKeys.images.all(),
-                    exact: false,
-                }),
-                queryClient.invalidateQueries({
-                    queryKey: queryKeys.calendar.all(),
-                    exact: false,
-                }),
-            ]);
+            await invalidateMany(queryClient, noteDeleteInvalidations);
             return;
     }
 };

--- a/packages/client/src/pages/Note.tsx
+++ b/packages/client/src/pages/Note.tsx
@@ -330,7 +330,7 @@ const NotePropertiesPanel = ({
                 getNormalizedRows(response.updateNoteProperties.properties ?? []),
             );
             onSaved(response.updateNoteProperties);
-            void queryClient.invalidateQueries({ queryKey: queryKeys.notes.propertyKeys() });
+            void queryClient.invalidateQueries({ queryKey: queryKeys.notes.propertyKeysAll(), exact: false });
             setAutoSaveStatus('saved');
         } catch {
             setAutoSaveStatus('error');


### PR DESCRIPTION
## :dart: Goal

Follow up on MCP property writes by making property-related MCP tools easier for agents to use, keeping query output lightweight, and preventing stale shared property counts after MCP changes.

## :hammer_and_wrench: Core Changes

- Tighten `ocean_brain_update_note_metadata` property patch schema with 50-item limits, empty patch rejection, duplicate key rejection, and set/delete conflict rejection.
- Shorten property tool descriptions while keeping the value-format rules agents need.
- Clarify that property queries require at least one `propertyFilter`, and that write confirmations use `operation.operationId` / `operation.confirmToken` from dry-run output.
- Move property query response formatting into a small CLI helper and test that properties are omitted by default or filtered by `propertyKeys`.
- Add `describe` groups and Arrange/Act/Assert comments to the touched tests.
- Invalidate shared property key queries for MCP note updates/deletes and use `propertyKeysAll()` after note property saves.

## :brain: Key Decisions

- Did not add a new MCP tool; this remains a guidance/schema/cache follow-up to the existing property metadata write path.
- Kept property existence, select option validity, and type-specific value validation on the server as the source of truth.
- Kept automated tests focused on schema, formatter, and invalidation behavior; actual agent-tool usability was verified with a local-only MCP smoke run.
- The local MCP smoke used an isolated SQLite DB, loopback URL, temporary token file, and cleanup; remote Ocean Brain MCP tools were not used.

## :test_tube: Verification Guide

Expected result: all commands pass.

```bash
pnpm check:encoding
pnpm lint
pnpm type-check
pnpm test:ci
pnpm build
pnpm --filter ocean-brain test:ci
pnpm --filter ocean-brain type-check
pnpm --filter ocean-brain build
git diff --check
```

Additional local MCP smoke verification:

- Local server only: `http://127.0.0.1:6693`
- Temporary token file only: `/tmp/ocean-brain-mcp-token` with `0600` permissions
- Seeded local properties: `state`, `project`, `homepage`
- Agent A verified `tools/list`, `ocean_brain_list_properties`, and lightweight `ocean_brain_query_notes_by_properties` output.
- Agent B verified `list_properties -> create_note -> read_note -> update_note_metadata dry-run -> confirm -> read/query` using property values without `valueType`.
- Judge agent reviewed the safety boundary and recommended keeping heavy protocol smoke as local/manual validation rather than CI.

## :white_check_mark: Checklist

- [x] Local validation for changed scope completed
- [x] Full workspace validation completed
- [x] Local-only MCP smoke verification completed
- [x] PR title follows `<emoji> <subject>`
- [x] PR body follows the required template headings
- [x] No release-impacting files changed
