### PR TITLE
📝 Add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Jino Bae
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -180,3 +180,7 @@ Example Claude Code `.mcp.json`:
 | `ocean_brain_list_recent_notes` | List recently updated notes |
 | `ocean_brain_create_note` / `ocean_brain_update_note` | Create or update notes |
 | `ocean_brain_create_tag` / `ocean_brain_delete_note` | Create tags or delete notes (safe write flow) |
+
+## License
+
+Ocean Brain is licensed under the [MIT License](./LICENSE).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
     "name": "ocean-brain-workspace",
     "private": true,
+    "license": "MIT",
     "scripts": {
         "check:encoding": "node scripts/ci/check-encoding.mjs",
         "dev": "pnpm --parallel --filter @ocean-brain/client --filter @ocean-brain/server dev",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,7 @@
 {
     "name": "ocean-brain",
     "version": "0.5.0",
+    "license": "MIT",
     "type": "module",
     "repository": {
         "type": "git",


### PR DESCRIPTION
## :dart: Goal

Add an explicit MIT license so Ocean Brain can be described and discovered as an open-source project without ambiguity.

## :hammer_and_wrench: Core Changes

- Add root `LICENSE` with the MIT license and `Jino Bae` as copyright holder.
- Add `license: MIT` to the workspace and CLI package metadata.
- Add a short README `License` section linking to the MIT license.

## :brain: Key Decisions

- Use MIT because the project is intended to be easy to use, fork, modify, and redistribute.
- Use `Jino Bae` instead of a generic contributors holder to keep the initial copyright holder explicit.
- This touches `packages/cli/package.json`, but only for license metadata. No version bump or release tag is included in this PR.
- Expected release version if this is published directly: `0.5.1`; tag plan: `v0.5.1`. Otherwise, ship with the next normal CLI release.

## :test_tube: Verification Guide

Expected result: all commands pass.

```bash
pnpm check:encoding
pnpm --filter ocean-brain type-check
pnpm --filter ocean-brain build
git diff --check
```

Release-linked note:

- `CLI_SMOKE` is configured for release branches/manual dispatch. Run it before an actual release tag is cut.

## :white_check_mark: Checklist

- [x] Local validation for changed scope completed
- [x] PR title follows `<emoji> <subject>`
- [x] PR body follows the required template headings
- [x] Release-impacting package metadata change documented
- [x] No version bump or release tag included in this PR
