### PR TITLE
🔖 Bump version to 0.6.0

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ocean-brain",
-    "version": "0.5.0",
+    "version": "0.6.0",
     "license": "MIT",
     "type": "module",
     "repository": {


### PR DESCRIPTION
## :dart: Goal

Prepare the dedicated release bump for Ocean Brain `0.6.0`.

## :hammer_and_wrench: Core Changes

- Update the published CLI package version from `0.5.0` to `0.6.0`.
- Keep the release trigger separate from this PR; the release will be triggered by pushing tag `v0.6.0` after this PR is merged into `main`.

## :brain: Key Decisions

- This is a release-only PR and intentionally changes only `packages/cli/package.json`.
- Expected release version: `0.6.0`.
- Tag plan: `v0.6.0` from merged `main`.
- `CLI_SMOKE` should run on this `chore/release-v0.6.0` branch before the tag is cut.

## :test_tube: Verification Guide

Expected result: all commands pass.

```bash
pnpm check:encoding
pnpm lint
pnpm type-check
pnpm test:ci
pnpm build
pnpm --filter ocean-brain build
git diff --check
```

Local result: passed.

Required before tagging:

- GitHub CI passes for this PR.
- GitHub `CLI_SMOKE` passes for this release branch.

## :white_check_mark: Checklist

- [x] Release commit follows `🔖 Bump version to 0.6.0`.
- [x] Version bump is isolated to `packages/cli/package.json`.
- [x] Expected tag is documented as `v0.6.0`.
- [x] Local validation completed.
- [x] GitHub CI passed.
- [x] GitHub `CLI_SMOKE` passed.
