### PR TITLE
🐛 Fix property panel layout shift

### DIFF
--- a/packages/client/src/pages/Note.tsx
+++ b/packages/client/src/pages/Note.tsx
@@ -432,12 +432,6 @@ const NotePropertiesPanel = ({
                 </>
             }
         >
-            {disabled && (
-                <Text as="p" variant="label" tone="tertiary" className="mb-3">
-                    Finish the current note save or resolve conflicts before editing properties.
-                </Text>
-            )}
-
             {rows.length === 0 ? (
                 <Text as="p" variant="label" tone="tertiary" className="px-1 py-2">
                     No properties yet.


### PR DESCRIPTION
## :dart: Goal

Prevent the note editor area from jumping when the properties panel is temporarily disabled during note saves or conflicts.

## :hammer_and_wrench: Core Changes

- Remove the inline disabled-state guidance text from the note properties panel.
- Keep existing property controls disabled while note saves/conflicts are unresolved.
- Preserve the panel header actions and autosave status behavior.

## :brain: Key Decisions

- Avoid replacing the message with another visible inline banner because any conditional body content above the editor can still cause layout movement.
- Keep the current save guard intact; this PR only removes the layout-shifting text.

## :test_tube: Verification Guide

Expected result: all commands pass.

```bash
pnpm check:encoding
pnpm --filter @ocean-brain/client lint
pnpm --filter @ocean-brain/client type-check
pnpm --filter @ocean-brain/client test:ci
pnpm --filter @ocean-brain/client build
git diff --check
```

Manual check:

- Open a note with properties.
- Trigger note saving or property editing while the properties panel is visible.
- Confirm the old `Finish the current note save...` body message no longer appears and the editor body does not shift because of that message.

## :white_check_mark: Checklist

- [x] Local validation for changed scope completed
- [x] PR title follows `<emoji> <subject>`
- [x] PR body follows the required template headings
- [x] No release-impacting files changed
