### PR TITLE
🐛 Preserve angle-bracket markdown text

### DIFF
--- a/packages/server/src/features/note/services/markdown-intent-write.test.ts
+++ b/packages/server/src/features/note/services/markdown-intent-write.test.ts
@@ -187,6 +187,40 @@ test('markdown intent write refuses apply when structured references would be lo
     });
 });
 
+test('markdown intent write refuses apply when Markdown import loses literal text markers', async () => {
+    const service = createMarkdownIntentWriteService({
+        findNoteById: async () => createNote({ content: 'before-content' }),
+        renderMarkdown: async (content) =>
+            content === 'before-content' ? 'Original sentence.' : '<MARKER> Updated sentence.',
+        parseMarkdownToContentJson: async () => 'after-content',
+        extractTagIds: () => [],
+        updateNote: async () => {
+            throw new Error('should not update');
+        },
+    });
+
+    const result = await service.patchNoteMarkdown({
+        id: 7,
+        expectedUpdatedAt: '2026-05-28T00:00:00.000Z',
+        intent: 'Replace one sentence',
+        selector: {
+            type: 'exact_text',
+            text: 'Original sentence.',
+        },
+        operation: {
+            type: 'replace',
+            replacement: '<MARKER> <MARKER> Updated sentence.',
+        },
+        dryRun: false,
+    });
+
+    assert.deepEqual(result, {
+        status: 'failed',
+        reason: 'MARKDOWN_IMPORT_LOSSY',
+        message: 'The markdown write would lose literal text during Markdown import.',
+    });
+});
+
 test('markdown intent write maps guarded update conflicts to baseline mismatch failures', async () => {
     const service = createMarkdownIntentWriteService({
         findNoteById: async () => createNote(),

--- a/packages/server/src/features/note/services/markdown-intent-write.ts
+++ b/packages/server/src/features/note/services/markdown-intent-write.ts
@@ -2,7 +2,9 @@ import models, { type NoteLayout } from '~/models.js';
 import {
     blocksToMarkdown,
     countReferenceInlinesFromContentJson,
+    extractLiteralAngleBracketTextTokens,
     extractTagIdsFromContentJson,
+    hasLiteralAngleBracketTextTokenLoss,
     hasUnsupportedMarkdownBlocks,
     markdownToBlocksJson,
 } from '~/modules/blocknote.js';
@@ -265,6 +267,12 @@ const referenceStructureFailure = (): MarkdownChangeFailure => ({
     message: 'The markdown write would reduce structured note reference links.',
 });
 
+const markdownImportLossyFailure = (): MarkdownChangeFailure => ({
+    status: 'failed',
+    reason: 'MARKDOWN_IMPORT_LOSSY',
+    message: 'The markdown write would lose literal text during Markdown import.',
+});
+
 const invalidPropertyInputFailure = (error: InvalidNotePropertyInputError): MarkdownChangeFailure => ({
     status: 'failed',
     reason: 'INVALID_PROPERTY_INPUT',
@@ -339,6 +347,16 @@ const applyMarkdownPlan = async (
     },
 ): Promise<AppliedMarkdownWriteResult | MarkdownChangeFailure> => {
     const content = await deps.parseMarkdownToContentJson(input.plan.afterMarkdown);
+    const literalAngleBracketTokens = extractLiteralAngleBracketTextTokens(input.plan.afterMarkdown);
+
+    if (literalAngleBracketTokens.length > 0) {
+        const importedMarkdown = await deps.renderMarkdown(content);
+
+        if (hasLiteralAngleBracketTextTokenLoss(input.plan.afterMarkdown, importedMarkdown)) {
+            return markdownImportLossyFailure();
+        }
+    }
+
     const beforeReferenceCount = deps.countReferenceInlines?.(input.beforeContentJson) ?? 0;
     const afterReferenceCount = deps.countReferenceInlines?.(content) ?? 0;
 

--- a/packages/server/src/features/note/services/markdown-patch.ts
+++ b/packages/server/src/features/note/services/markdown-patch.ts
@@ -162,6 +162,7 @@ export interface MarkdownChangeFailure {
         | 'HEADING_NOT_FOUND'
         | 'INVALID_HEADING_LEVEL'
         | 'INVALID_PROPERTY_INPUT'
+        | 'MARKDOWN_IMPORT_LOSSY'
         | 'MISSING_BASELINE'
         | 'NOOP'
         | 'REFERENCE_STRUCTURE_DECREASED'

--- a/packages/server/src/modules/blocknote.ts
+++ b/packages/server/src/modules/blocknote.ts
@@ -271,6 +271,184 @@ function preprocessMarkdownExplicitTags(markdown: string) {
     };
 }
 
+const MARKDOWN_ANGLE_BRACKET_TOKEN_PATTERN = /<([^<>\n]+)>/g;
+const MARKDOWN_FENCED_CODE_PATTERN = /^ {0,3}(`{3,}|~{3,})/;
+const ANGLE_BRACKET_PLACEHOLDER_PREFIX = '\uE000OBANGLE';
+const ANGLE_BRACKET_PLACEHOLDER_SUFFIX = '\uE001';
+
+function isMarkdownAutolinkAngleBracketText(innerText: string) {
+    if (innerText !== innerText.trim()) {
+        return false;
+    }
+
+    return /^[a-z][a-z0-9.+-]{1,31}:[^\s<>]*$/i.test(innerText) || /^[^\s@<>]+@[^\s@<>]+\.[^\s@<>]+$/.test(innerText);
+}
+
+function countLiteralAngleBracketTextTokens(markdown: string) {
+    const tokenCounts = new Map<string, number>();
+
+    for (const match of markdown.matchAll(MARKDOWN_ANGLE_BRACKET_TOKEN_PATTERN)) {
+        const token = match[0];
+        const innerText = match[1] ?? '';
+
+        if (!token || isMarkdownAutolinkAngleBracketText(innerText)) {
+            continue;
+        }
+
+        tokenCounts.set(token, (tokenCounts.get(token) ?? 0) + 1);
+    }
+
+    return tokenCounts;
+}
+
+export function extractLiteralAngleBracketTextTokens(markdown: string) {
+    return [...countLiteralAngleBracketTextTokens(markdown).keys()];
+}
+
+export function hasLiteralAngleBracketTextTokenLoss(sourceMarkdown: string, renderedMarkdown: string) {
+    const sourceCounts = countLiteralAngleBracketTextTokens(sourceMarkdown);
+
+    if (sourceCounts.size === 0) {
+        return false;
+    }
+
+    const renderedCounts = countLiteralAngleBracketTextTokens(renderedMarkdown);
+
+    for (const [token, sourceCount] of sourceCounts) {
+        if ((renderedCounts.get(token) ?? 0) < sourceCount) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+function protectMarkdownTextAngleBrackets(markdown: string) {
+    const protectedLines: string[] = [];
+    const placeholderToToken = new Map<string, string>();
+    let activeFence: { marker: '`' | '~'; length: number } | null = null;
+
+    for (const line of markdown.split(/(?<=\n)/)) {
+        const { body: lineBody, lineEnding } = splitMarkdownLineEnding(line);
+        const fenceMatch = lineBody.match(MARKDOWN_FENCED_CODE_PATTERN);
+
+        if (activeFence) {
+            protectedLines.push(line);
+
+            if (isClosingFenceLine(lineBody, activeFence)) {
+                activeFence = null;
+            }
+
+            continue;
+        }
+
+        if (fenceMatch?.[1]) {
+            const marker = fenceMatch[1][0] as '`' | '~';
+            activeFence = {
+                marker,
+                length: fenceMatch[1].length,
+            };
+            protectedLines.push(line);
+            continue;
+        }
+
+        if (/^(?: {4,}|\t)/.test(lineBody)) {
+            protectedLines.push(line);
+            continue;
+        }
+
+        protectedLines.push(`${protectMarkdownLineTextAngleBrackets(lineBody, placeholderToToken)}${lineEnding}`);
+    }
+
+    return {
+        markdown: protectedLines.join(''),
+        placeholderToToken,
+    };
+}
+
+function splitMarkdownLineEnding(line: string) {
+    if (line.endsWith('\r\n')) {
+        return {
+            body: line.slice(0, -2),
+            lineEnding: '\r\n',
+        };
+    }
+
+    if (line.endsWith('\n')) {
+        return {
+            body: line.slice(0, -1),
+            lineEnding: '\n',
+        };
+    }
+
+    return {
+        body: line,
+        lineEnding: '',
+    };
+}
+
+function isClosingFenceLine(line: string, fence: { marker: '`' | '~'; length: number }) {
+    const escapedMarker = fence.marker === '`' ? '`' : '~';
+    return new RegExp(`^ {0,3}${escapedMarker}{${fence.length},} *$`).test(line);
+}
+
+function protectMarkdownLineTextAngleBrackets(line: string, placeholderToToken: Map<string, string>) {
+    let result = '';
+    let cursor = 0;
+
+    while (cursor < line.length) {
+        const codeStart = line.indexOf('`', cursor);
+
+        if (codeStart === -1) {
+            result += replaceLiteralAngleBracketTextTokens(line.slice(cursor), placeholderToToken);
+            break;
+        }
+
+        result += replaceLiteralAngleBracketTextTokens(line.slice(cursor, codeStart), placeholderToToken);
+
+        const delimiterLength = countRepeatedCharacter(line, codeStart, '`');
+        const codeEnd = line.indexOf('`'.repeat(delimiterLength), codeStart + delimiterLength);
+
+        if (codeEnd === -1) {
+            result += replaceLiteralAngleBracketTextTokens(line.slice(codeStart), placeholderToToken);
+            break;
+        }
+
+        const codeEndExclusive = codeEnd + delimiterLength;
+        result += line.slice(codeStart, codeEndExclusive);
+        cursor = codeEndExclusive;
+    }
+
+    return result;
+}
+
+function replaceLiteralAngleBracketTextTokens(text: string, placeholderToToken: Map<string, string>) {
+    return text.replace(MARKDOWN_ANGLE_BRACKET_TOKEN_PATTERN, (match, innerText: string) => {
+        if (isMarkdownAutolinkAngleBracketText(innerText)) {
+            return match;
+        }
+
+        const placeholder = createAngleBracketPlaceholder(placeholderToToken.size);
+        placeholderToToken.set(placeholder, match);
+
+        return placeholder;
+    });
+}
+
+function createAngleBracketPlaceholder(index: number) {
+    return `${ANGLE_BRACKET_PLACEHOLDER_PREFIX}${index}${ANGLE_BRACKET_PLACEHOLDER_SUFFIX}`;
+}
+
+function countRepeatedCharacter(value: string, start: number, character: string) {
+    let cursor = start;
+
+    while (value[cursor] === character) {
+        cursor += 1;
+    }
+
+    return cursor - start;
+}
+
 function findTagPlaceholderAtCursor(text: string, cursor: number, placeholderToTag: Map<string, string>) {
     for (const [placeholder, tagToken] of placeholderToTag.entries()) {
         if (text.startsWith(placeholder, cursor)) {
@@ -295,6 +473,31 @@ function restoreRemainingTagPlaceholders(blocks: BlockNote[], placeholderToTag: 
 
             for (const [placeholder, tagToken] of placeholderToTag.entries()) {
                 text = text.split(placeholder).join(`[${tagToken}]`);
+            }
+
+            return {
+                ...inline,
+                text,
+            };
+        }),
+    );
+}
+
+function restoreAngleBracketPlaceholders(blocks: BlockNote[], placeholderToToken: Map<string, string>): BlockNote[] {
+    if (placeholderToToken.size === 0) {
+        return blocks;
+    }
+
+    return mapBlocks(blocks, (content) =>
+        mapBlockContent(content, (inline) => {
+            if (inline.type !== 'text' || typeof inline.text !== 'string') {
+                return inline;
+            }
+
+            let text = inline.text;
+
+            for (const [placeholder, token] of placeholderToToken.entries()) {
+                text = text.split(placeholder).join(token);
             }
 
             return {
@@ -485,13 +688,48 @@ export async function markdownToBlocksJson(
 ): Promise<string> {
     const editor = getEditor();
     const preprocessedMarkdown = preprocessMarkdownExplicitTags(markdown);
-    const blocks = await editor.tryParseMarkdownToBlocks(preprocessedMarkdown.markdown);
-    const restoredBlocks = await restoreCustomInlineContent(
-        blocks as BlockNote[],
+    const contentJson = await parseMarkdownToContentJson(
+        editor,
+        preprocessedMarkdown.markdown,
         deps,
         preprocessedMarkdown.placeholderToTag,
     );
-    return JSON.stringify(restoreRemainingTagPlaceholders(restoredBlocks, preprocessedMarkdown.placeholderToTag));
+
+    if (extractLiteralAngleBracketTextTokens(preprocessedMarkdown.markdown).length === 0) {
+        return contentJson;
+    }
+
+    if (!hasLiteralAngleBracketTextTokenLoss(preprocessedMarkdown.markdown, await blocksToMarkdown(contentJson))) {
+        return contentJson;
+    }
+
+    const protectedMarkdown = protectMarkdownTextAngleBrackets(preprocessedMarkdown.markdown);
+
+    return parseMarkdownToContentJson(
+        editor,
+        protectedMarkdown.markdown,
+        deps,
+        preprocessedMarkdown.placeholderToTag,
+        protectedMarkdown.placeholderToToken,
+    );
+}
+
+async function parseMarkdownToContentJson(
+    editor: ServerBlockNoteEditor,
+    markdown: string,
+    deps: MarkdownImportDeps,
+    placeholderToTag: Map<string, string>,
+    placeholderToAngleBracketToken: Map<string, string> = new Map(),
+) {
+    const blocks = await editor.tryParseMarkdownToBlocks(markdown);
+    const restoredBlocks = await restoreCustomInlineContent(blocks as BlockNote[], deps, placeholderToTag);
+    const restoredTagBlocks = restoreRemainingTagPlaceholders(restoredBlocks, placeholderToTag);
+    const restoredAngleBracketBlocks = restoreAngleBracketPlaceholders(
+        restoredTagBlocks,
+        placeholderToAngleBracketToken,
+    );
+
+    return JSON.stringify(restoredAngleBracketBlocks);
 }
 
 export function extractTagIdsFromContentJson(contentJson: string): string[] {

--- a/packages/server/test/blocknote.test.ts
+++ b/packages/server/test/blocknote.test.ts
@@ -4,6 +4,7 @@ import test from 'node:test';
 import {
     blocksToMarkdown,
     countReferenceInlinesFromContentJson,
+    extractLiteralAngleBracketTextTokens,
     extractTagIdsFromContentJson,
     hasUnsupportedMarkdownBlocks,
     markdownToBlocksJson,
@@ -412,6 +413,73 @@ test('markdownToBlocksJson leaves plain @ and # tokens as text to avoid accident
             styles: {},
         },
     ]);
+});
+
+test('markdownToBlocksJson preserves angle-bracket text markers', async () => {
+    const markdown = [
+        '**<MARKER> Primary note, <MARKER-A> Follow-up note, <BR> Final note**',
+        '',
+        '* <MARKER> First list item',
+        '* <MARKER-A> Second list item',
+        '* <BR> Third list item',
+    ].join('\n');
+
+    const contentJson = await markdownToBlocksJson(markdown, {
+        ensureTag: async () => {
+            throw new Error('should not ensure tags');
+        },
+        findNotesByTitle: async () => [],
+    });
+    const roundTripMarkdown = await blocksToMarkdown(contentJson);
+
+    assert.match(roundTripMarkdown, /<MARKER> Primary note/);
+    assert.match(roundTripMarkdown, /<MARKER-A> Follow-up note/);
+    assert.match(roundTripMarkdown, /<BR> Final note/);
+    assert.match(roundTripMarkdown, /<MARKER> First list item/);
+    assert.match(roundTripMarkdown, /<MARKER-A> Second list item/);
+    assert.match(roundTripMarkdown, /<BR> Third list item/);
+});
+
+test('markdownToBlocksJson leaves angle-bracket text markers unchanged inside code', async () => {
+    const markdown = ['Inline `<MARKER>` sample.', '', '```', '<MARKER-A>', '```'].join('\n');
+
+    const contentJson = await markdownToBlocksJson(markdown, {
+        ensureTag: async () => {
+            throw new Error('should not ensure tags');
+        },
+        findNotesByTitle: async () => [],
+    });
+    const roundTripMarkdown = await blocksToMarkdown(contentJson);
+
+    assert.match(roundTripMarkdown, /`<MARKER>`/);
+    assert.match(roundTripMarkdown, /```text\n<MARKER-A>\n```/);
+    assert.doesNotMatch(roundTripMarkdown, /&lt;MARKER(?:-A)?&gt;/);
+});
+
+test('markdownToBlocksJson preserves Markdown autolinks while protecting spaced angle text', async () => {
+    const markdown = 'Visit <https://example.com>, email <user@example.com>, keep < https://example.com > literal.';
+
+    const contentJson = await markdownToBlocksJson(markdown, {
+        ensureTag: async () => {
+            throw new Error('should not ensure tags');
+        },
+        findNotesByTitle: async () => [],
+    });
+    const roundTripMarkdown = await blocksToMarkdown(contentJson);
+
+    assert.match(roundTripMarkdown, /<https:\/\/example\.com>/);
+    assert.match(roundTripMarkdown, /<user@example\.com>/);
+    assert.match(roundTripMarkdown, /< https:\/\/example\.com >/);
+    assert.doesNotMatch(roundTripMarkdown, /&lt;/);
+});
+
+test('extractLiteralAngleBracketTextTokens ignores Markdown autolinks', () => {
+    assert.deepEqual(
+        extractLiteralAngleBracketTextTokens(
+            'Visit <https://example.com>, email <user@example.com>, then keep <MARKER_A> as text.',
+        ),
+        ['<MARKER_A>'],
+    );
 });
 
 test('markdownToBlocksJson leaves ambiguous references as plain text', async () => {


### PR DESCRIPTION
## :dart: Goal
- Prevent Markdown imports from losing literal angle-bracket text such as `<MARKER>` or `<MARKER-A>` during BlockNote conversion.
- Keep MCP markdown writes from applying when the import round-trip would silently drop literal text markers.

## :hammer_and_wrench: Core Changes
- Preserve non-autolink angle-bracket text through a fallback Markdown import path that only runs after normal parsing shows token loss.
- Restore protected tokens through internal placeholders instead of HTML entities, so code blocks and inline code stay unchanged.
- Add an apply-time MCP markdown guard for lossy literal angle-bracket imports.
- Add regression coverage for marker-like tokens, code contexts, Markdown autolinks, spaced angle text, and repeated-token loss.

## :brain: Key Decisions
- Use normal Markdown parsing first to avoid changing raw Markdown behavior unless literal text loss is detected.
- Preserve Markdown autolinks such as `<https://example.com>` and `<user@example.com>` instead of treating them as literal text markers.
- Compare literal token counts instead of simple substring presence so partial loss of repeated tokens is rejected.

## :test_tube: Verification Guide
### How to verify
1. Run `pnpm --filter @ocean-brain/server test`.
2. Run `pnpm --filter @ocean-brain/server type-check`.
3. Run `pnpm --filter @ocean-brain/server lint`.
4. Run `pnpm --filter @ocean-brain/server build`.

### Expected result
- Server tests pass with 240 passing tests.
- Type-check completes without errors.
- Lint completes without errors.
- Server build completes successfully.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed; not needed for this bug fix)
