### PR TITLE
🐛 Preserve numeric tilde markdown ranges

### DIFF
--- a/packages/server/src/features/note/services/markdown-intent-write.test.ts
+++ b/packages/server/src/features/note/services/markdown-intent-write.test.ts
@@ -221,6 +221,40 @@ test('markdown intent write refuses apply when Markdown import loses literal tex
     });
 });
 
+test('markdown intent write refuses apply when Markdown import loses numeric tilde ranges', async () => {
+    const service = createMarkdownIntentWriteService({
+        findNoteById: async () => createNote({ content: 'before-content' }),
+        renderMarkdown: async (content) =>
+            content === 'before-content' ? 'Original sentence.' : 'Range is 1~~3 and 4~~5.',
+        parseMarkdownToContentJson: async () => 'after-content',
+        extractTagIds: () => [],
+        updateNote: async () => {
+            throw new Error('should not update');
+        },
+    });
+
+    const result = await service.patchNoteMarkdown({
+        id: 7,
+        expectedUpdatedAt: '2026-05-28T00:00:00.000Z',
+        intent: 'Replace one sentence',
+        selector: {
+            type: 'exact_text',
+            text: 'Original sentence.',
+        },
+        operation: {
+            type: 'replace',
+            replacement: 'Range is 1~3 and 4~5.',
+        },
+        dryRun: false,
+    });
+
+    assert.deepEqual(result, {
+        status: 'failed',
+        reason: 'MARKDOWN_IMPORT_LOSSY',
+        message: 'The markdown write would lose literal text during Markdown import.',
+    });
+});
+
 test('markdown intent write maps guarded update conflicts to baseline mismatch failures', async () => {
     const service = createMarkdownIntentWriteService({
         findNoteById: async () => createNote(),

--- a/packages/server/src/features/note/services/markdown-intent-write.ts
+++ b/packages/server/src/features/note/services/markdown-intent-write.ts
@@ -5,6 +5,8 @@ import {
     extractLiteralAngleBracketTextTokens,
     extractTagIdsFromContentJson,
     hasLiteralAngleBracketTextTokenLoss,
+    hasNumericTildeRangeMarkerLoss,
+    hasNumericTildeRangeMarkers,
     hasUnsupportedMarkdownBlocks,
     markdownToBlocksJson,
 } from '~/modules/blocknote.js';
@@ -348,11 +350,16 @@ const applyMarkdownPlan = async (
 ): Promise<AppliedMarkdownWriteResult | MarkdownChangeFailure> => {
     const content = await deps.parseMarkdownToContentJson(input.plan.afterMarkdown);
     const literalAngleBracketTokens = extractLiteralAngleBracketTextTokens(input.plan.afterMarkdown);
+    const shouldCheckMarkdownImportLoss =
+        literalAngleBracketTokens.length > 0 || hasNumericTildeRangeMarkers(input.plan.afterMarkdown);
 
-    if (literalAngleBracketTokens.length > 0) {
+    if (shouldCheckMarkdownImportLoss) {
         const importedMarkdown = await deps.renderMarkdown(content);
 
-        if (hasLiteralAngleBracketTextTokenLoss(input.plan.afterMarkdown, importedMarkdown)) {
+        if (
+            hasLiteralAngleBracketTextTokenLoss(input.plan.afterMarkdown, importedMarkdown) ||
+            hasNumericTildeRangeMarkerLoss(input.plan.afterMarkdown, importedMarkdown)
+        ) {
             return markdownImportLossyFailure();
         }
     }

--- a/packages/server/src/modules/blocknote.ts
+++ b/packages/server/src/modules/blocknote.ts
@@ -272,9 +272,12 @@ function preprocessMarkdownExplicitTags(markdown: string) {
 }
 
 const MARKDOWN_ANGLE_BRACKET_TOKEN_PATTERN = /<([^<>\n]+)>/g;
+const MARKDOWN_NUMERIC_TILDE_RANGE_PATTERN = /(\d)~(?=\d)/g;
 const MARKDOWN_FENCED_CODE_PATTERN = /^ {0,3}(`{3,}|~{3,})/;
 const ANGLE_BRACKET_PLACEHOLDER_PREFIX = '\uE000OBANGLE';
 const ANGLE_BRACKET_PLACEHOLDER_SUFFIX = '\uE001';
+const NUMERIC_TILDE_RANGE_PLACEHOLDER_PREFIX = '\uE000OBTILDE';
+const NUMERIC_TILDE_RANGE_PLACEHOLDER_SUFFIX = '\uE001';
 
 function isMarkdownAutolinkAngleBracketText(innerText: string) {
     if (innerText !== innerText.trim()) {
@@ -321,6 +324,63 @@ export function hasLiteralAngleBracketTextTokenLoss(sourceMarkdown: string, rend
     }
 
     return false;
+}
+
+function countNumericTildeRangeMarkers(markdown: string) {
+    return [...markdown.matchAll(MARKDOWN_NUMERIC_TILDE_RANGE_PATTERN)].length;
+}
+
+export function hasNumericTildeRangeMarkers(markdown: string) {
+    return countNumericTildeRangeMarkers(markdown) > 0;
+}
+
+export function hasNumericTildeRangeMarkerLoss(sourceMarkdown: string, renderedMarkdown: string) {
+    const sourceCount = countNumericTildeRangeMarkers(sourceMarkdown);
+
+    return sourceCount > 0 && countNumericTildeRangeMarkers(renderedMarkdown) < sourceCount;
+}
+
+function protectMarkdownNumericTildeRanges(markdown: string) {
+    const protectedLines: string[] = [];
+    const placeholderToToken = new Map<string, string>();
+    let activeFence: { marker: '`' | '~'; length: number } | null = null;
+
+    for (const line of markdown.split(/(?<=\n)/)) {
+        const { body: lineBody, lineEnding } = splitMarkdownLineEnding(line);
+        const fenceMatch = lineBody.match(MARKDOWN_FENCED_CODE_PATTERN);
+
+        if (activeFence) {
+            protectedLines.push(line);
+
+            if (isClosingFenceLine(lineBody, activeFence)) {
+                activeFence = null;
+            }
+
+            continue;
+        }
+
+        if (fenceMatch?.[1]) {
+            const marker = fenceMatch[1][0] as '`' | '~';
+            activeFence = {
+                marker,
+                length: fenceMatch[1].length,
+            };
+            protectedLines.push(line);
+            continue;
+        }
+
+        if (/^(?: {4,}|\t)/.test(lineBody)) {
+            protectedLines.push(line);
+            continue;
+        }
+
+        protectedLines.push(`${protectMarkdownLineNumericTildeRanges(lineBody, placeholderToToken)}${lineEnding}`);
+    }
+
+    return {
+        markdown: protectedLines.join(''),
+        placeholderToToken,
+    };
 }
 
 function protectMarkdownTextAngleBrackets(markdown: string) {
@@ -422,6 +482,81 @@ function protectMarkdownLineTextAngleBrackets(line: string, placeholderToToken: 
     return result;
 }
 
+function protectMarkdownLineNumericTildeRanges(line: string, placeholderToToken: Map<string, string>) {
+    let result = '';
+    let cursor = 0;
+
+    while (cursor < line.length) {
+        const protectedSpan = findNextMarkdownProtectedSpan(line, cursor);
+
+        if (!protectedSpan) {
+            result += replaceNumericTildeRangeMarkers(line.slice(cursor), placeholderToToken);
+            break;
+        }
+
+        result += replaceNumericTildeRangeMarkers(line.slice(cursor, protectedSpan.start), placeholderToToken);
+        result += line.slice(protectedSpan.start, protectedSpan.end);
+        cursor = protectedSpan.end;
+    }
+
+    return result;
+}
+
+function findNextMarkdownProtectedSpan(line: string, cursor: number) {
+    const codeSpan = findNextInlineCodeSpan(line, cursor);
+    const linkDestinationSpan = findNextMarkdownLinkDestinationSpan(line, cursor);
+
+    if (!codeSpan) {
+        return linkDestinationSpan;
+    }
+
+    if (!linkDestinationSpan) {
+        return codeSpan;
+    }
+
+    return codeSpan.start <= linkDestinationSpan.start ? codeSpan : linkDestinationSpan;
+}
+
+function findNextInlineCodeSpan(line: string, cursor: number) {
+    const codeStart = line.indexOf('`', cursor);
+
+    if (codeStart === -1) {
+        return null;
+    }
+
+    const delimiterLength = countRepeatedCharacter(line, codeStart, '`');
+    const codeEnd = line.indexOf('`'.repeat(delimiterLength), codeStart + delimiterLength);
+
+    if (codeEnd === -1) {
+        return null;
+    }
+
+    return {
+        start: codeStart,
+        end: codeEnd + delimiterLength,
+    };
+}
+
+function findNextMarkdownLinkDestinationSpan(line: string, cursor: number) {
+    const linkDestinationPrefix = line.indexOf('](', cursor);
+
+    if (linkDestinationPrefix === -1) {
+        return null;
+    }
+
+    const destinationStart = linkDestinationPrefix + 2;
+    const destinationEnd = line.indexOf(')', destinationStart);
+
+    if (destinationEnd === -1) {
+        return null;
+    }
+
+    return {
+        start: destinationStart,
+        end: destinationEnd,
+    };
+}
+
 function replaceLiteralAngleBracketTextTokens(text: string, placeholderToToken: Map<string, string>) {
     return text.replace(MARKDOWN_ANGLE_BRACKET_TOKEN_PATTERN, (match, innerText: string) => {
         if (isMarkdownAutolinkAngleBracketText(innerText)) {
@@ -435,8 +570,21 @@ function replaceLiteralAngleBracketTextTokens(text: string, placeholderToToken: 
     });
 }
 
+function replaceNumericTildeRangeMarkers(text: string, placeholderToToken: Map<string, string>) {
+    return text.replace(MARKDOWN_NUMERIC_TILDE_RANGE_PATTERN, (match, leadingDigit: string) => {
+        const placeholder = createNumericTildeRangePlaceholder(placeholderToToken.size);
+        placeholderToToken.set(placeholder, '~');
+
+        return `${leadingDigit}${placeholder}`;
+    });
+}
+
 function createAngleBracketPlaceholder(index: number) {
     return `${ANGLE_BRACKET_PLACEHOLDER_PREFIX}${index}${ANGLE_BRACKET_PLACEHOLDER_SUFFIX}`;
+}
+
+function createNumericTildeRangePlaceholder(index: number) {
+    return `${NUMERIC_TILDE_RANGE_PLACEHOLDER_PREFIX}${index}${NUMERIC_TILDE_RANGE_PLACEHOLDER_SUFFIX}`;
 }
 
 function countRepeatedCharacter(value: string, start: number, character: string) {
@@ -483,29 +631,45 @@ function restoreRemainingTagPlaceholders(blocks: BlockNote[], placeholderToTag: 
     );
 }
 
-function restoreAngleBracketPlaceholders(blocks: BlockNote[], placeholderToToken: Map<string, string>): BlockNote[] {
+function restoreProtectedTextPlaceholders(blocks: BlockNote[], placeholderToToken: Map<string, string>): BlockNote[] {
     if (placeholderToToken.size === 0) {
         return blocks;
     }
 
     return mapBlocks(blocks, (content) =>
-        mapBlockContent(content, (inline) => {
-            if (inline.type !== 'text' || typeof inline.text !== 'string') {
-                return inline;
-            }
-
-            let text = inline.text;
-
-            for (const [placeholder, token] of placeholderToToken.entries()) {
-                text = text.split(placeholder).join(token);
-            }
-
-            return {
-                ...inline,
-                text,
-            };
-        }),
+        mapBlockContent(
+            content,
+            (inline) => restoreProtectedTextInValue(inline, placeholderToToken) as BlockNoteInline,
+        ),
     );
+}
+
+function restoreProtectedTextInValue(value: unknown, placeholderToToken: Map<string, string>): unknown {
+    if (typeof value === 'string') {
+        return restoreProtectedText(value, placeholderToToken);
+    }
+
+    if (Array.isArray(value)) {
+        return value.map((item) => restoreProtectedTextInValue(item, placeholderToToken));
+    }
+
+    if (value && typeof value === 'object') {
+        return Object.fromEntries(
+            Object.entries(value).map(([key, item]) => [key, restoreProtectedTextInValue(item, placeholderToToken)]),
+        );
+    }
+
+    return value;
+}
+
+function restoreProtectedText(text: string, placeholderToToken: Map<string, string>) {
+    let restoredText = text;
+
+    for (const [placeholder, token] of placeholderToToken.entries()) {
+        restoredText = restoredText.split(placeholder).join(token);
+    }
+
+    return restoredText;
 }
 
 function createTextInline(text: string, styles: Record<string, unknown> = {}): BlockNoteInline {
@@ -688,11 +852,13 @@ export async function markdownToBlocksJson(
 ): Promise<string> {
     const editor = getEditor();
     const preprocessedMarkdown = preprocessMarkdownExplicitTags(markdown);
+    const tildeProtectedMarkdown = protectMarkdownNumericTildeRanges(preprocessedMarkdown.markdown);
     const contentJson = await parseMarkdownToContentJson(
         editor,
-        preprocessedMarkdown.markdown,
+        tildeProtectedMarkdown.markdown,
         deps,
         preprocessedMarkdown.placeholderToTag,
+        tildeProtectedMarkdown.placeholderToToken,
     );
 
     if (extractLiteralAngleBracketTextTokens(preprocessedMarkdown.markdown).length === 0) {
@@ -703,14 +869,18 @@ export async function markdownToBlocksJson(
         return contentJson;
     }
 
-    const protectedMarkdown = protectMarkdownTextAngleBrackets(preprocessedMarkdown.markdown);
+    const protectedMarkdown = protectMarkdownTextAngleBrackets(tildeProtectedMarkdown.markdown);
+    const placeholderToToken = new Map([
+        ...tildeProtectedMarkdown.placeholderToToken,
+        ...protectedMarkdown.placeholderToToken,
+    ]);
 
     return parseMarkdownToContentJson(
         editor,
         protectedMarkdown.markdown,
         deps,
         preprocessedMarkdown.placeholderToTag,
-        protectedMarkdown.placeholderToToken,
+        placeholderToToken,
     );
 }
 
@@ -719,17 +889,17 @@ async function parseMarkdownToContentJson(
     markdown: string,
     deps: MarkdownImportDeps,
     placeholderToTag: Map<string, string>,
-    placeholderToAngleBracketToken: Map<string, string> = new Map(),
+    placeholderToProtectedTextToken: Map<string, string> = new Map(),
 ) {
     const blocks = await editor.tryParseMarkdownToBlocks(markdown);
     const restoredBlocks = await restoreCustomInlineContent(blocks as BlockNote[], deps, placeholderToTag);
     const restoredTagBlocks = restoreRemainingTagPlaceholders(restoredBlocks, placeholderToTag);
-    const restoredAngleBracketBlocks = restoreAngleBracketPlaceholders(
+    const restoredProtectedTextBlocks = restoreProtectedTextPlaceholders(
         restoredTagBlocks,
-        placeholderToAngleBracketToken,
+        placeholderToProtectedTextToken,
     );
 
-    return JSON.stringify(restoredAngleBracketBlocks);
+    return JSON.stringify(restoredProtectedTextBlocks);
 }
 
 export function extractTagIdsFromContentJson(contentJson: string): string[] {

--- a/packages/server/test/blocknote.test.ts
+++ b/packages/server/test/blocknote.test.ts
@@ -473,6 +473,94 @@ test('markdownToBlocksJson preserves Markdown autolinks while protecting spaced 
     assert.doesNotMatch(roundTripMarkdown, /&lt;/);
 });
 
+test('markdownToBlocksJson preserves numeric tilde ranges as plain text', async () => {
+    const markdown = 'Range is 1~3 and 4~5.';
+
+    const contentJson = await markdownToBlocksJson(markdown, {
+        ensureTag: async () => {
+            throw new Error('should not ensure tags');
+        },
+        findNotesByTitle: async () => [],
+    });
+    const blocks = JSON.parse(contentJson);
+    const roundTripMarkdown = await blocksToMarkdown(contentJson);
+
+    assert.deepEqual(blocks[0].content, [
+        {
+            type: 'text',
+            text: markdown,
+            styles: {},
+        },
+    ]);
+    assert.equal(roundTripMarkdown.trim(), markdown);
+});
+
+test('markdownToBlocksJson preserves double-tilde strikethrough', async () => {
+    const markdown = 'Keep ~~strike~~ text';
+
+    const contentJson = await markdownToBlocksJson(markdown, {
+        ensureTag: async () => {
+            throw new Error('should not ensure tags');
+        },
+        findNotesByTitle: async () => [],
+    });
+    const blocks = JSON.parse(contentJson);
+    const roundTripMarkdown = await blocksToMarkdown(contentJson);
+
+    assert.deepEqual(blocks[0].content, [
+        {
+            type: 'text',
+            text: 'Keep ',
+            styles: {},
+        },
+        {
+            type: 'text',
+            text: 'strike',
+            styles: {
+                strike: true,
+            },
+        },
+        {
+            type: 'text',
+            text: ' text',
+            styles: {},
+        },
+    ]);
+    assert.equal(roundTripMarkdown.trim(), markdown);
+});
+
+test('markdownToBlocksJson leaves numeric tilde ranges unchanged inside code', async () => {
+    const markdown = ['Code is `1~3 and 4~5`.', '', '~~~', '1~3 and 4~5', '~~~'].join('\n');
+
+    const contentJson = await markdownToBlocksJson(markdown, {
+        ensureTag: async () => {
+            throw new Error('should not ensure tags');
+        },
+        findNotesByTitle: async () => [],
+    });
+    const roundTripMarkdown = await blocksToMarkdown(contentJson);
+
+    assert.match(roundTripMarkdown, /`1~3 and 4~5`/);
+    assert.match(roundTripMarkdown, /1~3 and 4~5/);
+    assert.doesNotMatch(roundTripMarkdown, /1~~3 and 4~~5/);
+});
+
+test('markdownToBlocksJson restores numeric tilde ranges in link destinations', async () => {
+    const markdown = '[1~3](https://example.com/range/1~3)';
+
+    const contentJson = await markdownToBlocksJson(markdown, {
+        ensureTag: async () => {
+            throw new Error('should not ensure tags');
+        },
+        findNotesByTitle: async () => [],
+    });
+    const blocks = JSON.parse(contentJson);
+    const roundTripMarkdown = await blocksToMarkdown(contentJson);
+
+    assert.equal(blocks[0].content[0].href, 'https://example.com/range/1~3');
+    assert.equal(roundTripMarkdown.trim(), markdown);
+});
+
 test('extractLiteralAngleBracketTextTokens ignores Markdown autolinks', () => {
     assert.deepEqual(
         extractLiteralAngleBracketTextTokens(


### PR DESCRIPTION
## :dart: Goal
- Prevent Markdown imports from turning numeric ranges such as `1~3 and 4~5` into strikethrough text.
- Keep MCP Markdown writes from silently applying lossy numeric tilde range conversions.

## :hammer_and_wrench: Core Changes
- Protect `digit~digit` range markers before BlockNote Markdown parsing and restore them after import.
- Preserve real double-tilde strikethrough syntax such as `~~strike~~`.
- Skip numeric range protection in inline code, fenced code, indented code, and Markdown link destinations.
- Extend MCP markdown apply-time loss detection to numeric tilde ranges.

## :brain: Key Decisions
- Scope the fix to numeric `digit~digit` ranges only to avoid changing existing single-tilde Markdown dialect behavior.
- Keep the fix centralized in `markdownToBlocksJson` so MCP create/update/patch/append/replace flows share the same behavior.
- Use placeholder restoration rather than patching BlockNote or remark behavior directly.

## :test_tube: Verification Guide
### How to verify
1. Run `pnpm --filter @ocean-brain/server lint`.
2. Run `pnpm --filter @ocean-brain/server test`.
3. Run `pnpm --filter @ocean-brain/server type-check`.
4. Run `pnpm --filter @ocean-brain/server build`.

### Expected result
- Server lint completes without errors.
- Server tests pass with 245 passing tests.
- Server type-check completes without errors.
- Server build completes successfully.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed; not needed for this bug fix)
