### PR TITLE
🐛 Stabilize note list page sizes

### DIFF
--- a/packages/client/src/components/app/RouteFeedback.tsx
+++ b/packages/client/src/components/app/RouteFeedback.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 
 import { PageLayout, Skeleton } from '~/components/shared';
 import { Button, Text } from '~/components/ui';
+import { HOME_DEFAULT_LIMIT } from '~/modules/home-pagination';
 import { HOME_ROUTE } from '~/modules/url';
 
 interface RoutePendingViewProps {
@@ -125,6 +126,7 @@ export function QueryErrorView({
                                 to: HOME_ROUTE,
                                 search: {
                                     page: 1,
+                                    limit: HOME_DEFAULT_LIMIT,
                                     sortBy: 'updatedAt',
                                     sortOrder: 'desc',
                                     pinnedFirst: false,

--- a/packages/client/src/components/shared/NoteFilters.tsx
+++ b/packages/client/src/components/shared/NoteFilters.tsx
@@ -1,13 +1,13 @@
 import * as Icon from '~/components/icon';
 import { Checkbox, Label, Select, SelectItem, Text } from '~/components/ui';
+import { HOME_DEFAULT_LIMIT, HOME_LIMIT_OPTIONS, type HomeLimit, isHomeLimit } from '~/modules/home-pagination';
 
 export type SortBy = 'updatedAt' | 'createdAt';
 export type SortOrder = 'asc' | 'desc';
 
 interface Props {
     itemsPerPage: number;
-    onItemsPerPageChange: (count: number) => void;
-    isAutoLimit?: boolean;
+    onItemsPerPageChange: (count: HomeLimit) => void;
     sortBy: SortBy;
     onSortByChange: (sortBy: SortBy) => void;
     sortOrder: SortOrder;
@@ -19,7 +19,6 @@ interface Props {
 export default function NoteFilters({
     itemsPerPage,
     onItemsPerPageChange,
-    isAutoLimit = false,
     sortBy,
     onSortByChange,
     sortOrder,
@@ -36,18 +35,22 @@ export default function NoteFilters({
                         Items
                     </Text>
                     <Select
-                        value={isAutoLimit ? 'auto' : String(itemsPerPage)}
+                        value={String(itemsPerPage)}
                         onValueChange={(value) => {
-                            if (value === 'auto') return;
-                            onItemsPerPageChange(Number(value));
+                            const nextItemsPerPage = Number(value);
+
+                            if (isHomeLimit(nextItemsPerPage)) {
+                                onItemsPerPageChange(nextItemsPerPage);
+                            }
                         }}
                         variant="ghost"
                         size="sm"
                     >
-                        {isAutoLimit && <SelectItem value="auto">Auto ({itemsPerPage})</SelectItem>}
-                        <SelectItem value="25">25</SelectItem>
-                        <SelectItem value="50">50</SelectItem>
-                        <SelectItem value="100">100</SelectItem>
+                        {HOME_LIMIT_OPTIONS.map((option) => (
+                            <SelectItem key={option} value={String(option)}>
+                                {option === HOME_DEFAULT_LIMIT ? `Default (${option})` : option}
+                            </SelectItem>
+                        ))}
                     </Select>
                 </div>
 

--- a/packages/client/src/modules/home-pagination.ts
+++ b/packages/client/src/modules/home-pagination.ts
@@ -1,0 +1,8 @@
+export const HOME_DEFAULT_LIMIT = 28;
+export const HOME_LIMIT_OPTIONS = [HOME_DEFAULT_LIMIT, 50, 100] as const;
+
+export type HomeLimit = (typeof HOME_LIMIT_OPTIONS)[number];
+
+export function isHomeLimit(value: number): value is HomeLimit {
+    return HOME_LIMIT_OPTIONS.includes(value as HomeLimit);
+}

--- a/packages/client/src/modules/route-search.spec.ts
+++ b/packages/client/src/modules/route-search.spec.ts
@@ -20,11 +20,18 @@ describe('route-search validators', () => {
             }),
         ).toEqual({
             page: 1,
-            limit: undefined,
+            limit: 28,
             sortBy: 'updatedAt',
             sortOrder: 'desc',
             pinnedFirst: true,
         });
+    });
+
+    it('keeps supported home page sizes and rejects unsupported limits', () => {
+        expect(validateHomeSearch({ limit: '50' }).limit).toBe(50);
+        expect(validateHomeSearch({ limit: '100' }).limit).toBe(100);
+        expect(validateHomeSearch({ limit: '25' }).limit).toBe(28);
+        expect(validateHomeSearch({ limit: '100000' }).limit).toBe(28);
     });
 
     it('returns a safe pagination fallback', () => {

--- a/packages/client/src/modules/route-search.ts
+++ b/packages/client/src/modules/route-search.ts
@@ -1,12 +1,14 @@
 import dayjs from 'dayjs';
 
 import type { SortBy, SortOrder } from '~/components/shared/NoteFilters';
+import { HOME_DEFAULT_LIMIT, HOME_LIMIT_OPTIONS, type HomeLimit } from '~/modules/home-pagination';
 
 type SearchRecord = Record<string, unknown>;
 
 const HOME_SORT_BY = ['updatedAt', 'createdAt'] as const satisfies readonly SortBy[];
 const SORT_ORDER = ['asc', 'desc'] as const satisfies readonly SortOrder[];
 const CALENDAR_TYPES = ['create', 'update'] as const;
+
 const getFirstValue = (value: unknown) => (Array.isArray(value) ? value[0] : value);
 
 const parsePositiveInt = (
@@ -25,15 +27,14 @@ const parsePositiveInt = (
     return parsed;
 };
 
-const parseOptionalPositiveInt = (value: unknown) => {
-    const normalized = getFirstValue(value);
+const parseNumberEnum = <TValue extends number>(
+    value: unknown,
+    allowedValues: readonly TValue[],
+    fallback: TValue,
+): TValue => {
+    const parsed = parsePositiveInt(value, Number.NaN);
 
-    if (normalized === undefined || normalized === null || normalized === '') {
-        return undefined;
-    }
-
-    const parsed = parsePositiveInt(normalized, Number.NaN);
-    return Number.isNaN(parsed) ? undefined : parsed;
+    return allowedValues.includes(parsed as TValue) ? (parsed as TValue) : fallback;
 };
 
 const parseBoolean = (value: unknown, fallback = false) => {
@@ -67,7 +68,7 @@ const parseEnum = <TValue extends string>(value: unknown, allowedValues: readonl
 
 export interface HomeRouteSearch {
     page: number;
-    limit?: number;
+    limit: HomeLimit;
     sortBy: SortBy;
     sortOrder: SortOrder;
     pinnedFirst: boolean;
@@ -93,7 +94,7 @@ export interface ViewNotesRouteSearch extends PaginationRouteSearch {
 
 export const validateHomeSearch = (search: SearchRecord): HomeRouteSearch => ({
     page: parsePositiveInt(search.page, 1),
-    limit: parseOptionalPositiveInt(search.limit),
+    limit: parseNumberEnum(search.limit, HOME_LIMIT_OPTIONS, HOME_DEFAULT_LIMIT),
     sortBy: parseEnum(search.sortBy, HOME_SORT_BY, 'updatedAt'),
     sortOrder: parseEnum(search.sortOrder, SORT_ORDER, 'desc'),
     pinnedFirst: parseBoolean(search.pinnedFirst, false),

--- a/packages/client/src/pages/Home.tsx
+++ b/packages/client/src/pages/Home.tsx
@@ -6,24 +6,14 @@ import { NoteListCard } from '~/components/note';
 import { Empty, FallbackRender, NoteFilters, PageLayout, Pagination, Skeleton } from '~/components/shared';
 
 import useNoteMutate from '~/hooks/resource/useNoteMutate';
-import { useGridLimit } from '~/hooks/useGridLimit';
 import type { HomeRouteSearch } from '~/modules/route-search';
 import { HOME_ROUTE } from '~/modules/url';
 
-const CARD_MIN_WIDTH = 240;
-const CARD_GAP = 20;
-const GRID_ROWS = 6;
 const Route = getRouteApi(HOME_ROUTE);
 
 export default function Home() {
     const navigate = Route.useNavigate();
-    const { limit: urlLimit, page, sortBy, sortOrder, pinnedFirst } = Route.useSearch();
-    const { containerRef, limit, isAutoLimit } = useGridLimit({
-        minItemWidth: CARD_MIN_WIDTH,
-        gap: CARD_GAP,
-        rows: GRID_ROWS,
-        override: urlLimit ?? null,
-    });
+    const { limit, page, sortBy, sortOrder, pinnedFirst } = Route.useSearch();
 
     const { onDelete, onPinned, deleteWarningDialog } = useNoteMutate();
 
@@ -38,7 +28,7 @@ export default function Home() {
 
     return (
         <PageLayout title="" variant="none">
-            <div ref={containerRef} className="flex flex-col gap-5">
+            <div className="flex flex-col gap-5">
                 <NoteFilters
                     itemsPerPage={limit}
                     onItemsPerPageChange={(count) =>
@@ -47,7 +37,6 @@ export default function Home() {
                             page: 1,
                         })
                     }
-                    isAutoLimit={isAutoLimit}
                     sortBy={sortBy}
                     onSortByChange={(sort) =>
                         updateSearchParams({

--- a/packages/client/src/pages/Tag.tsx
+++ b/packages/client/src/pages/Tag.tsx
@@ -4,25 +4,19 @@ import { QueryBoundary } from '~/components/app';
 import { Tags } from '~/components/entities';
 import { Empty, FallbackRender, PageLayout, Pagination, Skeleton } from '~/components/shared';
 import { Text } from '~/components/ui';
-import { useGridLimit } from '~/hooks/useGridLimit';
+import { HOME_DEFAULT_LIMIT } from '~/modules/home-pagination';
 import { TAG_NOTES_ROUTE, TAG_ROUTE } from '~/modules/url';
 
-const TAG_MIN_WIDTH = 100;
-const TAG_GAP = 8;
-const TAG_ROWS = 12;
+const TAG_PAGE_LIMIT = HOME_DEFAULT_LIMIT;
 const Route = getRouteApi(TAG_ROUTE);
 
 export default function Tag() {
     const navigate = Route.useNavigate();
     const { page } = Route.useSearch();
-    const { containerRef, limit } = useGridLimit({
-        minItemWidth: TAG_MIN_WIDTH,
-        gap: TAG_GAP,
-        rows: TAG_ROWS,
-    });
+    const limit = TAG_PAGE_LIMIT;
 
     return (
-        <div ref={containerRef}>
+        <div>
             <QueryBoundary
                 fallback={
                     <PageLayout


### PR DESCRIPTION
## :dart: Goal
- Stop Home and Tag lists from recalculating their API page size from viewport measurements.
- Keep note browsing visually stable while preserving larger scan options for Home.

## :hammer_and_wrench: Core Changes
- Replaced Home's auto grid limit with a deterministic default page size of 28.
- Limited Home page-size choices to `Default (28)`, `50`, and `100`.
- Clamped Home URL `limit` values to the supported set: `28`, `50`, or `100`.
- Replaced Tag's auto grid limit with the same fixed default of 28.
- Kept `useGridLimit` for the image manager, where it is still used.

## :brain: Key Decisions
- Treat Home as a stable card-browsing surface rather than a viewport-measured grid filler.
- Use `Default (28)` so the default density is clear without pretending 28 is a universal page-size convention.
- Keep `50` and `100` for users who want larger scan or skip units.
- Scope the cleanup to Home and Tag; image management remains unchanged because image loading has different cost tradeoffs.

## :test_tube: Verification Guide
### How to verify
1. Run `pnpm --filter @ocean-brain/client lint`.
2. Run `pnpm --filter @ocean-brain/client type-check`.
3. Run `pnpm --filter @ocean-brain/client test`.
4. Run `pnpm --filter @ocean-brain/client build`.

### Expected result
- Client lint completes without errors.
- Client type-check completes without errors.
- Client tests pass with 50 test files and 154 tests.
- Client build completes successfully.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Build completed
- [x] Documentation updated (if needed; not needed for this UI behavior fix)
