### PR TITLE
✨ Add table renderer for saved views

### DIFF
--- a/packages/client/src/apis/view.api.ts
+++ b/packages/client/src/apis/view.api.ts
@@ -1,5 +1,6 @@
 import type { Note } from '~/models/note.model';
 import type {
+    ViewDisplayOptions,
     ViewDisplayType,
     ViewPropertyFilter,
     ViewSection,
@@ -12,6 +13,7 @@ import { graphQuery } from '~/modules/graph-query';
 export interface ViewSectionInput {
     title?: string;
     displayType?: ViewDisplayType;
+    displayOptions?: ViewDisplayOptions;
     tagNames?: string[];
     mode?: 'and' | 'or';
     propertyFilters?: Array<Pick<ViewPropertyFilter, 'key' | 'valueType' | 'operator' | 'value'>>;
@@ -25,6 +27,9 @@ const VIEW_SECTION_FIELDS = `
     tabId
     title
     displayType
+    displayOptions {
+        tableColumns
+    }
     tagNames
     mode
     propertyFilters {

--- a/packages/client/src/components/view/ViewSectionCard.tsx
+++ b/packages/client/src/components/view/ViewSectionCard.tsx
@@ -1,14 +1,20 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
-import { fetchViewSectionNotes } from '~/apis/view.api';
-import * as Icon from '~/components/icon';
+import { useState } from 'react';
+import { fetchViewSectionNotes, updateViewSection } from '~/apis/view.api';
 import { Dropdown, SurfaceCard } from '~/components/shared';
-import { Button, MoreButton, Text } from '~/components/ui';
-import type { ViewSection } from '~/models/view.model';
+import { Button, MoreButton, Text, useToast } from '~/components/ui';
+import type { ViewSection, ViewSortBy, ViewSortOrder } from '~/models/view.model';
 import { queryKeys } from '~/modules/query-key-factory';
-import { timeSince } from '~/modules/time';
-import { NOTE_ROUTE, VIEW_NOTES_ROUTE } from '~/modules/url';
-import { buildViewNotesSearch, formatViewPropertyFilter, getViewTagMatchToken } from '~/modules/view-dashboard';
+import { VIEW_NOTES_ROUTE } from '~/modules/url';
+import {
+    buildViewNotesSearch,
+    buildViewSectionInput,
+    formatViewPropertyFilter,
+    getViewDisplayTypeLabel,
+    getViewTagMatchToken,
+} from '~/modules/view-dashboard';
+import ViewSectionRenderer from './ViewSectionRenderer';
 
 interface ViewSectionCardProps {
     section: ViewSection;
@@ -17,10 +23,10 @@ interface ViewSectionCardProps {
     dragHandle?: React.ReactNode;
 }
 
-const sectionPreviewRowClassName =
-    'flex items-start justify-between gap-3 rounded-[14px] border border-border-subtle/70 px-3 py-2.5 transition-colors hover:border-border-secondary hover:bg-hover-subtle';
-
 export default function ViewSectionCard({ section, onEdit, onDelete, dragHandle }: ViewSectionCardProps) {
+    const queryClient = useQueryClient();
+    const toast = useToast();
+    const [isSortPending, setIsSortPending] = useState(false);
     const sectionSearch = buildViewNotesSearch(section);
 
     const { data, isPending, isError, refetch } = useQuery({
@@ -44,6 +50,43 @@ export default function ViewSectionCard({ section, onEdit, onDelete, dragHandle 
     const tagMatchToken = getViewTagMatchToken(section.mode);
     const hasFilters = section.tagNames.length > 0 || section.propertyFilters.length > 0;
 
+    const updateSectionSort = async (sortBy: ViewSortBy) => {
+        if (isSortPending) {
+            return;
+        }
+
+        const nextSortOrder: ViewSortOrder =
+            section.sortBy === sortBy
+                ? section.sortOrder === 'asc'
+                    ? 'desc'
+                    : 'asc'
+                : sortBy === 'title'
+                  ? 'asc'
+                  : 'desc';
+
+        setIsSortPending(true);
+
+        const response = await updateViewSection(
+            section.id,
+            buildViewSectionInput(section, {
+                sortBy,
+                sortOrder: nextSortOrder,
+            }),
+        );
+
+        if (response.type === 'error') {
+            toast(response.errors[0]?.message ?? 'Failed to update table sort.');
+            setIsSortPending(false);
+            return;
+        }
+
+        await queryClient.invalidateQueries({
+            queryKey: queryKeys.views.all(),
+            exact: false,
+        });
+        setIsSortPending(false);
+    };
+
     return (
         <SurfaceCard className="flex h-full flex-col gap-4">
             <div className="flex items-start justify-between gap-3">
@@ -63,6 +106,9 @@ export default function ViewSectionCard({ section, onEdit, onDelete, dragHandle 
                         </div>
                     </div>
                     <div className="mt-3 flex flex-wrap gap-1.5">
+                        <span className="inline-flex items-center rounded-full border border-border-subtle/80 bg-elevated px-2.5 py-1 text-xs font-medium text-fg-secondary">
+                            {getViewDisplayTypeLabel(section.displayType)}
+                        </span>
                         {section.tagNames.map((tagName, index) => (
                             <div key={tagName} className="flex items-center gap-1.5">
                                 {index > 0 && (
@@ -109,61 +155,16 @@ export default function ViewSectionCard({ section, onEdit, onDelete, dragHandle 
             </div>
 
             <div className="flex flex-1 flex-col gap-2.5">
-                {isPending && (
-                    <>
-                        <div className="h-14 animate-pulse rounded-[14px] bg-hover-subtle" />
-                        <div className="h-14 animate-pulse rounded-[14px] bg-hover-subtle" />
-                        <div className="h-14 animate-pulse rounded-[14px] bg-hover-subtle" />
-                    </>
-                )}
-
-                {isError && (
-                    <div className="rounded-[16px] border border-border-subtle bg-hover-subtle/70 p-4">
-                        <Text as="p" variant="body" weight="semibold">
-                            Failed to load this section
-                        </Text>
-                        <Text as="p" variant="meta" tone="tertiary" className="mt-1">
-                            Retry to refresh this saved query.
-                        </Text>
-                        <div className="mt-3">
-                            <Button type="button" variant="ghost" size="sm" onClick={() => refetch()}>
-                                Retry
-                            </Button>
-                        </div>
-                    </div>
-                )}
-
-                {!isPending && !isError && notes.length === 0 && (
-                    <div className="rounded-[16px] border border-dashed border-border-subtle px-4 py-5">
-                        <Text as="p" variant="body" weight="semibold">
-                            No notes match yet
-                        </Text>
-                        <Text as="p" variant="meta" tone="tertiary" className="mt-1">
-                            Add matching notes, or edit this view query.
-                        </Text>
-                    </div>
-                )}
-
-                {!isPending &&
-                    !isError &&
-                    notes.map((note) => (
-                        <Link
-                            key={note.id}
-                            to={NOTE_ROUTE}
-                            params={{ id: note.id }}
-                            className={sectionPreviewRowClassName}
-                        >
-                            <div className="min-w-0">
-                                <Text as="div" variant="body" weight="semibold" className="line-clamp-1">
-                                    {note.title || 'Untitled'}
-                                </Text>
-                                <Text as="div" variant="meta" tone="tertiary" className="mt-1">
-                                    Updated {timeSince(Number(note.updatedAt))}
-                                </Text>
-                            </div>
-                            <Icon.ArrowRight className="mt-0.5 h-4 w-4 shrink-0 text-fg-tertiary" />
-                        </Link>
-                    ))}
+                <ViewSectionRenderer
+                    section={section}
+                    notes={notes}
+                    isPending={isPending}
+                    isError={isError}
+                    onRetry={() => void refetch()}
+                    onEdit={onEdit}
+                    onSortChange={updateSectionSort}
+                    isSortPending={isSortPending}
+                />
             </div>
 
             <div className="flex items-center justify-between gap-3 border-t border-border-subtle/70 pt-4">
@@ -172,7 +173,7 @@ export default function ViewSectionCard({ section, onEdit, onDelete, dragHandle 
                 </Text>
                 <Button asChild variant="subtle" size="sm">
                     <Link to={VIEW_NOTES_ROUTE} search={sectionSearch}>
-                        Open list
+                        Open results
                     </Link>
                 </Button>
             </div>

--- a/packages/client/src/components/view/ViewSectionDialog.spec.tsx
+++ b/packages/client/src/components/view/ViewSectionDialog.spec.tsx
@@ -1,0 +1,111 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import type { ViewSection } from '~/models/view.model';
+import ViewSectionDialog from './ViewSectionDialog';
+
+const createSection = (patch: Partial<ViewSection> = {}): ViewSection => ({
+    id: 'section-1',
+    tabId: 'tab-1',
+    title: 'Ocean Brain tasks',
+    displayType: 'list',
+    displayOptions: {
+        tableColumns: ['title', 'tags', 'properties', 'createdAt', 'updatedAt'],
+    },
+    tagNames: [],
+    mode: 'and',
+    propertyFilters: [],
+    sortBy: 'updatedAt',
+    sortOrder: 'desc',
+    limit: 5,
+    order: 0,
+    ...patch,
+});
+
+describe('<ViewSectionDialog />', () => {
+    it('submits the selected table display type', async () => {
+        const user = userEvent.setup();
+        const handleSubmit = vi.fn();
+
+        render(
+            <ViewSectionDialog
+                open
+                mode="create"
+                availableTags={[]}
+                availableProperties={[]}
+                onClose={vi.fn()}
+                onSubmit={handleSubmit}
+            />,
+        );
+
+        await user.click(screen.getByRole('radio', { name: 'Show as table' }));
+        await user.click(screen.getByRole('button', { name: 'Create view' }));
+
+        expect(handleSubmit).toHaveBeenCalledWith(
+            expect.objectContaining({
+                displayType: 'table',
+            }),
+        );
+    });
+
+    it('submits selected table columns with title kept visible', async () => {
+        const user = userEvent.setup();
+        const handleSubmit = vi.fn();
+
+        render(
+            <ViewSectionDialog
+                open
+                mode="create"
+                availableTags={[]}
+                availableProperties={[]}
+                onClose={vi.fn()}
+                onSubmit={handleSubmit}
+            />,
+        );
+
+        await user.click(screen.getByRole('radio', { name: 'Show as table' }));
+        await user.click(screen.getByRole('checkbox', { name: 'Show Tags column' }));
+        await user.click(screen.getByRole('checkbox', { name: 'Show Properties column' }));
+        await user.click(screen.getByRole('checkbox', { name: 'Show Created column' }));
+        await user.click(screen.getByRole('button', { name: 'Create view' }));
+
+        expect(handleSubmit).toHaveBeenCalledWith(
+            expect.objectContaining({
+                displayOptions: {
+                    tableColumns: ['title', 'updatedAt'],
+                },
+            }),
+        );
+    });
+
+    it('does not expose unavailable calendar display options', () => {
+        render(
+            <ViewSectionDialog
+                open
+                mode="create"
+                availableTags={[]}
+                availableProperties={[]}
+                onClose={vi.fn()}
+                onSubmit={vi.fn()}
+            />,
+        );
+
+        expect(screen.queryByText(/Calendar/i)).not.toBeInTheDocument();
+    });
+
+    it('normalizes unavailable initial display types back to list when editing', () => {
+        render(
+            <ViewSectionDialog
+                open
+                mode="edit"
+                initialSection={createSection({ displayType: 'calendar' })}
+                availableTags={[]}
+                availableProperties={[]}
+                onClose={vi.fn()}
+                onSubmit={vi.fn()}
+            />,
+        );
+
+        expect(screen.getByRole('radio', { name: 'Show as list' })).toHaveAttribute('aria-checked', 'true');
+    });
+});

--- a/packages/client/src/components/view/ViewSectionDialog.tsx
+++ b/packages/client/src/components/view/ViewSectionDialog.tsx
@@ -3,6 +3,7 @@ import type { NotePropertyKeySummary } from '~/apis/note.api';
 import { ModalActionRow } from '~/components/shared';
 import {
     Button,
+    Checkbox,
     Input,
     Label,
     Modal,
@@ -15,19 +16,31 @@ import {
 } from '~/components/ui';
 import type { Tag } from '~/models/tag.model';
 import type {
+    ViewDisplayOptions,
     ViewDisplayType,
     ViewPropertyFilter,
     ViewPropertyFilterOperator,
     ViewSection,
     ViewSortBy,
     ViewSortOrder,
+    ViewTableColumn,
     ViewTagMatchMode,
 } from '~/models/view.model';
-import { getViewPropertyOperatorLabel, getViewTagMatchLabel, normalizeViewTagNames } from '~/modules/view-dashboard';
+import {
+    DEFAULT_VIEW_TABLE_COLUMNS,
+    getViewDisplayTypeLabel,
+    getViewPropertyOperatorLabel,
+    getViewTableColumnLabel,
+    getViewTagMatchLabel,
+    normalizeViewDisplayOptions,
+    normalizeViewTableColumns,
+    normalizeViewTagNames,
+} from '~/modules/view-dashboard';
 
 export interface ViewSectionDialogDraft {
     title: string;
     displayType: ViewDisplayType;
+    displayOptions: ViewDisplayOptions;
     tagNames: string[];
     mode: ViewTagMatchMode;
     propertyFilters: Array<Pick<ViewPropertyFilter, 'key' | 'valueType' | 'operator' | 'value'>>;
@@ -56,8 +69,18 @@ interface ViewSectionDialogProps {
 }
 
 const PROPERTY_PLACEHOLDER_VALUE = '__choose_property__';
+const TABLE_COLUMN_OPTIONS: ViewTableColumn[] = ['title', 'tags', 'properties', 'createdAt', 'updatedAt'];
 
 const getInitialLimitValue = (section?: ViewSection | null) => String(section?.limit ?? 5);
+const getInitialDisplayTypeValue = (section?: ViewSection | null): ViewDisplayType => {
+    if (section?.displayType === 'table') {
+        return 'table';
+    }
+
+    return 'list';
+};
+const getInitialTableColumnsValue = (section?: ViewSection | null): ViewTableColumn[] =>
+    normalizeViewTableColumns(section?.displayOptions?.tableColumns ?? DEFAULT_VIEW_TABLE_COLUMNS);
 const getInitialModeValue = (section?: ViewSection | null): ViewTagMatchMode => section?.mode ?? 'and';
 const getInitialTagsValue = (section?: ViewSection | null) => (section ? section.tagNames.join(', ') : '');
 const getInitialTitleValue = (section?: ViewSection | null) => section?.title ?? '';
@@ -122,6 +145,8 @@ export default function ViewSectionDialog({
     onSubmit,
 }: ViewSectionDialogProps) {
     const [title, setTitle] = useState(getInitialTitleValue(initialSection));
+    const [displayType, setDisplayType] = useState<ViewDisplayType>(getInitialDisplayTypeValue(initialSection));
+    const [tableColumns, setTableColumns] = useState<ViewTableColumn[]>(getInitialTableColumnsValue(initialSection));
     const [tagInput, setTagInput] = useState(getInitialTagsValue(initialSection));
     const [matchMode, setMatchMode] = useState<ViewTagMatchMode>(getInitialModeValue(initialSection));
     const [sortBy, setSortBy] = useState<ViewSortBy>(getInitialSortByValue(initialSection));
@@ -142,6 +167,8 @@ export default function ViewSectionDialog({
         }
 
         setTitle(getInitialTitleValue(initialSection));
+        setDisplayType(getInitialDisplayTypeValue(initialSection));
+        setTableColumns(getInitialTableColumnsValue(initialSection));
         setTagInput(getInitialTagsValue(initialSection));
         setMatchMode(getInitialModeValue(initialSection));
         setSortBy(getInitialSortByValue(initialSection));
@@ -155,6 +182,22 @@ export default function ViewSectionDialog({
     const selectedTagNames = normalizeViewTagNames([tagInput]);
     const showTagFilter = isTagFilterOpen || selectedTagNames.length > 0;
     const isAllNotesView = selectedTagNames.length === 0 && filters.length === 0;
+
+    const toggleTableColumn = (column: ViewTableColumn) => {
+        if (column === 'title') {
+            return;
+        }
+
+        setTableColumns((currentColumns) => {
+            if (currentColumns.includes(column)) {
+                const nextColumns = currentColumns.filter((currentColumn) => currentColumn !== column);
+                return nextColumns.length > 0 ? nextColumns : currentColumns;
+            }
+
+            return normalizeViewTableColumns([...currentColumns, column]);
+        });
+        setFormError('');
+    };
 
     const toggleTagName = (tagName: string) => {
         const nextTagNames = selectedTagNames.includes(tagName)
@@ -274,7 +317,10 @@ export default function ViewSectionDialog({
 
                         onSubmit({
                             title,
-                            displayType: 'list',
+                            displayType,
+                            displayOptions: normalizeViewDisplayOptions({
+                                tableColumns,
+                            }),
                             tagNames,
                             mode: matchMode,
                             propertyFilters,
@@ -296,6 +342,75 @@ export default function ViewSectionDialog({
                             autoFocus
                         />
                     </div>
+
+                    <section className="flex flex-col gap-3 rounded-[18px] border border-border-subtle bg-elevated px-4 py-3">
+                        <div className="flex flex-wrap items-start justify-between gap-3">
+                            <div className="min-w-0">
+                                <Label size="md">Display</Label>
+                                <Text as="p" variant="meta" tone="tertiary" className="mt-1">
+                                    Show the same query as a compact list or a table.
+                                </Text>
+                            </div>
+                            <Text as="span" variant="meta" tone="tertiary">
+                                {getViewDisplayTypeLabel(displayType)}
+                            </Text>
+                        </div>
+                        <ToggleGroup
+                            type="single"
+                            value={displayType}
+                            onValueChange={(value) => {
+                                if (value === 'list' || value === 'table') {
+                                    setDisplayType(value);
+                                }
+                            }}
+                            variant="quiet"
+                            size="sm"
+                            className="self-start"
+                        >
+                            <ToggleGroupItem value="list" aria-label="Show as list">
+                                List
+                            </ToggleGroupItem>
+                            <ToggleGroupItem value="table" aria-label="Show as table">
+                                Table
+                            </ToggleGroupItem>
+                        </ToggleGroup>
+                        {displayType === 'table' ? (
+                            <div className="rounded-[16px] border border-border-subtle bg-subtle/45 p-3">
+                                <div className="flex flex-wrap items-center justify-between gap-2">
+                                    <Label size="sm">Table columns</Label>
+                                    <Text as="span" variant="meta" tone="tertiary">
+                                        {tableColumns.length} shown
+                                    </Text>
+                                </div>
+                                <div className="mt-3 grid gap-2 sm:grid-cols-2">
+                                    {TABLE_COLUMN_OPTIONS.map((column) => {
+                                        const label = getViewTableColumnLabel(column);
+
+                                        return (
+                                            <div
+                                                key={column}
+                                                className="flex items-center gap-2 rounded-[12px] border border-border-subtle bg-elevated px-3 py-2"
+                                            >
+                                                <Checkbox
+                                                    size="sm"
+                                                    checked={tableColumns.includes(column)}
+                                                    disabled={column === 'title'}
+                                                    aria-label={`Show ${label} column`}
+                                                    onChange={() => toggleTableColumn(column)}
+                                                />
+                                                <Text as="span" variant="label" tone="secondary">
+                                                    {label}
+                                                </Text>
+                                            </div>
+                                        );
+                                    })}
+                                </div>
+                                <Text as="p" variant="meta" tone="tertiary" className="mt-2">
+                                    Title is always shown because it opens the note.
+                                </Text>
+                            </div>
+                        ) : null}
+                    </section>
 
                     <section className="flex flex-col gap-3 rounded-[20px] border border-border-subtle bg-subtle/40 p-4">
                         <div className="flex flex-wrap items-start justify-between gap-3">

--- a/packages/client/src/components/view/ViewSectionListRenderer.tsx
+++ b/packages/client/src/components/view/ViewSectionListRenderer.tsx
@@ -1,0 +1,78 @@
+import { Link } from '@tanstack/react-router';
+
+import * as Icon from '~/components/icon';
+import { Button, Text } from '~/components/ui';
+import type { Note } from '~/models/note.model';
+import { timeSince } from '~/modules/time';
+import { NOTE_ROUTE } from '~/modules/url';
+
+interface ViewSectionListRendererProps {
+    notes: Note[];
+    isPending: boolean;
+    isError: boolean;
+    onRetry: () => void;
+}
+
+const sectionPreviewRowClassName =
+    'flex items-start justify-between gap-3 rounded-[14px] border border-border-subtle/70 px-3 py-2.5 transition-colors hover:border-border-secondary hover:bg-hover-subtle';
+
+export default function ViewSectionListRenderer({ notes, isPending, isError, onRetry }: ViewSectionListRendererProps) {
+    if (isPending) {
+        return (
+            <>
+                <div className="h-14 animate-pulse rounded-[14px] bg-hover-subtle" />
+                <div className="h-14 animate-pulse rounded-[14px] bg-hover-subtle" />
+                <div className="h-14 animate-pulse rounded-[14px] bg-hover-subtle" />
+            </>
+        );
+    }
+
+    if (isError) {
+        return (
+            <div className="rounded-[16px] border border-border-subtle bg-hover-subtle/70 p-4">
+                <Text as="p" variant="body" weight="semibold">
+                    Failed to load this section
+                </Text>
+                <Text as="p" variant="meta" tone="tertiary" className="mt-1">
+                    Retry to refresh this saved query.
+                </Text>
+                <div className="mt-3">
+                    <Button type="button" variant="ghost" size="sm" onClick={onRetry}>
+                        Retry
+                    </Button>
+                </div>
+            </div>
+        );
+    }
+
+    if (notes.length === 0) {
+        return (
+            <div className="rounded-[16px] border border-dashed border-border-subtle px-4 py-5">
+                <Text as="p" variant="body" weight="semibold">
+                    No notes match yet
+                </Text>
+                <Text as="p" variant="meta" tone="tertiary" className="mt-1">
+                    Add matching notes, or edit this view query.
+                </Text>
+            </div>
+        );
+    }
+
+    return (
+        <>
+            {notes.map((note) => (
+                <Link key={note.id} to={NOTE_ROUTE} params={{ id: note.id }} className={sectionPreviewRowClassName}>
+                    <div className="min-w-0">
+                        <Text as="div" variant="body" weight="semibold" className="line-clamp-1">
+                            {note.title || 'Untitled'}
+                        </Text>
+                        <Text as="div" variant="meta" tone="tertiary" className="mt-1">
+                            Updated {timeSince(Number(note.updatedAt))}
+                        </Text>
+                    </div>
+                    <Icon.ArrowRight className="mt-0.5 h-4 w-4 shrink-0 text-fg-tertiary" />
+                </Link>
+            ))}
+        </>
+    );
+}

--- a/packages/client/src/components/view/ViewSectionRenderer.spec.tsx
+++ b/packages/client/src/components/view/ViewSectionRenderer.spec.tsx
@@ -1,0 +1,98 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import type { Note } from '~/models/note.model';
+import type { ViewSection } from '~/models/view.model';
+import ViewSectionRenderer from './ViewSectionRenderer';
+
+vi.mock('@tanstack/react-router', () => ({
+    Link: ({
+        children,
+        params,
+        to,
+        ...props
+    }: {
+        children: React.ReactNode;
+        params?: { id?: string };
+        to?: string;
+    }) => (
+        <a href={params?.id ? `/${params.id}` : to} {...props}>
+            {children}
+        </a>
+    ),
+    useNavigate: () => vi.fn(),
+}));
+
+const createNote = (): Note => ({
+    id: 'note-1',
+    title: 'Ocean Brain task',
+    content: '',
+    pinned: false,
+    order: 0,
+    layout: 'wide',
+    tags: [{ id: 'tag-1', name: '@제품' }],
+    properties: [],
+    createdAt: '1780000000000',
+    updatedAt: '1780000000000',
+});
+
+const createSection = (patch: Partial<ViewSection> = {}): ViewSection => ({
+    id: 'section-1',
+    tabId: 'tab-1',
+    title: 'Ocean Brain tasks',
+    displayType: 'list',
+    displayOptions: {
+        tableColumns: ['title', 'tags', 'properties', 'createdAt', 'updatedAt'],
+    },
+    tagNames: [],
+    mode: 'and',
+    propertyFilters: [],
+    sortBy: 'updatedAt',
+    sortOrder: 'desc',
+    limit: 5,
+    order: 0,
+    ...patch,
+});
+
+const renderRenderer = (section: ViewSection, onEdit = vi.fn()) =>
+    render(
+        <ViewSectionRenderer
+            section={section}
+            notes={[createNote()]}
+            isPending={false}
+            isError={false}
+            onRetry={vi.fn()}
+            onEdit={onEdit}
+            onSortChange={vi.fn()}
+            isSortPending={false}
+        />,
+    );
+
+describe('<ViewSectionRenderer />', () => {
+    it('renders list sections with the list renderer', () => {
+        renderRenderer(createSection({ displayType: 'list' }));
+
+        expect(screen.getByRole('link', { name: /Ocean Brain task/i })).toBeInTheDocument();
+        expect(screen.queryByRole('table')).not.toBeInTheDocument();
+    });
+
+    it('renders table sections with the table renderer', () => {
+        renderRenderer(createSection({ displayType: 'table' }));
+
+        expect(screen.getByRole('table', { name: 'View query results as a table' })).toBeInTheDocument();
+    });
+
+    it('shows a generic unavailable state for unsupported display types', () => {
+        const handleEdit = vi.fn();
+
+        renderRenderer(createSection({ displayType: 'calendar' }), handleEdit);
+
+        expect(screen.getByText('This display type is unavailable')).toBeInTheDocument();
+        expect(
+            screen.getByText('Switch this section to List or Table to preview the saved query here.'),
+        ).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Change display' }));
+
+        expect(handleEdit).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/client/src/components/view/ViewSectionRenderer.tsx
+++ b/packages/client/src/components/view/ViewSectionRenderer.tsx
@@ -1,0 +1,47 @@
+import type { Note } from '~/models/note.model';
+import type { ViewSection, ViewSortBy } from '~/models/view.model';
+import ViewSectionListRenderer from './ViewSectionListRenderer';
+import ViewSectionTableRenderer from './ViewSectionTableRenderer';
+import ViewSectionUnsupportedRenderer from './ViewSectionUnsupportedRenderer';
+
+interface ViewSectionRendererProps {
+    section: ViewSection;
+    notes: Note[];
+    isPending: boolean;
+    isError: boolean;
+    onRetry: () => void;
+    onEdit: () => void;
+    onSortChange: (sortBy: ViewSortBy) => void;
+    isSortPending: boolean;
+}
+
+export default function ViewSectionRenderer({
+    section,
+    notes,
+    isPending,
+    isError,
+    onRetry,
+    onEdit,
+    onSortChange,
+    isSortPending,
+}: ViewSectionRendererProps) {
+    if (section.displayType === 'table') {
+        return (
+            <ViewSectionTableRenderer
+                section={section}
+                notes={notes}
+                isPending={isPending}
+                isError={isError}
+                onRetry={onRetry}
+                onSortChange={onSortChange}
+                isSortPending={isSortPending}
+            />
+        );
+    }
+
+    if (section.displayType === 'calendar') {
+        return <ViewSectionUnsupportedRenderer onEdit={onEdit} />;
+    }
+
+    return <ViewSectionListRenderer notes={notes} isPending={isPending} isError={isError} onRetry={onRetry} />;
+}

--- a/packages/client/src/components/view/ViewSectionTableRenderer.spec.tsx
+++ b/packages/client/src/components/view/ViewSectionTableRenderer.spec.tsx
@@ -1,0 +1,155 @@
+import { fireEvent, render, screen, within } from '@testing-library/react';
+
+import type { Note } from '~/models/note.model';
+import type { ViewSection } from '~/models/view.model';
+import { NOTE_ROUTE } from '~/modules/url';
+import ViewSectionTableRenderer from './ViewSectionTableRenderer';
+
+const mockNavigate = vi.fn();
+
+vi.mock('@tanstack/react-router', () => ({
+    Link: ({
+        children,
+        params,
+        to,
+        ...props
+    }: {
+        children: React.ReactNode;
+        params?: { id?: string };
+        to?: string;
+    }) => (
+        <a href={params?.id ? `/${params.id}` : to} {...props}>
+            {children}
+        </a>
+    ),
+    useNavigate: () => mockNavigate,
+}));
+
+const createNote = (patch: Partial<Note> = {}): Note => ({
+    id: 'note-1',
+    title: 'Ocean Brain task',
+    content: '',
+    pinned: false,
+    order: 0,
+    layout: 'wide',
+    tags: [{ id: 'tag-1', name: '@제품' }],
+    properties: [
+        {
+            key: 'status',
+            name: 'Status',
+            value: 'doing',
+            valueType: 'select',
+            option: {
+                id: 'option-1',
+                label: 'Doing',
+                value: 'doing',
+                order: 0,
+            },
+            createdAt: '1780000000000',
+            updatedAt: '1780000000000',
+        },
+    ],
+    createdAt: '1780000000000',
+    updatedAt: '1780000000000',
+    ...patch,
+});
+
+const createSection = (patch: Partial<ViewSection> = {}): ViewSection => ({
+    id: 'section-1',
+    tabId: 'tab-1',
+    title: 'Ocean Brain tasks',
+    displayType: 'table',
+    displayOptions: {
+        tableColumns: ['title', 'tags', 'properties', 'createdAt', 'updatedAt'],
+    },
+    tagNames: [],
+    mode: 'and',
+    propertyFilters: [],
+    sortBy: 'updatedAt',
+    sortOrder: 'desc',
+    limit: 5,
+    order: 0,
+    ...patch,
+});
+
+const renderTable = (props: Partial<React.ComponentProps<typeof ViewSectionTableRenderer>> = {}) =>
+    render(
+        <ViewSectionTableRenderer
+            section={createSection()}
+            notes={[createNote()]}
+            isPending={false}
+            isError={false}
+            onRetry={vi.fn()}
+            onSortChange={vi.fn()}
+            isSortPending={false}
+            {...props}
+        />,
+    );
+
+describe('<ViewSectionTableRenderer />', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('renders note query results as table rows with tags and properties', () => {
+        renderTable();
+
+        const table = screen.getByRole('table', { name: 'View query results as a table' });
+
+        expect(table).toBeInTheDocument();
+        expect(within(table).getByRole('columnheader', { name: /Created/ })).toBeInTheDocument();
+        expect(within(table).getByRole('columnheader', { name: /Updated/ })).toBeInTheDocument();
+        expect(within(table).getByText('Ocean Brain task')).toBeInTheDocument();
+        expect(within(table).getByText('@제품')).toBeInTheDocument();
+        expect(within(table).getByText('Status')).toBeInTheDocument();
+        expect(within(table).getByText('Doing')).toBeInTheDocument();
+    });
+
+    it('opens the note when a table row is activated', () => {
+        renderTable();
+
+        const row = screen.getByRole('link', { name: /Ocean Brain task/i }).closest('tr');
+
+        expect(row).toBeInTheDocument();
+        fireEvent.click(row);
+
+        expect(mockNavigate).toHaveBeenCalledWith({
+            to: NOTE_ROUTE,
+            params: { id: 'note-1' },
+        });
+    });
+
+    it('keeps notes without tags or properties visible with empty table cells', () => {
+        renderTable({ notes: [createNote({ tags: [], properties: [] })] });
+
+        expect(screen.getByText('Ocean Brain task')).toBeInTheDocument();
+        expect(screen.getAllByText('—')).toHaveLength(2);
+    });
+
+    it('respects selected table columns', () => {
+        renderTable({
+            section: createSection({
+                displayOptions: {
+                    tableColumns: ['title', 'updatedAt'],
+                },
+            }),
+        });
+
+        const table = screen.getByRole('table', { name: 'View query results as a table' });
+
+        expect(within(table).getByRole('columnheader', { name: /Title/ })).toBeInTheDocument();
+        expect(within(table).getByRole('columnheader', { name: /Updated/ })).toBeInTheDocument();
+        expect(within(table).queryByRole('columnheader', { name: 'Tags' })).not.toBeInTheDocument();
+        expect(within(table).queryByRole('columnheader', { name: 'Properties' })).not.toBeInTheDocument();
+    });
+
+    it('requests saved section sorting from sortable column headers', () => {
+        const handleSortChange = vi.fn();
+
+        renderTable({ onSortChange: handleSortChange });
+
+        fireEvent.click(screen.getByRole('button', { name: /Title/ }));
+
+        expect(handleSortChange).toHaveBeenCalledWith('title');
+    });
+});

--- a/packages/client/src/components/view/ViewSectionTableRenderer.tsx
+++ b/packages/client/src/components/view/ViewSectionTableRenderer.tsx
@@ -1,0 +1,283 @@
+import { Link, useNavigate } from '@tanstack/react-router';
+
+import { Button, Text } from '~/components/ui';
+import type { Note, NoteProperty } from '~/models/note.model';
+import type { ViewSection, ViewSortBy, ViewTableColumn } from '~/models/view.model';
+import { timeSince } from '~/modules/time';
+import { NOTE_ROUTE } from '~/modules/url';
+import { getViewTableColumnLabel, normalizeViewTableColumns } from '~/modules/view-dashboard';
+
+interface ViewSectionTableRendererProps {
+    section: ViewSection;
+    notes: Note[];
+    isPending: boolean;
+    isError: boolean;
+    onRetry: () => void;
+    onSortChange: (sortBy: ViewSortBy) => void;
+    isSortPending: boolean;
+}
+
+const formatPropertyValue = (property: NoteProperty) => {
+    if (property.valueType === 'select') {
+        return property.option?.label ?? property.value;
+    }
+
+    if (property.valueType === 'boolean') {
+        return property.value === 'true' ? 'True' : 'False';
+    }
+
+    return property.value;
+};
+
+const getVisibleProperties = (note: Note) => (note.properties ?? []).slice(0, 3);
+const TABLE_COLUMN_WIDTHS: Record<ViewTableColumn, number> = {
+    title: 280,
+    tags: 190,
+    properties: 260,
+    createdAt: 132,
+    updatedAt: 132,
+};
+const SORTABLE_TABLE_COLUMNS: Partial<Record<ViewTableColumn, ViewSortBy>> = {
+    title: 'title',
+    createdAt: 'createdAt',
+    updatedAt: 'updatedAt',
+};
+
+const getTableMinWidth = (columns: ViewTableColumn[]) => {
+    const width = columns.reduce((totalWidth, column) => totalWidth + TABLE_COLUMN_WIDTHS[column], 0);
+
+    return Math.max(520, width);
+};
+
+const renderTagSummary = (note: Note, options: { hideEmpty?: boolean } = {}) => {
+    if (note.tags.length === 0) {
+        if (options.hideEmpty) {
+            return null;
+        }
+
+        return <span className="text-fg-tertiary">—</span>;
+    }
+
+    const visibleTags = note.tags.slice(0, 3);
+    const hiddenCount = note.tags.length - visibleTags.length;
+
+    return (
+        <div className="flex min-w-0 max-w-full gap-1.5 overflow-hidden">
+            {visibleTags.map((tag) => (
+                <span
+                    key={tag.id}
+                    className="inline-flex max-w-[132px] shrink-0 items-center rounded-full border border-border-subtle bg-transparent px-2 py-0.5 text-xs font-medium text-fg-secondary"
+                >
+                    <span className="truncate">{tag.name}</span>
+                </span>
+            ))}
+            {hiddenCount > 0 && (
+                <span className="inline-flex items-center rounded-full border border-border-subtle bg-subtle px-2 py-0.5 text-xs font-medium text-fg-tertiary">
+                    +{hiddenCount}
+                </span>
+            )}
+        </div>
+    );
+};
+
+const renderPropertySummary = (note: Note, options: { hideEmpty?: boolean } = {}) => {
+    const visibleProperties = getVisibleProperties(note);
+
+    if (visibleProperties.length === 0) {
+        if (options.hideEmpty) {
+            return null;
+        }
+
+        return <span className="text-fg-tertiary">—</span>;
+    }
+
+    const hiddenCount = (note.properties?.length ?? 0) - visibleProperties.length;
+
+    return (
+        <div className="flex min-w-0 max-w-full gap-1.5 overflow-hidden">
+            {visibleProperties.map((property) => (
+                <span
+                    key={property.key}
+                    className="inline-flex max-w-[190px] shrink-0 items-center gap-1 rounded-full border border-border-subtle bg-subtle px-2 py-0.5 text-xs font-medium text-fg-secondary"
+                >
+                    <span className="max-w-[76px] shrink-0 truncate text-fg-tertiary">{property.name}</span>
+                    <span className="min-w-0 truncate">{formatPropertyValue(property) || '—'}</span>
+                </span>
+            ))}
+            {hiddenCount > 0 && (
+                <span className="inline-flex items-center rounded-full border border-border-subtle bg-subtle px-2 py-0.5 text-xs font-medium text-fg-tertiary">
+                    +{hiddenCount}
+                </span>
+            )}
+        </div>
+    );
+};
+
+export default function ViewSectionTableRenderer({
+    section,
+    notes,
+    isPending,
+    isError,
+    onRetry,
+    onSortChange,
+    isSortPending,
+}: ViewSectionTableRendererProps) {
+    const navigate = useNavigate();
+    const visibleColumns = normalizeViewTableColumns(section.displayOptions?.tableColumns);
+    const tableMinWidth = getTableMinWidth(visibleColumns);
+
+    const openNote = (noteId: string) => {
+        void navigate({
+            to: NOTE_ROUTE,
+            params: { id: noteId },
+        });
+    };
+
+    const renderHeaderCell = (column: ViewTableColumn) => {
+        const sortBy = SORTABLE_TABLE_COLUMNS[column];
+        const label = getViewTableColumnLabel(column);
+        const isActiveSort = sortBy ? section.sortBy === sortBy : false;
+
+        return (
+            <th
+                key={column}
+                aria-sort={isActiveSort ? (section.sortOrder === 'asc' ? 'ascending' : 'descending') : undefined}
+                className="px-3 py-2.5 text-xs font-semibold text-fg-tertiary"
+            >
+                {sortBy ? (
+                    <button
+                        type="button"
+                        className="focus-ring-soft -ml-1 inline-flex items-center gap-1 rounded-[8px] px-1 py-0.5 outline-none transition-colors hover:bg-hover-subtle hover:text-fg-secondary disabled:cursor-wait disabled:opacity-60"
+                        disabled={isSortPending}
+                        onClick={() => onSortChange(sortBy)}
+                    >
+                        <span>{label}</span>
+                        <span aria-hidden="true" className="text-[10px] text-fg-tertiary">
+                            {isActiveSort ? (section.sortOrder === 'asc' ? '↑' : '↓') : '↕'}
+                        </span>
+                    </button>
+                ) : (
+                    label
+                )}
+            </th>
+        );
+    };
+
+    const renderCell = (note: Note, column: ViewTableColumn) => {
+        switch (column) {
+            case 'tags':
+                return (
+                    <td key={column} className="px-3 py-2.5 align-middle">
+                        {renderTagSummary(note)}
+                    </td>
+                );
+            case 'properties':
+                return (
+                    <td key={column} className="px-3 py-2.5 align-middle">
+                        {renderPropertySummary(note)}
+                    </td>
+                );
+            case 'createdAt':
+                return (
+                    <td key={column} className="whitespace-nowrap px-3 py-2.5 align-middle">
+                        <Text as="span" variant="meta" tone="tertiary">
+                            {timeSince(Number(note.createdAt))}
+                        </Text>
+                    </td>
+                );
+            case 'updatedAt':
+                return (
+                    <td key={column} className="whitespace-nowrap px-3 py-2.5 align-middle">
+                        <Text as="span" variant="meta" tone="tertiary">
+                            {timeSince(Number(note.updatedAt))}
+                        </Text>
+                    </td>
+                );
+            case 'title':
+            default:
+                return (
+                    <td key={column} className="px-3 py-2.5 align-middle">
+                        <Text as="div" variant="body" weight="semibold" className="line-clamp-1">
+                            <Link
+                                to={NOTE_ROUTE}
+                                params={{ id: note.id }}
+                                className="focus-ring-soft rounded-[6px] outline-none transition-colors hover:text-fg-default/85"
+                                onClick={(event) => event.stopPropagation()}
+                            >
+                                {note.title || 'Untitled'}
+                            </Link>
+                        </Text>
+                    </td>
+                );
+        }
+    };
+
+    if (isPending) {
+        return (
+            <div className="overflow-hidden rounded-[16px] border border-border-subtle">
+                <div className="h-11 animate-pulse bg-hover-subtle" />
+                <div className="h-14 animate-pulse border-t border-border-subtle bg-elevated" />
+                <div className="h-14 animate-pulse border-t border-border-subtle bg-elevated" />
+                <div className="h-14 animate-pulse border-t border-border-subtle bg-elevated" />
+            </div>
+        );
+    }
+
+    if (isError) {
+        return (
+            <div className="rounded-[16px] border border-border-subtle bg-hover-subtle/70 p-4">
+                <Text as="p" variant="body" weight="semibold">
+                    Failed to load this table
+                </Text>
+                <Text as="p" variant="meta" tone="tertiary" className="mt-1">
+                    Retry to refresh this saved query.
+                </Text>
+                <div className="mt-3">
+                    <Button type="button" variant="ghost" size="sm" onClick={onRetry}>
+                        Retry
+                    </Button>
+                </div>
+            </div>
+        );
+    }
+
+    if (notes.length === 0) {
+        return (
+            <div className="rounded-[16px] border border-dashed border-border-subtle px-4 py-5">
+                <Text as="p" variant="body" weight="semibold">
+                    No rows yet
+                </Text>
+                <Text as="p" variant="meta" tone="tertiary" className="mt-1">
+                    Add matching notes, or edit this view query.
+                </Text>
+            </div>
+        );
+    }
+
+    return (
+        <div className="overflow-x-auto rounded-[16px] border border-border-subtle bg-elevated">
+            <table className="w-full table-fixed border-collapse text-left" style={{ minWidth: tableMinWidth }}>
+                <caption className="sr-only">View query results as a table</caption>
+                <colgroup>
+                    {visibleColumns.map((column) => (
+                        <col key={column} style={{ width: TABLE_COLUMN_WIDTHS[column] }} />
+                    ))}
+                </colgroup>
+                <thead className="bg-subtle/80">
+                    <tr className="border-b border-border-subtle">{visibleColumns.map(renderHeaderCell)}</tr>
+                </thead>
+                <tbody className="bg-elevated">
+                    {notes.map((note) => (
+                        <tr
+                            key={note.id}
+                            className="h-12 cursor-pointer border-b border-border-subtle/70 transition-colors last:border-b-0 hover:bg-hover-subtle"
+                            onClick={() => openNote(note.id)}
+                        >
+                            {visibleColumns.map((column) => renderCell(note, column))}
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </div>
+    );
+}

--- a/packages/client/src/components/view/ViewSectionUnsupportedRenderer.tsx
+++ b/packages/client/src/components/view/ViewSectionUnsupportedRenderer.tsx
@@ -1,0 +1,23 @@
+import { Button, Text } from '~/components/ui';
+
+interface ViewSectionUnsupportedRendererProps {
+    onEdit: () => void;
+}
+
+export default function ViewSectionUnsupportedRenderer({ onEdit }: ViewSectionUnsupportedRendererProps) {
+    return (
+        <div className="rounded-[16px] border border-dashed border-border-subtle bg-subtle/40 px-4 py-5">
+            <Text as="p" variant="body" weight="semibold">
+                This display type is unavailable
+            </Text>
+            <Text as="p" variant="meta" tone="tertiary" className="mt-1">
+                Switch this section to List or Table to preview the saved query here.
+            </Text>
+            <div className="mt-3">
+                <Button type="button" variant="ghost" size="sm" onClick={onEdit}>
+                    Change display
+                </Button>
+            </div>
+        </div>
+    );
+}

--- a/packages/client/src/components/view/index.ts
+++ b/packages/client/src/components/view/index.ts
@@ -1,4 +1,8 @@
 export { default as ViewSectionCard } from './ViewSectionCard';
 export type { ViewSectionDialogDraft } from './ViewSectionDialog';
 export { default as ViewSectionDialog } from './ViewSectionDialog';
+export { default as ViewSectionListRenderer } from './ViewSectionListRenderer';
+export { default as ViewSectionRenderer } from './ViewSectionRenderer';
+export { default as ViewSectionTableRenderer } from './ViewSectionTableRenderer';
+export { default as ViewSectionUnsupportedRenderer } from './ViewSectionUnsupportedRenderer';
 export { default as ViewTabDialog } from './ViewTabDialog';

--- a/packages/client/src/models/view.model.ts
+++ b/packages/client/src/models/view.model.ts
@@ -1,8 +1,13 @@
 export type ViewTagMatchMode = 'and' | 'or';
-export type ViewDisplayType = 'list' | 'calendar';
+export type ViewDisplayType = 'list' | 'table' | 'calendar';
+export type ViewTableColumn = 'title' | 'tags' | 'properties' | 'createdAt' | 'updatedAt';
 export type ViewPropertyFilterOperator = 'equals' | 'before' | 'after' | 'exists' | 'notExists';
 export type ViewSortBy = 'updatedAt' | 'createdAt' | 'title';
 export type ViewSortOrder = 'asc' | 'desc';
+
+export interface ViewDisplayOptions {
+    tableColumns: ViewTableColumn[];
+}
 
 export interface ViewPropertyFilter {
     key: string;
@@ -17,6 +22,7 @@ export interface ViewSection {
     tabId: string;
     title: string;
     displayType: ViewDisplayType;
+    displayOptions: ViewDisplayOptions;
     tagNames: string[];
     mode: ViewTagMatchMode;
     propertyFilters: ViewPropertyFilter[];

--- a/packages/client/src/modules/view-dashboard.spec.ts
+++ b/packages/client/src/modules/view-dashboard.spec.ts
@@ -1,9 +1,13 @@
 import {
+    buildViewSectionInput,
     EMPTY_VIEWS_WORKSPACE,
     formatViewPropertyFilter,
     getActiveViewTab,
+    getViewDisplayTypeLabel,
     getViewPropertyOperatorLabel,
+    getViewTableColumnLabel,
     getViewTagMatchToken,
+    normalizeViewTableColumns,
     normalizeViewTagNames,
     reorderViewSectionsInWorkspace,
     reorderViewTabsInWorkspace,
@@ -20,6 +24,9 @@ const createSection = (section: {
     order: number;
 }) => ({
     displayType: 'list' as const,
+    displayOptions: {
+        tableColumns: ['title', 'tags', 'properties', 'createdAt', 'updatedAt'] as const,
+    },
     propertyFilters: [],
     sortBy: 'updatedAt' as const,
     sortOrder: 'desc' as const,
@@ -167,5 +174,49 @@ describe('view-dashboard helpers', () => {
                 value: null,
             }),
         ).toBe('State is set');
+    });
+
+    it('labels supported view display types', () => {
+        expect(getViewDisplayTypeLabel('list')).toBe('List');
+        expect(getViewDisplayTypeLabel('table')).toBe('Table');
+        expect(getViewDisplayTypeLabel('calendar')).toBe('Unavailable');
+    });
+
+    it('normalizes table columns and keeps title visible', () => {
+        expect(normalizeViewTableColumns(['tags', 'tags', 'updatedAt'])).toEqual(['title', 'tags', 'updatedAt']);
+        expect(normalizeViewTableColumns([])).toEqual(['title', 'tags', 'properties', 'createdAt', 'updatedAt']);
+        expect(getViewTableColumnLabel('createdAt')).toBe('Created');
+    });
+
+    it('builds a mutation input from a saved section while preserving filters', () => {
+        expect(
+            buildViewSectionInput(
+                createSection({
+                    id: 'section-1',
+                    tabId: 'tab-1',
+                    title: 'Tasks',
+                    tagNames: ['@제품'],
+                    mode: 'and',
+                    limit: 5,
+                    order: 0,
+                }),
+                {
+                    sortBy: 'title',
+                    sortOrder: 'asc',
+                },
+            ),
+        ).toEqual({
+            title: 'Tasks',
+            displayType: 'list',
+            displayOptions: {
+                tableColumns: ['title', 'tags', 'properties', 'createdAt', 'updatedAt'],
+            },
+            tagNames: ['@제품'],
+            mode: 'and',
+            propertyFilters: [],
+            sortBy: 'title',
+            sortOrder: 'asc',
+            limit: 5,
+        });
     });
 });

--- a/packages/client/src/modules/view-dashboard.ts
+++ b/packages/client/src/modules/view-dashboard.ts
@@ -1,15 +1,19 @@
 import type {
+    ViewDisplayOptions,
+    ViewDisplayType,
     ViewPropertyFilter,
     ViewPropertyFilterOperator,
     ViewSection,
     ViewsWorkspace,
     ViewTab,
+    ViewTableColumn,
     ViewTagMatchMode,
 } from '~/models/view.model';
 
 export const DEFAULT_VIEW_SECTION_LIMIT = 5;
 export const MIN_VIEW_SECTION_LIMIT = 1;
 export const MAX_VIEW_SECTION_LIMIT = 20;
+export const DEFAULT_VIEW_TABLE_COLUMNS: ViewTableColumn[] = ['title', 'tags', 'properties', 'createdAt', 'updatedAt'];
 
 export const EMPTY_VIEWS_WORKSPACE: ViewsWorkspace = {
     activeTabId: null,
@@ -137,6 +141,50 @@ export const getViewPropertyOperatorLabel = (operator: ViewPropertyFilterOperato
     }
 };
 
+export const getViewDisplayTypeLabel = (displayType: ViewDisplayType) => {
+    switch (displayType) {
+        case 'table':
+            return 'Table';
+        case 'calendar':
+            return 'Unavailable';
+        case 'list':
+        default:
+            return 'List';
+    }
+};
+
+export const getViewTableColumnLabel = (column: ViewTableColumn) => {
+    switch (column) {
+        case 'tags':
+            return 'Tags';
+        case 'properties':
+            return 'Properties';
+        case 'createdAt':
+            return 'Created';
+        case 'updatedAt':
+            return 'Updated';
+        case 'title':
+        default:
+            return 'Title';
+    }
+};
+
+export const normalizeViewTableColumns = (columns?: readonly ViewTableColumn[] | null): ViewTableColumn[] => {
+    const allowedColumns = new Set(DEFAULT_VIEW_TABLE_COLUMNS);
+    const nextColumns = (columns ?? []).filter((column): column is ViewTableColumn => allowedColumns.has(column));
+    const uniqueColumns = Array.from(new Set(nextColumns));
+
+    if (uniqueColumns.length === 0) {
+        return [...DEFAULT_VIEW_TABLE_COLUMNS];
+    }
+
+    return uniqueColumns.includes('title') ? uniqueColumns : ['title', ...uniqueColumns];
+};
+
+export const normalizeViewDisplayOptions = (options?: Partial<ViewDisplayOptions> | null): ViewDisplayOptions => ({
+    tableColumns: normalizeViewTableColumns(options?.tableColumns),
+});
+
 export const formatViewPropertyFilter = (filter: ViewPropertyFilter) => {
     const operatorLabel = getViewPropertyOperatorLabel(filter.operator);
 
@@ -145,6 +193,33 @@ export const formatViewPropertyFilter = (filter: ViewPropertyFilter) => {
     }
 
     return `${filter.name} ${operatorLabel} ${filter.value ?? ''}`.trim();
+};
+
+export const buildViewSectionInput = (
+    section: ViewSection,
+    overrides: Partial<Pick<ViewSection, 'sortBy' | 'sortOrder' | 'displayOptions' | 'displayType'>> = {},
+) => {
+    const nextSection = {
+        ...section,
+        ...overrides,
+    };
+
+    return {
+        title: nextSection.title,
+        displayType: nextSection.displayType,
+        displayOptions: normalizeViewDisplayOptions(nextSection.displayOptions),
+        tagNames: nextSection.tagNames,
+        mode: nextSection.mode,
+        propertyFilters: nextSection.propertyFilters.map((filter) => ({
+            key: filter.key,
+            valueType: filter.valueType,
+            operator: filter.operator,
+            value: filter.value,
+        })),
+        sortBy: nextSection.sortBy,
+        sortOrder: nextSection.sortOrder,
+        limit: nextSection.limit,
+    };
 };
 
 export const buildViewNotesSearch = (section: Pick<ViewSection, 'id'>) => ({

--- a/packages/client/src/pages/ViewNotes.spec.tsx
+++ b/packages/client/src/pages/ViewNotes.spec.tsx
@@ -1,0 +1,208 @@
+import { QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import type { Note } from '~/models/note.model';
+import type { ViewSection } from '~/models/view.model';
+import { createTestQueryClient } from '~/test/test-utils';
+import ViewNotes from './ViewNotes';
+
+const routeState = vi.hoisted(() => ({
+    navigate: vi.fn(),
+    search: {
+        page: 1,
+        sectionId: 'section-1',
+    },
+}));
+
+const apiMocks = vi.hoisted(() => ({
+    fetchViewSection: vi.fn(),
+    fetchViewSectionNotes: vi.fn(),
+    updateViewSection: vi.fn(),
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+    getRouteApi: () => ({
+        useNavigate: () => routeState.navigate,
+        useSearch: () => routeState.search,
+    }),
+    Link: ({
+        children,
+        params,
+        to,
+        ...props
+    }: {
+        children: React.ReactNode;
+        params?: { id?: string };
+        to?: string;
+    }) => (
+        <a href={params?.id ? `/${params.id}` : to} {...props}>
+            {children}
+        </a>
+    ),
+    useNavigate: () => routeState.navigate,
+    useRouter: () => ({
+        history: {
+            back: vi.fn(),
+        },
+    }),
+}));
+
+vi.mock('~/apis/view.api', () => apiMocks);
+
+vi.mock('~/hooks/resource/useNoteMutate', () => ({
+    default: () => ({
+        onDelete: vi.fn(),
+        onPinned: vi.fn(),
+        deleteWarningDialog: null,
+    }),
+}));
+
+const createNote = (): Note => ({
+    id: 'note-1',
+    title: 'Ocean Brain task',
+    content: '',
+    pinned: false,
+    order: 0,
+    layout: 'wide',
+    tags: [{ id: 'tag-1', name: '@제품' }],
+    properties: [
+        {
+            key: 'status',
+            name: 'Status',
+            value: 'doing',
+            valueType: 'select',
+            option: {
+                id: 'option-1',
+                label: 'Doing',
+                value: 'doing',
+                order: 0,
+            },
+            createdAt: '1780000000000',
+            updatedAt: '1780000000000',
+        },
+    ],
+    createdAt: '1780000000000',
+    updatedAt: '1780000000000',
+});
+
+const createSection = (patch: Partial<ViewSection> = {}): ViewSection => ({
+    id: 'section-1',
+    tabId: 'tab-1',
+    title: 'Ocean Brain tasks',
+    displayType: 'table',
+    displayOptions: {
+        tableColumns: ['title', 'tags', 'properties', 'updatedAt'],
+    },
+    tagNames: [],
+    mode: 'and',
+    propertyFilters: [
+        {
+            key: 'project',
+            name: 'Project',
+            valueType: 'select',
+            operator: 'equals',
+            value: 'ocean-brain',
+        },
+        {
+            key: 'status',
+            name: 'Status',
+            valueType: 'select',
+            operator: 'equals',
+            value: 'doing',
+        },
+    ],
+    sortBy: 'updatedAt',
+    sortOrder: 'desc',
+    limit: 5,
+    order: 0,
+    ...patch,
+});
+
+const renderViewNotes = () => {
+    const queryClient = createTestQueryClient();
+
+    return render(
+        <QueryClientProvider client={queryClient}>
+            <ViewNotes />
+        </QueryClientProvider>,
+    );
+};
+
+describe('<ViewNotes />', () => {
+    beforeEach(() => {
+        routeState.search = {
+            page: 1,
+            sectionId: 'section-1',
+        };
+
+        apiMocks.fetchViewSection.mockResolvedValue({
+            type: 'success',
+            viewSection: createSection(),
+        });
+        apiMocks.fetchViewSectionNotes.mockResolvedValue({
+            type: 'success',
+            viewSectionNotes: {
+                totalCount: 1,
+                notes: [createNote()],
+            },
+        });
+        apiMocks.updateViewSection.mockResolvedValue({
+            type: 'success',
+            updateViewSection: {
+                id: 'section-1',
+            },
+        });
+    });
+
+    it('keeps a table section rendered as a table on the full results page', async () => {
+        renderViewNotes();
+
+        expect(await screen.findByRole('table', { name: 'View query results as a table' })).toBeInTheDocument();
+        expect(screen.getByText('Project is ocean-brain')).toBeInTheDocument();
+        expect(screen.getByText('Status is doing')).toBeInTheDocument();
+
+        expect(apiMocks.fetchViewSectionNotes).toHaveBeenCalledWith('section-1', {
+            limit: 25,
+            offset: 0,
+        });
+    });
+
+    it('saves full-result table sorting without dropping filters or display options', async () => {
+        renderViewNotes();
+
+        fireEvent.click(await screen.findByRole('button', { name: /Title/ }));
+
+        await waitFor(() => {
+            expect(apiMocks.updateViewSection).toHaveBeenCalledWith(
+                'section-1',
+                expect.objectContaining({
+                    displayType: 'table',
+                    displayOptions: {
+                        tableColumns: ['title', 'tags', 'properties', 'updatedAt'],
+                    },
+                    propertyFilters: [
+                        {
+                            key: 'project',
+                            valueType: 'select',
+                            operator: 'equals',
+                            value: 'ocean-brain',
+                        },
+                        {
+                            key: 'status',
+                            valueType: 'select',
+                            operator: 'equals',
+                            value: 'doing',
+                        },
+                    ],
+                    sortBy: 'title',
+                    sortOrder: 'asc',
+                }),
+            );
+        });
+
+        await waitFor(() => {
+            expect(apiMocks.fetchViewSection).toHaveBeenCalledTimes(2);
+            expect(apiMocks.fetchViewSectionNotes).toHaveBeenCalledTimes(2);
+        });
+    });
+});

--- a/packages/client/src/pages/ViewNotes.tsx
+++ b/packages/client/src/pages/ViewNotes.tsx
@@ -1,31 +1,41 @@
-import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
+import { useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
 import { getRouteApi } from '@tanstack/react-router';
+import { useState } from 'react';
 
-import { fetchViewSection, fetchViewSectionNotes } from '~/apis/view.api';
+import { fetchViewSection, fetchViewSectionNotes, updateViewSection } from '~/apis/view.api';
 import { QueryBoundary } from '~/components/app';
 import { NoteListCard } from '~/components/note';
 import { Empty, FallbackRender, PageLayout, Pagination, Skeleton } from '~/components/shared';
-import { Text } from '~/components/ui';
+import { Text, useToast } from '~/components/ui';
+import { ViewSectionTableRenderer } from '~/components/view';
 import useNoteMutate from '~/hooks/resource/useNoteMutate';
+import type { ViewSortBy, ViewSortOrder } from '~/models/view.model';
 import { queryKeys } from '~/modules/query-key-factory';
 import { VIEW_NOTES_ROUTE } from '~/modules/url';
-import { formatViewPropertyFilter, getViewTagMatchLabel } from '~/modules/view-dashboard';
+import { buildViewSectionInput, formatViewPropertyFilter, getViewTagMatchLabel } from '~/modules/view-dashboard';
 
 const Route = getRouteApi(VIEW_NOTES_ROUTE);
 
 function ViewNotesContent() {
     const navigate = Route.useNavigate();
+    const queryClient = useQueryClient();
+    const toast = useToast();
     const { page, sectionId } = Route.useSearch();
     const { onDelete, onPinned, deleteWarningDialog } = useNoteMutate();
+    const [isSortPending, setIsSortPending] = useState(false);
     const limit = 25;
 
-    const { data: sectionData } = useQuery({
+    const { data: sectionData } = useSuspenseQuery({
         queryKey: queryKeys.views.section(sectionId),
         async queryFn() {
             const response = await fetchViewSection(sectionId);
 
             if (response.type === 'error') {
                 throw response;
+            }
+
+            if (!response.viewSection) {
+                throw new Error('View section not found.');
             }
 
             return response.viewSection;
@@ -51,10 +61,10 @@ function ViewNotesContent() {
         },
     });
 
-    const heading = sectionData?.title || 'View Notes';
-    const tagNames = sectionData?.tagNames ?? [];
-    const mode = sectionData?.mode ?? 'and';
-    const propertyFilters = sectionData?.propertyFilters ?? [];
+    const heading = sectionData.title;
+    const tagNames = sectionData.tagNames;
+    const mode = sectionData.mode;
+    const propertyFilters = sectionData.propertyFilters;
     const hasTagFilter = tagNames.length > 0;
     const hasPropertyFilter = propertyFilters.length > 0;
     const filterSummary = hasTagFilter
@@ -64,6 +74,61 @@ function ViewNotesContent() {
         : hasPropertyFilter
           ? 'Property filters'
           : 'All notes';
+    const pagination = (
+        <FallbackRender fallback={null}>
+            {data.totalCount && limit < data.totalCount && (
+                <Pagination
+                    page={page}
+                    last={Math.ceil(data.totalCount / limit)}
+                    onChange={(nextPage) => {
+                        navigate({
+                            search: (prev) => ({
+                                ...prev,
+                                page: nextPage,
+                            }),
+                        });
+                    }}
+                />
+            )}
+        </FallbackRender>
+    );
+
+    const updateSectionSort = async (sortBy: ViewSortBy) => {
+        if (isSortPending) {
+            return;
+        }
+
+        const nextSortOrder: ViewSortOrder =
+            sectionData.sortBy === sortBy
+                ? sectionData.sortOrder === 'asc'
+                    ? 'desc'
+                    : 'asc'
+                : sortBy === 'title'
+                  ? 'asc'
+                  : 'desc';
+
+        setIsSortPending(true);
+
+        const response = await updateViewSection(
+            sectionData.id,
+            buildViewSectionInput(sectionData, {
+                sortBy,
+                sortOrder: nextSortOrder,
+            }),
+        );
+
+        if (response.type === 'error') {
+            toast(response.errors[0]?.message ?? 'Failed to update table sort.');
+            setIsSortPending(false);
+            return;
+        }
+
+        await queryClient.invalidateQueries({
+            queryKey: queryKeys.views.all(),
+            exact: false,
+        });
+        setIsSortPending(false);
+    };
 
     return (
         <PageLayout
@@ -108,7 +173,27 @@ function ViewNotesContent() {
                     />
                 }
             >
-                {data.notes.length > 0 && (
+                {data.notes.length > 0 && sectionData.displayType === 'table' ? (
+                    <div className="flex flex-col gap-4">
+                        <ViewSectionTableRenderer
+                            section={sectionData}
+                            notes={data.notes}
+                            isPending={false}
+                            isError={false}
+                            onRetry={() =>
+                                void queryClient.invalidateQueries({
+                                    queryKey: queryKeys.views.sectionNotes(sectionId, {
+                                        limit,
+                                        offset: (page - 1) * limit,
+                                    }),
+                                })
+                            }
+                            onSortChange={updateSectionSort}
+                            isSortPending={isSortPending}
+                        />
+                        {pagination}
+                    </div>
+                ) : data.notes.length > 0 ? (
                     <div className="flex flex-col gap-4">
                         <div className="grid-auto-cards grid gap-5">
                             {data.notes.map((note) => (
@@ -120,24 +205,9 @@ function ViewNotesContent() {
                                 />
                             ))}
                         </div>
-                        <FallbackRender fallback={null}>
-                            {data.totalCount && limit < data.totalCount && (
-                                <Pagination
-                                    page={page}
-                                    last={Math.ceil(data.totalCount / limit)}
-                                    onChange={(nextPage) => {
-                                        navigate({
-                                            search: (prev) => ({
-                                                ...prev,
-                                                page: nextPage,
-                                            }),
-                                        });
-                                    }}
-                                />
-                            )}
-                        </FallbackRender>
+                        {pagination}
                     </div>
-                )}
+                ) : null}
             </FallbackRender>
             {deleteWarningDialog}
         </PageLayout>

--- a/packages/server/prisma/schema.prisma
+++ b/packages/server/prisma/schema.prisma
@@ -289,5 +289,6 @@ enum ViewTagMatchMode {
 
 enum ViewDisplayType {
   list
+  table
   calendar
 }

--- a/packages/server/src/features/view/graphql/view.type-defs.ts
+++ b/packages/server/src/features/view/graphql/view.type-defs.ts
@@ -18,6 +18,7 @@ export const viewType = gql`
         tabId: ID!
         title: String!
         displayType: ViewDisplayType!
+        displayOptions: ViewDisplayOptions!
         tagNames: [String!]!
         mode: TagMatchMode!
         propertyFilters: [ViewPropertyFilter!]!
@@ -35,9 +36,22 @@ export const viewType = gql`
         value: String
     }
 
+    type ViewDisplayOptions {
+        tableColumns: [ViewTableColumn!]!
+    }
+
     enum ViewDisplayType {
         list
+        table
         calendar
+    }
+
+    enum ViewTableColumn {
+        title
+        tags
+        properties
+        createdAt
+        updatedAt
     }
 
     enum ViewPropertyFilterOperator {
@@ -66,9 +80,14 @@ export const viewType = gql`
         value: String
     }
 
+    input ViewDisplayOptionsInput {
+        tableColumns: [ViewTableColumn!]
+    }
+
     input ViewSectionInput {
         title: String
         displayType: ViewDisplayType
+        displayOptions: ViewDisplayOptionsInput
         tagNames: [String!]
         mode: TagMatchMode
         propertyFilters: [ViewPropertyFilterInput!]

--- a/packages/server/src/features/view/services/workspace.test.ts
+++ b/packages/server/src/features/view/services/workspace.test.ts
@@ -6,6 +6,7 @@ import {
     buildViewSectionWhere,
     clampViewSectionLimit,
     hydratePropertyFilters,
+    normalizeViewDisplayOptions,
     normalizeViewNotesPagination,
     normalizeViewNotesQueryInput,
     normalizeViewPropertyFilters,
@@ -36,6 +37,9 @@ test('normalizeViewSectionInput derives a default title and clamps invalid limit
         {
             title: '@project + @review',
             displayType: 'list',
+            displayOptions: {
+                tableColumns: ['title', 'tags', 'properties', 'createdAt', 'updatedAt'],
+            },
             tagNames: ['@project', '@review'],
             mode: 'or',
             propertyFilters: [],
@@ -55,6 +59,9 @@ test('normalizeViewSectionInput allows all-note views without filters', () => {
         {
             title: 'All notes',
             displayType: 'list',
+            displayOptions: {
+                tableColumns: ['title', 'tags', 'properties', 'createdAt', 'updatedAt'],
+            },
             tagNames: [],
             mode: 'and',
             propertyFilters: [],
@@ -63,6 +70,26 @@ test('normalizeViewSectionInput allows all-note views without filters', () => {
             limit: 5,
         },
     );
+});
+
+test('normalizeViewSectionInput preserves table display sections', () => {
+    assert.equal(
+        normalizeViewSectionInput({
+            title: 'Project tasks',
+            displayType: 'table',
+            displayOptions: {
+                tableColumns: ['title', 'properties', 'updatedAt'],
+            },
+            tagNames: [],
+        }).displayType,
+        'table',
+    );
+});
+
+test('normalizeViewDisplayOptions keeps table title visible and drops duplicates', () => {
+    assert.deepEqual(normalizeViewDisplayOptions({ tableColumns: ['tags', 'tags', 'updatedAt'] }), {
+        tableColumns: ['title', 'tags', 'updatedAt'],
+    });
 });
 
 test('normalizeViewPropertyFilters validates typed filter values', () => {
@@ -377,6 +404,9 @@ const createSectionRecord = (patch: Partial<ViewSectionRecord> = {}): ViewSectio
     tabId: '1',
     title: 'Doing',
     displayType: 'list',
+    displayOptions: {
+        tableColumns: ['title', 'tags', 'properties', 'createdAt', 'updatedAt'],
+    },
     tagNames: [],
     mode: 'and',
     propertyFilters: [],

--- a/packages/server/src/features/view/services/workspace.ts
+++ b/packages/server/src/features/view/services/workspace.ts
@@ -8,10 +8,15 @@ import { buildNoteTagNamesWhere, type NoteTagMatchMode } from '~/features/note/s
 import models from '~/models.js';
 
 export type ViewTagMatchMode = NoteTagMatchMode;
-export type ViewDisplayType = 'list' | 'calendar';
+export type ViewDisplayType = 'list' | 'table' | 'calendar';
+export type ViewTableColumn = 'title' | 'tags' | 'properties' | 'createdAt' | 'updatedAt';
 export type ViewPropertyFilterOperator = 'equals' | 'before' | 'after' | 'exists' | 'notExists';
 export type ViewSortBy = 'updatedAt' | 'createdAt' | 'title';
 export type ViewSortOrder = 'asc' | 'desc';
+
+export interface ViewDisplayOptionsRecord {
+    tableColumns: ViewTableColumn[];
+}
 
 export interface ViewPropertyFilterRecord {
     key: string;
@@ -26,6 +31,7 @@ export interface ViewSectionRecord {
     tabId: string;
     title: string;
     displayType: ViewDisplayType;
+    displayOptions: ViewDisplayOptionsRecord;
     tagNames: string[];
     mode: ViewTagMatchMode;
     propertyFilters: ViewPropertyFilterRecord[];
@@ -50,6 +56,7 @@ export interface ViewWorkspaceRecord {
 export interface ViewSectionInput {
     title?: string;
     displayType?: ViewDisplayType;
+    displayOptions?: ViewDisplayOptionsInput | null;
     tagNames?: string[] | null;
     mode?: ViewTagMatchMode;
     propertyFilters?: ViewPropertyFilterInput[] | null;
@@ -81,6 +88,10 @@ export interface ViewPropertyFilterInput {
     valueType?: PropertyValueType | null;
 }
 
+export interface ViewDisplayOptionsInput {
+    tableColumns?: ViewTableColumn[] | null;
+}
+
 export interface ViewSectionNotesResult {
     totalCount: number;
     notes: Note[];
@@ -97,6 +108,7 @@ const MAX_VIEW_PROPERTY_FILTERS = 10;
 const DEFAULT_VIEW_DISPLAY_TYPE: ViewDisplayType = 'list';
 const DEFAULT_VIEW_SORT_BY: ViewSortBy = 'updatedAt';
 const DEFAULT_VIEW_SORT_ORDER: ViewSortOrder = 'desc';
+const DEFAULT_VIEW_TABLE_COLUMNS: ViewTableColumn[] = ['title', 'tags', 'properties', 'createdAt', 'updatedAt'];
 
 type ViewDbClient = typeof models | Prisma.TransactionClient;
 
@@ -149,6 +161,14 @@ interface StoredViewQuery {
     propertyFilters?: ViewPropertyFilterRecord[];
     sortBy?: ViewSortBy;
     sortOrder?: ViewSortOrder;
+    displayOptions?: Partial<ViewDisplayOptionsRecord>;
+}
+
+interface ParsedStoredViewQuery {
+    propertyFilters: ViewPropertyFilterRecord[];
+    sortBy: ViewSortBy;
+    sortOrder: ViewSortOrder;
+    displayOptions: ViewDisplayOptionsRecord;
 }
 
 const isViewPropertyFilterOperator = (value: unknown): value is ViewPropertyFilterOperator => {
@@ -166,8 +186,22 @@ const isPropertyValueType = (value: unknown): value is PropertyValueType => {
     );
 };
 
+const isViewTableColumn = (value: unknown): value is ViewTableColumn => {
+    return (
+        value === 'title' ||
+        value === 'tags' ||
+        value === 'properties' ||
+        value === 'createdAt' ||
+        value === 'updatedAt'
+    );
+};
+
 const normalizeViewDisplayType = (value: ViewDisplayType | undefined): ViewDisplayType => {
-    return value === 'calendar' ? 'calendar' : DEFAULT_VIEW_DISPLAY_TYPE;
+    if (value === 'table' || value === 'calendar') {
+        return value;
+    }
+
+    return DEFAULT_VIEW_DISPLAY_TYPE;
 };
 
 const normalizeViewSortBy = (value: ViewSortBy | undefined): ViewSortBy => {
@@ -176,6 +210,25 @@ const normalizeViewSortBy = (value: ViewSortBy | undefined): ViewSortBy => {
 
 const normalizeViewSortOrder = (value: ViewSortOrder | undefined): ViewSortOrder => {
     return value === 'asc' ? 'asc' : DEFAULT_VIEW_SORT_ORDER;
+};
+
+export const normalizeViewTableColumns = (columns: ViewTableColumn[] | null | undefined): ViewTableColumn[] => {
+    const normalizedColumns = (columns ?? []).filter(isViewTableColumn);
+    const uniqueColumns = Array.from(new Set(normalizedColumns));
+
+    if (uniqueColumns.length === 0) {
+        return [...DEFAULT_VIEW_TABLE_COLUMNS];
+    }
+
+    return uniqueColumns.includes('title') ? uniqueColumns : ['title' as const, ...uniqueColumns];
+};
+
+export const normalizeViewDisplayOptions = (
+    options: ViewDisplayOptionsInput | Partial<ViewDisplayOptionsRecord> | null | undefined,
+): ViewDisplayOptionsRecord => {
+    return {
+        tableColumns: normalizeViewTableColumns(options?.tableColumns),
+    };
 };
 
 const normalizeFilterValue = ({
@@ -267,12 +320,13 @@ export const normalizeViewPropertyFilters = (filters: ViewPropertyFilterInput[] 
         .filter((filter): filter is ViewPropertyFilterRecord => filter !== null);
 };
 
-const parseStoredViewQuery = (value: string | null): Required<StoredViewQuery> => {
+const parseStoredViewQuery = (value: string | null): ParsedStoredViewQuery => {
     if (!value) {
         return {
             propertyFilters: [],
             sortBy: DEFAULT_VIEW_SORT_BY,
             sortOrder: DEFAULT_VIEW_SORT_ORDER,
+            displayOptions: normalizeViewDisplayOptions(null),
         };
     }
 
@@ -283,21 +337,24 @@ const parseStoredViewQuery = (value: string | null): Required<StoredViewQuery> =
             propertyFilters: normalizeViewPropertyFilters(parsed.propertyFilters ?? []),
             sortBy: normalizeViewSortBy(parsed.sortBy),
             sortOrder: normalizeViewSortOrder(parsed.sortOrder),
+            displayOptions: normalizeViewDisplayOptions(parsed.displayOptions),
         };
     } catch {
         return {
             propertyFilters: [],
             sortBy: DEFAULT_VIEW_SORT_BY,
             sortOrder: DEFAULT_VIEW_SORT_ORDER,
+            displayOptions: normalizeViewDisplayOptions(null),
         };
     }
 };
 
-const serializeStoredViewQuery = ({ propertyFilters, sortBy, sortOrder }: Required<StoredViewQuery>) => {
+const serializeStoredViewQuery = ({ propertyFilters, sortBy, sortOrder, displayOptions }: ParsedStoredViewQuery) => {
     return JSON.stringify({
         propertyFilters,
         sortBy,
         sortOrder,
+        displayOptions,
     });
 };
 
@@ -338,10 +395,12 @@ export const normalizeViewSectionInput = (input: ViewSectionInput) => {
     const trimmedTitle = input.title?.trim() ?? '';
     const sortBy = normalizeViewSortBy(input.sortBy);
     const sortOrder = normalizeViewSortOrder(input.sortOrder);
+    const displayOptions = normalizeViewDisplayOptions(input.displayOptions);
 
     return {
         title: trimmedTitle || buildDefaultSectionTitle(tagNames, propertyFilters),
         displayType: normalizeViewDisplayType(input.displayType),
+        displayOptions,
         tagNames,
         mode: input.mode === 'or' ? 'or' : 'and',
         propertyFilters,
@@ -351,6 +410,7 @@ export const normalizeViewSectionInput = (input: ViewSectionInput) => {
     } satisfies {
         title: string;
         displayType: ViewDisplayType;
+        displayOptions: ViewDisplayOptionsRecord;
         tagNames: string[];
         mode: ViewTagMatchMode;
         propertyFilters: ViewPropertyFilterRecord[];
@@ -432,6 +492,7 @@ const serializeViewSection = (section: DbViewSection): ViewSectionRecord => {
         tabId: String(section.tabId),
         title: section.title,
         displayType: normalizeViewDisplayType(section.displayType as ViewDisplayType),
+        displayOptions: query.displayOptions,
         tagNames: section.tags.map((tag) => tag.name),
         mode: section.mode as ViewTagMatchMode,
         propertyFilters: query.propertyFilters,
@@ -551,6 +612,7 @@ const buildStoredViewQuery = async (db: ViewDbClient, section: ReturnType<typeof
         propertyFilters,
         sortBy: section.sortBy,
         sortOrder: section.sortOrder,
+        displayOptions: section.displayOptions,
     });
 };
 


### PR DESCRIPTION
## :dart: Goal
- Turn saved Views into a more useful long-term dashboard by letting users render the same saved query as a table, not only as a note list.
- Keep the first renderer expansion focused on List and Table so Calendar/Board work can stay out of this PR.

## :hammer_and_wrench: Core Changes
- Added a View section renderer switch with separate List, Table, and unavailable display states.
- Added Table display support with configurable columns for Title, Tags, Properties, Created, and Updated.
- Render Table sections in both the Views dashboard card and the full View results page.
- Preserved saved filters, sorting, and result pagination when switching or sorting Table sections.
- Removed the disabled Calendar option from the section dialog until it is actually ready to use.

## :brain: Key Decisions
- Table uses horizontal scrolling on narrow screens instead of a separate mobile card fallback, so users can still inspect all selected columns.
- Table column preferences are stored inside existing section query/display options rather than adding a new database column.
- Calendar remains unsupported in the renderer contract but is hidden from the creation flow to avoid advertising unfinished behavior.
- Prisma diff against the local development database is empty, so no migration file is needed for the current SQLite enum state.

## :test_tube: Verification Guide
### How to verify
1. Run `pnpm check:encoding`, `pnpm lint`, `pnpm type-check`, `pnpm build`, and `pnpm test:ci`.
2. Run `pnpm --filter @ocean-brain/server exec prisma migrate diff --from-url "file:./prisma/data/db.sqlite3" --to-schema-datamodel ./prisma/schema.prisma --script`.
3. Start `pnpm dev`, open `/views`, create a Table section with property filters such as `project = ocean-brain` and `status = doing` or `done`.
4. Confirm the Table section renders on `/views`, opens as a Table from `Open results`, and keeps sorting after clicking sortable headers.
5. Confirm the section dialog only exposes List and Table, and that mobile/narrow screens show the Table with horizontal scrolling.

### Expected result
- Encoding, lint, type-check, build, and test suites pass.
- Prisma diff prints `-- This is an empty migration.`
- Saved View sections can be shown as List or Table without breaking existing tag/property filters.
- Table sections remain readable on narrow screens through horizontal scrolling.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)
