### PR TITLE
🐛 Preserve Markdown hard breaks

### DIFF
--- a/packages/server/src/modules/blocknote.ts
+++ b/packages/server/src/modules/blocknote.ts
@@ -278,6 +278,8 @@ const ANGLE_BRACKET_PLACEHOLDER_PREFIX = '\uE000OBANGLE';
 const ANGLE_BRACKET_PLACEHOLDER_SUFFIX = '\uE001';
 const NUMERIC_TILDE_RANGE_PLACEHOLDER_PREFIX = '\uE000OBTILDE';
 const NUMERIC_TILDE_RANGE_PLACEHOLDER_SUFFIX = '\uE001';
+const HARD_BREAK_PLACEHOLDER_PREFIX = '\uE000OBHARDBREAK';
+const HARD_BREAK_PLACEHOLDER_SUFFIX = '\uE001';
 
 function isMarkdownAutolinkAngleBracketText(innerText: string) {
     if (innerText !== innerText.trim()) {
@@ -375,6 +377,58 @@ function protectMarkdownNumericTildeRanges(markdown: string) {
         }
 
         protectedLines.push(`${protectMarkdownLineNumericTildeRanges(lineBody, placeholderToToken)}${lineEnding}`);
+    }
+
+    return {
+        markdown: protectedLines.join(''),
+        placeholderToToken,
+    };
+}
+
+function protectMarkdownLineEndHardBreakMarkers(markdown: string) {
+    const protectedLines: string[] = [];
+    const placeholderToToken = new Map<string, string>();
+    let activeFence: { marker: '`' | '~'; length: number } | null = null;
+    const lines = markdown.split(/(?<=\n)/);
+
+    for (const [index, line] of lines.entries()) {
+        const { body: lineBody, lineEnding } = splitMarkdownLineEnding(line);
+        const fenceMatch = lineBody.match(MARKDOWN_FENCED_CODE_PATTERN);
+
+        if (activeFence) {
+            protectedLines.push(line);
+
+            if (isClosingFenceLine(lineBody, activeFence)) {
+                activeFence = null;
+            }
+
+            continue;
+        }
+
+        if (fenceMatch?.[1]) {
+            const marker = fenceMatch[1][0] as '`' | '~';
+            activeFence = {
+                marker,
+                length: fenceMatch[1].length,
+            };
+            protectedLines.push(line);
+            continue;
+        }
+
+        if (/^(?: {4,}|\t)/.test(lineBody)) {
+            protectedLines.push(line);
+            continue;
+        }
+
+        const nextLineBody = splitMarkdownLineEnding(lines[index + 1] ?? '').body;
+        protectedLines.push(
+            `${protectMarkdownLineEndHardBreakMarker(
+                lineBody,
+                lineEnding,
+                isMarkdownHardBreakContinuationLine(nextLineBody),
+                placeholderToToken,
+            )}${lineEnding}`,
+        );
     }
 
     return {
@@ -579,12 +633,83 @@ function replaceNumericTildeRangeMarkers(text: string, placeholderToToken: Map<s
     });
 }
 
+function protectMarkdownLineEndHardBreakMarker(
+    line: string,
+    lineEnding: string,
+    hasContinuationLine: boolean,
+    placeholderToToken: Map<string, string>,
+) {
+    if (!lineEnding || !line.endsWith('\\')) {
+        return line;
+    }
+
+    const placeholder = createHardBreakPlaceholder(placeholderToToken.size);
+    const shouldPreserveAsHardBreak = hasContinuationLine && !hasUnclosedInlineCodeSpanAtLineEnd(line);
+    placeholderToToken.set(placeholder, shouldPreserveAsHardBreak ? '' : '\\');
+
+    return `${line.slice(0, -1)}${placeholder}`;
+}
+
+function isMarkdownHardBreakContinuationLine(line: string) {
+    if (!line.trim()) {
+        return false;
+    }
+
+    const trimmedLine = line.trimStart();
+
+    if (trimmedLine.match(MARKDOWN_FENCED_CODE_PATTERN)) {
+        return false;
+    }
+
+    if (/^(?:#{1,6})(?:\s|$)/.test(trimmedLine)) {
+        return false;
+    }
+
+    if (/^>/.test(trimmedLine)) {
+        return false;
+    }
+
+    if (/^(?:[-+*])(?:\s|$)/.test(trimmedLine) || /^\d{1,9}[.)](?:\s|$)/.test(trimmedLine)) {
+        return false;
+    }
+
+    if (/^(?:-{3,}|\*{3,}|_{3,})\s*$/.test(trimmedLine)) {
+        return false;
+    }
+
+    return true;
+}
+
+function hasUnclosedInlineCodeSpanAtLineEnd(line: string) {
+    let cursor = 0;
+    let openDelimiter: string | null = null;
+
+    while (cursor < line.length) {
+        const codeStart = line.indexOf('`', cursor);
+
+        if (codeStart === -1) {
+            break;
+        }
+
+        const delimiterLength = countRepeatedCharacter(line, codeStart, '`');
+        const delimiter = '`'.repeat(delimiterLength);
+        openDelimiter = openDelimiter === delimiter ? null : delimiter;
+        cursor = codeStart + delimiterLength;
+    }
+
+    return openDelimiter !== null;
+}
+
 function createAngleBracketPlaceholder(index: number) {
     return `${ANGLE_BRACKET_PLACEHOLDER_PREFIX}${index}${ANGLE_BRACKET_PLACEHOLDER_SUFFIX}`;
 }
 
 function createNumericTildeRangePlaceholder(index: number) {
     return `${NUMERIC_TILDE_RANGE_PLACEHOLDER_PREFIX}${index}${NUMERIC_TILDE_RANGE_PLACEHOLDER_SUFFIX}`;
+}
+
+function createHardBreakPlaceholder(index: number) {
+    return `${HARD_BREAK_PLACEHOLDER_PREFIX}${index}${HARD_BREAK_PLACEHOLDER_SUFFIX}`;
 }
 
 function countRepeatedCharacter(value: string, start: number, character: string) {
@@ -853,12 +978,17 @@ export async function markdownToBlocksJson(
     const editor = getEditor();
     const preprocessedMarkdown = preprocessMarkdownExplicitTags(markdown);
     const tildeProtectedMarkdown = protectMarkdownNumericTildeRanges(preprocessedMarkdown.markdown);
+    const hardBreakProtectedMarkdown = protectMarkdownLineEndHardBreakMarkers(tildeProtectedMarkdown.markdown);
+    const basePlaceholderToToken = new Map([
+        ...tildeProtectedMarkdown.placeholderToToken,
+        ...hardBreakProtectedMarkdown.placeholderToToken,
+    ]);
     const contentJson = await parseMarkdownToContentJson(
         editor,
-        tildeProtectedMarkdown.markdown,
+        hardBreakProtectedMarkdown.markdown,
         deps,
         preprocessedMarkdown.placeholderToTag,
-        tildeProtectedMarkdown.placeholderToToken,
+        basePlaceholderToToken,
     );
 
     if (extractLiteralAngleBracketTextTokens(preprocessedMarkdown.markdown).length === 0) {
@@ -869,11 +999,8 @@ export async function markdownToBlocksJson(
         return contentJson;
     }
 
-    const protectedMarkdown = protectMarkdownTextAngleBrackets(tildeProtectedMarkdown.markdown);
-    const placeholderToToken = new Map([
-        ...tildeProtectedMarkdown.placeholderToToken,
-        ...protectedMarkdown.placeholderToToken,
-    ]);
+    const protectedMarkdown = protectMarkdownTextAngleBrackets(hardBreakProtectedMarkdown.markdown);
+    const placeholderToToken = new Map([...basePlaceholderToToken, ...protectedMarkdown.placeholderToToken]);
 
     return parseMarkdownToContentJson(
         editor,

--- a/packages/server/test/blocknote.test.ts
+++ b/packages/server/test/blocknote.test.ts
@@ -10,6 +10,13 @@ import {
     markdownToBlocksJson,
 } from '../src/modules/blocknote.js';
 
+const noopMarkdownImportDeps = {
+    ensureTag: async () => {
+        throw new Error('should not ensure tags');
+    },
+    findNotesByTitle: async () => [],
+};
+
 test('blocksToMarkdown preserves supported content when tableOfContents blocks are present', async () => {
     const content = JSON.stringify([
         {
@@ -493,6 +500,117 @@ test('markdownToBlocksJson preserves numeric tilde ranges as plain text', async 
         },
     ]);
     assert.equal(roundTripMarkdown.trim(), markdown);
+});
+
+test('markdownToBlocksJson preserves numeric tilde ranges across hard break lines', async () => {
+    const markdown = 'Range is 1~3 and 4~5\\\nNext range is 6~7.';
+
+    const contentJson = await markdownToBlocksJson(markdown, noopMarkdownImportDeps);
+    const blocks = JSON.parse(contentJson);
+    const renderedMarkdown = await blocksToMarkdown(contentJson);
+
+    assert.equal(blocks.length, 1);
+    assert.deepEqual(blocks[0].content, [
+        {
+            type: 'text',
+            text: 'Range is 1~3 and 4~5\nNext range is 6~7.',
+            styles: {},
+        },
+    ]);
+    assert.equal(renderedMarkdown, `${markdown}\n`);
+    assert.doesNotMatch(renderedMarkdown, /~~/);
+});
+
+test('markdownToBlocksJson preserves line-end hard break markers without doubling them', async () => {
+    const markdown = 'Updated: 2026-06-01\\\n상태: 실제 프로젝트 구조 기반 초안';
+
+    const contentJson = await markdownToBlocksJson(markdown, noopMarkdownImportDeps);
+    const blocks = JSON.parse(contentJson);
+
+    assert.equal(blocks.length, 1);
+    assert.deepEqual(blocks[0].content, [
+        {
+            type: 'text',
+            text: 'Updated: 2026-06-01\n상태: 실제 프로젝트 구조 기반 초안',
+            styles: {},
+        },
+    ]);
+    assert.equal(await blocksToMarkdown(contentJson), `${markdown}\n`);
+});
+
+test('markdownToBlocksJson preserves consecutive line-end hard break markers without paragraph splitting', async () => {
+    const markdown = 'Updated: 2026-06-01\\\n\\\n상태: 실제 프로젝트 구조 기반 초안';
+
+    const contentJson = await markdownToBlocksJson(markdown, noopMarkdownImportDeps);
+    const blocks = JSON.parse(contentJson);
+
+    assert.equal(blocks.length, 1);
+    assert.deepEqual(blocks[0].content, [
+        {
+            type: 'text',
+            text: 'Updated: 2026-06-01\n\n상태: 실제 프로젝트 구조 기반 초안',
+            styles: {},
+        },
+    ]);
+    assert.equal(await blocksToMarkdown(contentJson), `${markdown}\n`);
+});
+
+test('markdownToBlocksJson preserves trailing backslashes at paragraph boundaries', async () => {
+    const markdown = 'Path: C:\\\n\nNext paragraph';
+
+    const contentJson = await markdownToBlocksJson(markdown, noopMarkdownImportDeps);
+    const blocks = JSON.parse(contentJson);
+
+    assert.equal(blocks.length, 2);
+    assert.deepEqual(blocks[0].content, [
+        {
+            type: 'text',
+            text: 'Path: C:\\',
+            styles: {},
+        },
+    ]);
+    assert.equal(await blocksToMarkdown(contentJson), `${markdown}\n`);
+});
+
+test('markdownToBlocksJson preserves trailing backslashes before block boundaries', async () => {
+    const cases = ['foo\\\n# heading', 'foo\\\n- item', 'foo\\\n> quote'];
+
+    for (const markdown of cases) {
+        const contentJson = await markdownToBlocksJson(markdown, noopMarkdownImportDeps);
+        const blocks = JSON.parse(contentJson);
+
+        assert.deepEqual(blocks[0].content, [
+            {
+                type: 'text',
+                text: 'foo\\',
+                styles: {},
+            },
+        ]);
+    }
+});
+
+test('markdownToBlocksJson preserves code block trailing backslashes', async () => {
+    const markdown = ['```', 'Updated: 2026-06-01\\', '```'].join('\n');
+
+    const contentJson = await markdownToBlocksJson(markdown, noopMarkdownImportDeps);
+    const blocks = JSON.parse(contentJson);
+    const renderedMarkdown = await blocksToMarkdown(contentJson);
+
+    assert.equal(blocks[0].type, 'codeBlock');
+    assert.equal(blocks[0].content[0].text, 'Updated: 2026-06-01\\');
+    assert.match(renderedMarkdown, /Updated: 2026-06-01\\\n```/);
+});
+
+test('markdownToBlocksJson preserves trailing backslashes inside multiline inline code', async () => {
+    const markdown = '`foo\\\nbar`';
+
+    const contentJson = await markdownToBlocksJson(markdown, noopMarkdownImportDeps);
+    const blocks = JSON.parse(contentJson);
+    const renderedMarkdown = await blocksToMarkdown(contentJson);
+
+    assert.equal(blocks[0].content[0].text, 'foo\\ bar');
+    assert.equal(blocks[0].content[0].styles.code, true);
+    assert.match(renderedMarkdown, /foo\\ bar/);
 });
 
 test('markdownToBlocksJson preserves double-tilde strikethrough', async () => {


### PR DESCRIPTION
## :dart: Goal
- Preserve Markdown line-end backslash hard breaks when MCP/agent writes import Markdown into BlockNote content.
- Keep existing numeric tilde range protection working when hard breaks are present in the same Markdown input.

## :hammer_and_wrench: Core Changes
- Added a hard-break placeholder pass before BlockNote Markdown parsing.
- Preserved literal trailing backslashes at paragraph/block boundaries instead of treating every line-end backslash as a hard break.
- Added regression coverage for hard breaks, paragraph boundaries, block boundaries, code blocks, multiline inline code, and numeric tilde ranges with hard breaks.

## :brain: Key Decisions
- Scope is limited to Markdown import paths through `markdownToBlocksJson`; the normal BlockNote JSON editor flow is not changed.
- Numeric tilde handling was already fixed before; this PR only verifies it still works when hard-break protection is applied afterward.
- HTTP MCP smoke was checked locally with a temporary SQLite database and local `/api/mcp/notes/create`, `/api/mcp/notes/update`, and `/api/mcp/notes/delete` calls.

## :test_tube: Verification Guide
### How to verify
1. `pnpm --dir packages/server exec tsx --tsconfig tsconfig.json --test test/blocknote.test.ts`
2. `pnpm --filter ./packages/server lint`
3. `pnpm --filter ./packages/server type-check`
4. `pnpm --filter ./packages/server test:ci`

### Expected result
- BlockNote markdown tests pass.
- Server lint and type-check pass.
- Server CI test suite passes.
- MCP Markdown imports preserve intentional hard breaks without converting numeric ranges like `1~3` into strikethrough or dropping literal trailing backslashes.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)
