### PR TITLE
✨ Add richer view property filters

### DIFF
--- a/packages/client/src/components/ui/Select/Select.tsx
+++ b/packages/client/src/components/ui/Select/Select.tsx
@@ -48,6 +48,7 @@ export interface SelectProps extends VariantProps<typeof selectTriggerVariants> 
     defaultValue?: string;
     onValueChange?: (value: string) => void;
     placeholder?: string;
+    ariaLabel?: string;
     className?: string;
     children: React.ReactNode;
     disabled?: boolean;
@@ -58,6 +59,7 @@ const Select = ({
     defaultValue,
     onValueChange,
     placeholder,
+    ariaLabel,
     variant,
     size,
     className,
@@ -72,13 +74,14 @@ const Select = ({
             disabled={disabled}
         >
             <SelectPrimitive.Trigger
+                aria-label={ariaLabel}
                 className={selectTriggerVariants({
                     variant,
                     size,
                     className,
                 })}
             >
-                <SelectPrimitive.Value placeholder={placeholder} />
+                <SelectPrimitive.Value className="min-w-0 truncate" placeholder={placeholder} />
                 <SelectPrimitive.Icon>
                     <Icon.ChevronDown className="w-3.5 h-3.5 opacity-60" />
                 </SelectPrimitive.Icon>

--- a/packages/client/src/components/view/ViewSectionDialog.spec.tsx
+++ b/packages/client/src/components/view/ViewSectionDialog.spec.tsx
@@ -1,8 +1,25 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
+import type { NotePropertyKeySummary } from '~/apis/note.api';
+import type { Tag } from '~/models/tag.model';
 import type { ViewSection } from '~/models/view.model';
 import ViewSectionDialog from './ViewSectionDialog';
+
+const createTag = (name: string, index: number): Pick<Tag, 'id' | 'name'> => ({
+    id: `tag-${index}`,
+    name,
+});
+
+const createProperty = (patch: Partial<NotePropertyKeySummary> = {}): NotePropertyKeySummary => ({
+    key: 'source',
+    name: 'Source',
+    valueType: 'url',
+    noteCount: 0,
+    options: [],
+    updatedAt: '2026-06-03T00:00:00.000Z',
+    ...patch,
+});
 
 const createSection = (patch: Partial<ViewSection> = {}): ViewSection => ({
     id: 'section-1',
@@ -93,6 +110,25 @@ describe('<ViewSectionDialog />', () => {
         expect(screen.queryByText(/Calendar/i)).not.toBeInTheDocument();
     });
 
+    it('labels tag match choices as AND and OR with helper text', () => {
+        render(
+            <ViewSectionDialog
+                open
+                mode="edit"
+                initialSection={createSection({ tagNames: ['@product', '@docs'] })}
+                availableTags={[createTag('@product', 1), createTag('@docs', 2)]}
+                availableProperties={[]}
+                onClose={vi.fn()}
+                onSubmit={vi.fn()}
+            />,
+        );
+
+        expect(screen.getByText('Tag match')).toBeInTheDocument();
+        expect(screen.getByRole('radio', { name: 'AND — all selected tags' })).toHaveTextContent('AND');
+        expect(screen.getByRole('radio', { name: 'OR — any selected tag' })).toHaveTextContent('OR');
+        expect(screen.getByText('AND requires every selected tag. OR accepts any selected tag.')).toBeInTheDocument();
+    });
+
     it('normalizes unavailable initial display types back to list when editing', () => {
         render(
             <ViewSectionDialog
@@ -107,5 +143,52 @@ describe('<ViewSectionDialog />', () => {
         );
 
         expect(screen.getByRole('radio', { name: 'Show as list' })).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('submits partial URL text for contains filters', async () => {
+        const user = userEvent.setup();
+        const handleSubmit = vi.fn();
+
+        render(
+            <ViewSectionDialog
+                open
+                mode="edit"
+                initialSection={createSection({
+                    propertyFilters: [
+                        {
+                            key: 'source',
+                            name: 'Source',
+                            valueType: 'url',
+                            operator: 'contains',
+                            value: '',
+                        },
+                    ],
+                })}
+                availableTags={[]}
+                availableProperties={[createProperty()]}
+                onClose={vi.fn()}
+                onSubmit={handleSubmit}
+            />,
+        );
+
+        const valueInput = screen.getByLabelText('Property filter value');
+
+        expect(valueInput).toHaveAttribute('type', 'text');
+
+        await user.type(valueInput, 'example.com');
+        await user.click(screen.getByRole('button', { name: 'Save view' }));
+
+        expect(handleSubmit).toHaveBeenCalledWith(
+            expect.objectContaining({
+                propertyFilters: [
+                    {
+                        key: 'source',
+                        operator: 'contains',
+                        value: 'example.com',
+                        valueType: 'url',
+                    },
+                ],
+            }),
+        );
     });
 });

--- a/packages/client/src/components/view/ViewSectionDialog.tsx
+++ b/packages/client/src/components/view/ViewSectionDialog.tsx
@@ -104,10 +104,14 @@ const getOperatorsForProperty = (property?: NotePropertyKeySummary): ViewPropert
     }
 
     if (property.valueType === 'date' || property.valueType === 'number') {
-        return ['equals', 'before', 'after', 'exists', 'notExists'];
+        return ['equals', 'notEquals', 'before', 'after', 'exists', 'notExists'];
     }
 
-    return ['equals', 'exists', 'notExists'];
+    if (property.valueType === 'text' || property.valueType === 'url') {
+        return ['equals', 'notEquals', 'contains', 'notContains', 'exists', 'notExists'];
+    }
+
+    return ['equals', 'notEquals', 'exists', 'notExists'];
 };
 
 const getDefaultOperator = (property?: NotePropertyKeySummary): ViewPropertyFilterOperator => {
@@ -132,6 +136,37 @@ const getDefaultValue = (property?: NotePropertyKeySummary) => {
 
 const shouldShowFilterValue = (operator: ViewPropertyFilterOperator) =>
     operator !== 'exists' && operator !== 'notExists';
+
+const isSearchTextOperator = (operator: ViewPropertyFilterOperator) =>
+    operator === 'contains' || operator === 'notContains';
+
+const getFilterInputType = (property: NotePropertyKeySummary, operator: ViewPropertyFilterOperator) => {
+    if (property.valueType === 'date') {
+        return 'date';
+    }
+
+    if (property.valueType === 'number') {
+        return 'number';
+    }
+
+    if (property.valueType === 'url' && !isSearchTextOperator(operator)) {
+        return 'url';
+    }
+
+    return 'text';
+};
+
+const getFilterInputPlaceholder = (property: NotePropertyKeySummary, operator: ViewPropertyFilterOperator) => {
+    if (property.valueType === 'url') {
+        return isSearchTextOperator(operator) ? 'example.com' : 'https://example.com';
+    }
+
+    if (property.valueType === 'text') {
+        return 'Value';
+    }
+
+    return undefined;
+};
 
 export default function ViewSectionDialog({
     open,
@@ -452,10 +487,12 @@ export default function ViewSectionDialog({
                                     return (
                                         <div
                                             key={filter.id}
-                                            className="grid gap-2 rounded-[16px] border border-border-subtle bg-elevated p-3 md:grid-cols-[minmax(0,1fr)_150px_minmax(0,1fr)_auto] md:items-center"
+                                            className="grid gap-2 rounded-[16px] border border-border-subtle bg-elevated p-3 md:grid-cols-[minmax(0,1fr)_minmax(10.5rem,12rem)_minmax(0,1fr)_auto] md:items-center"
                                         >
                                             <Select
                                                 value={filter.key || PROPERTY_PLACEHOLDER_VALUE}
+                                                ariaLabel="Property filter property"
+                                                className="w-full min-w-0"
                                                 onValueChange={(value) => {
                                                     if (value === PROPERTY_PLACEHOLDER_VALUE) {
                                                         return;
@@ -477,6 +514,8 @@ export default function ViewSectionDialog({
                                             <Select
                                                 value={filter.operator}
                                                 disabled={!property}
+                                                ariaLabel="Property filter operator"
+                                                className="w-full min-w-0"
                                                 onValueChange={(value) =>
                                                     updateFilter(filter.id, {
                                                         operator: value as ViewPropertyFilterOperator,
@@ -494,6 +533,8 @@ export default function ViewSectionDialog({
                                                 property.valueType === 'select' ? (
                                                     <Select
                                                         value={filter.value}
+                                                        ariaLabel="Property filter value"
+                                                        className="w-full min-w-0"
                                                         onValueChange={(value) => updateFilter(filter.id, { value })}
                                                     >
                                                         {property.options.map((option) => (
@@ -505,6 +546,8 @@ export default function ViewSectionDialog({
                                                 ) : property.valueType === 'boolean' ? (
                                                     <Select
                                                         value={filter.value || 'true'}
+                                                        ariaLabel="Property filter value"
+                                                        className="w-full min-w-0"
                                                         onValueChange={(value) => updateFilter(filter.id, { value })}
                                                     >
                                                         <SelectItem value="true">True</SelectItem>
@@ -512,26 +555,16 @@ export default function ViewSectionDialog({
                                                     </Select>
                                                 ) : (
                                                     <Input
-                                                        type={
-                                                            property.valueType === 'date'
-                                                                ? 'date'
-                                                                : property.valueType === 'number'
-                                                                  ? 'number'
-                                                                  : property.valueType === 'url'
-                                                                    ? 'url'
-                                                                    : 'text'
-                                                        }
+                                                        type={getFilterInputType(property, filter.operator)}
                                                         value={filter.value}
                                                         onChange={(event) =>
                                                             updateFilter(filter.id, { value: event.target.value })
                                                         }
-                                                        placeholder={
-                                                            property.valueType === 'url'
-                                                                ? 'https://example.com'
-                                                                : property.valueType === 'text'
-                                                                  ? 'Value'
-                                                                  : undefined
-                                                        }
+                                                        placeholder={getFilterInputPlaceholder(
+                                                            property,
+                                                            filter.operator,
+                                                        )}
+                                                        aria-label="Property filter value"
                                                     />
                                                 )
                                             ) : (
@@ -591,7 +624,7 @@ export default function ViewSectionDialog({
 
                                 {selectedTagNames.length > 1 ? (
                                     <div className="flex flex-col gap-2">
-                                        <Label size="sm">When multiple tags are selected</Label>
+                                        <Label size="sm">Tag match</Label>
                                         <ToggleGroup
                                             type="single"
                                             value={matchMode}
@@ -605,12 +638,15 @@ export default function ViewSectionDialog({
                                             className="self-start"
                                         >
                                             <ToggleGroupItem value="and" aria-label={getViewTagMatchLabel('and')}>
-                                                Match all
+                                                AND
                                             </ToggleGroupItem>
                                             <ToggleGroupItem value="or" aria-label={getViewTagMatchLabel('or')}>
-                                                Match any
+                                                OR
                                             </ToggleGroupItem>
                                         </ToggleGroup>
+                                        <Text as="p" variant="meta" tone="tertiary">
+                                            AND requires every selected tag. OR accepts any selected tag.
+                                        </Text>
                                     </div>
                                 ) : null}
 

--- a/packages/client/src/models/view.model.ts
+++ b/packages/client/src/models/view.model.ts
@@ -1,7 +1,15 @@
 export type ViewTagMatchMode = 'and' | 'or';
 export type ViewDisplayType = 'list' | 'table' | 'calendar';
 export type ViewTableColumn = 'title' | 'tags' | 'properties' | 'createdAt' | 'updatedAt';
-export type ViewPropertyFilterOperator = 'equals' | 'before' | 'after' | 'exists' | 'notExists';
+export type ViewPropertyFilterOperator =
+    | 'equals'
+    | 'notEquals'
+    | 'contains'
+    | 'notContains'
+    | 'before'
+    | 'after'
+    | 'exists'
+    | 'notExists';
 export type ViewSortBy = 'updatedAt' | 'createdAt' | 'title';
 export type ViewSortOrder = 'asc' | 'desc';
 

--- a/packages/client/src/modules/view-dashboard.spec.ts
+++ b/packages/client/src/modules/view-dashboard.spec.ts
@@ -6,6 +6,7 @@ import {
     getViewDisplayTypeLabel,
     getViewPropertyOperatorLabel,
     getViewTableColumnLabel,
+    getViewTagMatchLabel,
     getViewTagMatchToken,
     normalizeViewTableColumns,
     normalizeViewTagNames,
@@ -148,12 +149,17 @@ describe('view-dashboard helpers', () => {
         ).toEqual(['section-3', 'section-1', 'section-2']);
     });
 
-    it('returns a short conjunction token for tag matching', () => {
+    it('returns clear labels and short conjunction tokens for tag matching', () => {
+        expect(getViewTagMatchLabel('and')).toBe('AND — all selected tags');
+        expect(getViewTagMatchLabel('or')).toBe('OR — any selected tag');
         expect(getViewTagMatchToken('and')).toBe('AND');
         expect(getViewTagMatchToken('or')).toBe('OR');
     });
 
     it('formats property filter labels for display', () => {
+        expect(getViewPropertyOperatorLabel('notEquals')).toBe('is not');
+        expect(getViewPropertyOperatorLabel('contains')).toBe('contains');
+        expect(getViewPropertyOperatorLabel('notContains')).toBe('does not contain');
         expect(getViewPropertyOperatorLabel('exists')).toBe('is set');
         expect(getViewPropertyOperatorLabel('notExists')).toBe('is empty');
         expect(
@@ -174,6 +180,15 @@ describe('view-dashboard helpers', () => {
                 value: null,
             }),
         ).toBe('State is set');
+        expect(
+            formatViewPropertyFilter({
+                key: 'source',
+                name: 'Source',
+                valueType: 'url',
+                operator: 'contains',
+                value: 'github.com',
+            }),
+        ).toBe('Source contains github.com');
     });
 
     it('labels supported view display types', () => {

--- a/packages/client/src/modules/view-dashboard.ts
+++ b/packages/client/src/modules/view-dashboard.ts
@@ -118,7 +118,7 @@ export const reorderViewSectionsInWorkspace = (
 });
 
 export const getViewTagMatchLabel = (mode: ViewTagMatchMode) => {
-    return mode === 'or' ? 'Matches any selected tag' : 'Matches all selected tags';
+    return mode === 'or' ? 'OR — any selected tag' : 'AND — all selected tags';
 };
 
 export const getViewTagMatchToken = (mode: ViewTagMatchMode) => {
@@ -127,6 +127,12 @@ export const getViewTagMatchToken = (mode: ViewTagMatchMode) => {
 
 export const getViewPropertyOperatorLabel = (operator: ViewPropertyFilterOperator) => {
     switch (operator) {
+        case 'notEquals':
+            return 'is not';
+        case 'contains':
+            return 'contains';
+        case 'notContains':
+            return 'does not contain';
         case 'before':
             return 'before';
         case 'after':

--- a/packages/client/src/pages/ViewNotes.tsx
+++ b/packages/client/src/pages/ViewNotes.tsx
@@ -67,10 +67,11 @@ function ViewNotesContent() {
     const propertyFilters = sectionData.propertyFilters;
     const hasTagFilter = tagNames.length > 0;
     const hasPropertyFilter = propertyFilters.length > 0;
+    const tagModeSummary = tagNames.length > 1 ? ` · ${getViewTagMatchLabel(mode)}` : '';
     const filterSummary = hasTagFilter
         ? hasPropertyFilter
-            ? `Property and tag filters · ${getViewTagMatchLabel(mode)}`
-            : `Tag filters · ${getViewTagMatchLabel(mode)}`
+            ? `Property and tag filters${tagModeSummary}`
+            : `Tag filters${tagModeSummary}`
         : hasPropertyFilter
           ? 'Property filters'
           : 'All notes';

--- a/packages/client/src/pages/Views.tsx
+++ b/packages/client/src/pages/Views.tsx
@@ -72,7 +72,7 @@ const SortableViewTab = ({ tab, isActive, onSelect }: SortableViewTabProps) => {
         <div
             ref={setNodeRef}
             style={{
-                transform: CSS.Transform.toString(transform),
+                transform: CSS.Translate.toString(transform),
                 transition,
                 opacity: isDragging ? 0.6 : 1,
             }}
@@ -130,7 +130,7 @@ const SortableViewSection = ({ section, onEdit, onDelete }: SortableViewSectionP
         <div
             ref={setNodeRef}
             style={{
-                transform: CSS.Transform.toString(transform),
+                transform: CSS.Translate.toString(transform),
                 transition,
                 opacity: isDragging ? 0.6 : 1,
             }}

--- a/packages/server/src/features/view/graphql/view.type-defs.ts
+++ b/packages/server/src/features/view/graphql/view.type-defs.ts
@@ -56,6 +56,9 @@ export const viewType = gql`
 
     enum ViewPropertyFilterOperator {
         equals
+        notEquals
+        contains
+        notContains
         before
         after
         exists

--- a/packages/server/src/features/view/services/workspace.test.ts
+++ b/packages/server/src/features/view/services/workspace.test.ts
@@ -1,13 +1,11 @@
 import assert from 'node:assert/strict';
-import { randomUUID } from 'node:crypto';
 import test from 'node:test';
 
-import models from '~/models.js';
 import {
     buildPropertyFilterWhere,
     buildViewSectionWhere,
     clampViewSectionLimit,
-    getNotesByProperties,
+    getNotesByPropertiesWithDb,
     hydratePropertyFilters,
     normalizeViewDisplayOptions,
     normalizeViewNotesPagination,
@@ -399,139 +397,110 @@ test('buildPropertyFilterWhere maps negative and contains operators while requir
     );
 });
 
-test('getNotesByProperties excludes notes missing the property for negative filters', async () => {
-    const suffix = randomUUID().slice(0, 8);
-    const stateKey = `state-${suffix}`;
-    const summaryKey = `summary-${suffix}`;
-    const noteIds: number[] = [];
-    const propertyDefinitionIds: number[] = [];
+test('getNotesByProperties builds negative filters that require property existence', async () => {
+    let capturedWhere = {};
 
-    try {
-        const stateDefinition = await models.propertyDefinition.create({
-            data: {
-                key: stateKey,
-                name: `State ${suffix}`,
-                valueType: 'select',
-                options: {
-                    create: [
-                        { label: 'Done', value: 'done', order: 0 },
-                        { label: 'Doing', value: 'doing', order: 1 },
-                    ],
+    const db = {
+        propertyDefinition: {
+            findMany: async () => [
+                {
+                    key: 'state',
+                    name: 'State',
+                    valueType: 'select' as const,
+                    options: [{ value: 'done' }, { value: 'doing' }],
                 },
-            },
-            include: {
-                options: true,
-            },
-        });
-        const summaryDefinition = await models.propertyDefinition.create({
-            data: {
-                key: summaryKey,
-                name: `Summary ${suffix}`,
-                valueType: 'text',
-            },
-        });
-        propertyDefinitionIds.push(stateDefinition.id, summaryDefinition.id);
-
-        const doneOption = stateDefinition.options.find((option) => option.value === 'done');
-        const doingOption = stateDefinition.options.find((option) => option.value === 'doing');
-
-        assert.ok(doneOption);
-        assert.ok(doingOption);
-
-        const doneNote = await models.note.create({
-            data: {
-                title: `Done ${suffix}`,
-                content: '',
-                properties: {
-                    create: [
-                        {
-                            propertyDefinitionId: stateDefinition.id,
-                            optionId: doneOption.id,
-                        },
-                        {
-                            propertyDefinitionId: summaryDefinition.id,
-                            textValue: 'Brainstorm note',
-                            textValueNormalized: 'brainstorm note',
-                        },
-                    ],
+                {
+                    key: 'summary',
+                    name: 'Summary',
+                    valueType: 'text' as const,
+                    options: [],
                 },
+            ],
+        },
+        note: {
+            count: async ({ where }: { where: unknown }) => {
+                capturedWhere = where as object;
+                return 1;
             },
-        });
-        const doingNote = await models.note.create({
-            data: {
-                title: `Doing ${suffix}`,
-                content: '',
-                properties: {
-                    create: [
-                        {
-                            propertyDefinitionId: stateDefinition.id,
-                            optionId: doingOption.id,
-                        },
-                        {
-                            propertyDefinitionId: summaryDefinition.id,
-                            textValue: 'Plain note',
-                            textValueNormalized: 'plain note',
-                        },
-                    ],
+            findMany: async () => [
+                {
+                    id: 2,
+                    title: 'Doing',
+                    content: '',
+                    searchableText: '',
+                    searchableTextVersion: 0,
+                    createdAt: new Date('2026-06-03T00:00:00.000Z'),
+                    updatedAt: new Date('2026-06-03T00:00:00.000Z'),
+                    pinned: false,
+                    order: 0,
+                    layout: 'wide' as const,
                 },
-            },
-        });
-        const missingPropertiesNote = await models.note.create({
-            data: {
-                title: `Missing properties ${suffix}`,
-                content: '',
-            },
-        });
-        noteIds.push(doneNote.id, doingNote.id, missingPropertiesNote.id);
+            ],
+        },
+    } as never;
 
-        const notDoneResult = await getNotesByProperties(
+    const result = await getNotesByPropertiesWithDb(
+        db,
+        {
+            propertyFilters: [
+                {
+                    key: 'state',
+                    valueType: 'select',
+                    operator: 'notEquals',
+                    value: 'done',
+                },
+                {
+                    key: 'summary',
+                    valueType: 'text',
+                    operator: 'notContains',
+                    value: 'brain',
+                },
+            ],
+            sortBy: 'title',
+            sortOrder: 'asc',
+        },
+        { limit: 20, offset: 0 },
+    );
+
+    assert.equal(result.totalCount, 1);
+    assert.deepEqual(capturedWhere, {
+        AND: [
             {
-                propertyFilters: [
-                    {
-                        key: stateKey,
-                        valueType: 'select',
-                        operator: 'notEquals',
-                        value: 'done',
+                properties: {
+                    some: {
+                        definition: {
+                            is: {
+                                key: 'state',
+                            },
+                        },
+                        option: {
+                            is: {
+                                value: {
+                                    not: 'done',
+                                },
+                            },
+                        },
                     },
-                ],
-                sortBy: 'title',
-                sortOrder: 'asc',
+                },
             },
-            { limit: 20, offset: 0 },
-        );
-        const notBrainResult = await getNotesByProperties(
             {
-                propertyFilters: [
-                    {
-                        key: summaryKey,
-                        valueType: 'text',
-                        operator: 'notContains',
-                        value: 'brain',
+                properties: {
+                    some: {
+                        definition: {
+                            is: {
+                                key: 'summary',
+                            },
+                        },
+                        textValueNormalized: {
+                            not: {
+                                contains: 'brain',
+                            },
+                        },
                     },
-                ],
-                sortBy: 'title',
-                sortOrder: 'asc',
+                },
             },
-            { limit: 20, offset: 0 },
-        );
-
-        assert.deepEqual(
-            notDoneResult.notes.map((note) => note.id),
-            [doingNote.id],
-        );
-        assert.deepEqual(
-            notBrainResult.notes.map((note) => note.id),
-            [doingNote.id],
-        );
-    } finally {
-        if (noteIds.length > 0) {
-            await models.note.deleteMany({ where: { id: { in: noteIds } } });
-        }
-
-        if (propertyDefinitionIds.length > 0) {
-            await models.propertyDefinition.deleteMany({ where: { id: { in: propertyDefinitionIds } } });
-        }
-    }
+        ],
+    });
 });
 
 test('hydratePropertyFilters validates property definitions and select options', async () => {

--- a/packages/server/src/features/view/services/workspace.test.ts
+++ b/packages/server/src/features/view/services/workspace.test.ts
@@ -1,10 +1,13 @@
 import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
 import test from 'node:test';
 
+import models from '~/models.js';
 import {
     buildPropertyFilterWhere,
     buildViewSectionWhere,
     clampViewSectionLimit,
+    getNotesByProperties,
     hydratePropertyFilters,
     normalizeViewDisplayOptions,
     normalizeViewNotesPagination,
@@ -127,6 +130,23 @@ test('normalizeViewPropertyFilters validates typed filter values', () => {
 
     assert.throws(() =>
         normalizeViewPropertyFilters([{ key: 'source', valueType: 'url', operator: 'equals', value: 'not-a-url' }]),
+    );
+
+    assert.deepEqual(
+        normalizeViewPropertyFilters([{ key: 'source', valueType: 'url', operator: 'contains', value: 'example.com' }]),
+        [
+            {
+                key: 'source',
+                name: 'source',
+                valueType: 'url',
+                operator: 'contains',
+                value: 'example.com',
+            },
+        ],
+    );
+
+    assert.throws(() =>
+        normalizeViewPropertyFilters([{ key: 'priority', valueType: 'number', operator: 'contains', value: '1' }]),
     );
 });
 
@@ -297,6 +317,221 @@ test('buildPropertyFilterWhere maps URL filters through normalized text storage'
             },
         },
     );
+});
+
+test('buildPropertyFilterWhere maps negative and contains operators while requiring the property to exist', () => {
+    assert.deepEqual(
+        buildPropertyFilterWhere({
+            key: 'state',
+            name: 'State',
+            valueType: 'select',
+            operator: 'notEquals',
+            value: 'Done',
+        }),
+        {
+            properties: {
+                some: {
+                    definition: {
+                        is: {
+                            key: 'state',
+                        },
+                    },
+                    option: {
+                        is: {
+                            value: {
+                                not: 'done',
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    );
+
+    assert.deepEqual(
+        buildPropertyFilterWhere({
+            key: 'summary',
+            name: 'Summary',
+            valueType: 'text',
+            operator: 'contains',
+            value: 'Brain',
+        }),
+        {
+            properties: {
+                some: {
+                    definition: {
+                        is: {
+                            key: 'summary',
+                        },
+                    },
+                    textValueNormalized: {
+                        contains: 'brain',
+                    },
+                },
+            },
+        },
+    );
+
+    assert.deepEqual(
+        buildPropertyFilterWhere({
+            key: 'summary',
+            name: 'Summary',
+            valueType: 'text',
+            operator: 'notContains',
+            value: 'Brain',
+        }),
+        {
+            properties: {
+                some: {
+                    definition: {
+                        is: {
+                            key: 'summary',
+                        },
+                    },
+                    textValueNormalized: {
+                        not: {
+                            contains: 'brain',
+                        },
+                    },
+                },
+            },
+        },
+    );
+});
+
+test('getNotesByProperties excludes notes missing the property for negative filters', async () => {
+    const suffix = randomUUID().slice(0, 8);
+    const stateKey = `state-${suffix}`;
+    const summaryKey = `summary-${suffix}`;
+    const noteIds: number[] = [];
+    const propertyDefinitionIds: number[] = [];
+
+    try {
+        const stateDefinition = await models.propertyDefinition.create({
+            data: {
+                key: stateKey,
+                name: `State ${suffix}`,
+                valueType: 'select',
+                options: {
+                    create: [
+                        { label: 'Done', value: 'done', order: 0 },
+                        { label: 'Doing', value: 'doing', order: 1 },
+                    ],
+                },
+            },
+            include: {
+                options: true,
+            },
+        });
+        const summaryDefinition = await models.propertyDefinition.create({
+            data: {
+                key: summaryKey,
+                name: `Summary ${suffix}`,
+                valueType: 'text',
+            },
+        });
+        propertyDefinitionIds.push(stateDefinition.id, summaryDefinition.id);
+
+        const doneOption = stateDefinition.options.find((option) => option.value === 'done');
+        const doingOption = stateDefinition.options.find((option) => option.value === 'doing');
+
+        assert.ok(doneOption);
+        assert.ok(doingOption);
+
+        const doneNote = await models.note.create({
+            data: {
+                title: `Done ${suffix}`,
+                content: '',
+                properties: {
+                    create: [
+                        {
+                            propertyDefinitionId: stateDefinition.id,
+                            optionId: doneOption.id,
+                        },
+                        {
+                            propertyDefinitionId: summaryDefinition.id,
+                            textValue: 'Brainstorm note',
+                            textValueNormalized: 'brainstorm note',
+                        },
+                    ],
+                },
+            },
+        });
+        const doingNote = await models.note.create({
+            data: {
+                title: `Doing ${suffix}`,
+                content: '',
+                properties: {
+                    create: [
+                        {
+                            propertyDefinitionId: stateDefinition.id,
+                            optionId: doingOption.id,
+                        },
+                        {
+                            propertyDefinitionId: summaryDefinition.id,
+                            textValue: 'Plain note',
+                            textValueNormalized: 'plain note',
+                        },
+                    ],
+                },
+            },
+        });
+        const missingPropertiesNote = await models.note.create({
+            data: {
+                title: `Missing properties ${suffix}`,
+                content: '',
+            },
+        });
+        noteIds.push(doneNote.id, doingNote.id, missingPropertiesNote.id);
+
+        const notDoneResult = await getNotesByProperties(
+            {
+                propertyFilters: [
+                    {
+                        key: stateKey,
+                        valueType: 'select',
+                        operator: 'notEquals',
+                        value: 'done',
+                    },
+                ],
+                sortBy: 'title',
+                sortOrder: 'asc',
+            },
+            { limit: 20, offset: 0 },
+        );
+        const notBrainResult = await getNotesByProperties(
+            {
+                propertyFilters: [
+                    {
+                        key: summaryKey,
+                        valueType: 'text',
+                        operator: 'notContains',
+                        value: 'brain',
+                    },
+                ],
+                sortBy: 'title',
+                sortOrder: 'asc',
+            },
+            { limit: 20, offset: 0 },
+        );
+
+        assert.deepEqual(
+            notDoneResult.notes.map((note) => note.id),
+            [doingNote.id],
+        );
+        assert.deepEqual(
+            notBrainResult.notes.map((note) => note.id),
+            [doingNote.id],
+        );
+    } finally {
+        if (noteIds.length > 0) {
+            await models.note.deleteMany({ where: { id: { in: noteIds } } });
+        }
+
+        if (propertyDefinitionIds.length > 0) {
+            await models.propertyDefinition.deleteMany({ where: { id: { in: propertyDefinitionIds } } });
+        }
+    }
 });
 
 test('hydratePropertyFilters validates property definitions and select options', async () => {

--- a/packages/server/src/features/view/services/workspace.ts
+++ b/packages/server/src/features/view/services/workspace.ts
@@ -10,7 +10,15 @@ import models from '~/models.js';
 export type ViewTagMatchMode = NoteTagMatchMode;
 export type ViewDisplayType = 'list' | 'table' | 'calendar';
 export type ViewTableColumn = 'title' | 'tags' | 'properties' | 'createdAt' | 'updatedAt';
-export type ViewPropertyFilterOperator = 'equals' | 'before' | 'after' | 'exists' | 'notExists';
+export type ViewPropertyFilterOperator =
+    | 'equals'
+    | 'notEquals'
+    | 'contains'
+    | 'notContains'
+    | 'before'
+    | 'after'
+    | 'exists'
+    | 'notExists';
 export type ViewSortBy = 'updatedAt' | 'createdAt' | 'title';
 export type ViewSortOrder = 'asc' | 'desc';
 
@@ -172,7 +180,16 @@ interface ParsedStoredViewQuery {
 }
 
 const isViewPropertyFilterOperator = (value: unknown): value is ViewPropertyFilterOperator => {
-    return value === 'equals' || value === 'before' || value === 'after' || value === 'exists' || value === 'notExists';
+    return (
+        value === 'equals' ||
+        value === 'notEquals' ||
+        value === 'contains' ||
+        value === 'notContains' ||
+        value === 'before' ||
+        value === 'after' ||
+        value === 'exists' ||
+        value === 'notExists'
+    );
 };
 
 const isPropertyValueType = (value: unknown): value is PropertyValueType => {
@@ -274,7 +291,11 @@ const normalizeFilterValue = ({
         throw new InvalidNotePropertyInputError('Before and after filters require date or number properties.');
     }
 
-    if (valueType === 'url') {
+    if ((operator === 'contains' || operator === 'notContains') && valueType !== 'text' && valueType !== 'url') {
+        throw new InvalidNotePropertyInputError('Contains filters require text or url properties.');
+    }
+
+    if (valueType === 'url' && operator !== 'contains' && operator !== 'notContains') {
         return normalizeUrlValue(normalizedValue);
     }
 
@@ -693,6 +714,10 @@ const buildPropertyFilterValueWhere = (filter: ViewPropertyFilterRecord): Prisma
                 return { numberValue: { gt: numberValue } };
             }
 
+            if (filter.operator === 'notEquals') {
+                return { numberValue: { not: numberValue } };
+            }
+
             return { numberValue };
         }
         case 'date': {
@@ -706,16 +731,44 @@ const buildPropertyFilterValueWhere = (filter: ViewPropertyFilterRecord): Prisma
                 return { dateValue: { gt: dateValue } };
             }
 
+            if (filter.operator === 'notEquals') {
+                return { dateValue: { not: dateValue } };
+            }
+
             return { dateValue };
         }
-        case 'boolean':
+        case 'boolean': {
+            if (filter.operator === 'notEquals') {
+                return { boolValue: { not: filter.value === 'true' } };
+            }
+
             return { boolValue: filter.value === 'true' };
+        }
         case 'select':
+            if (filter.operator === 'notEquals') {
+                return { option: { is: { value: { not: normalizeSelectFilterValue(filter.value ?? '') } } } };
+            }
+
             return { option: { is: { value: normalizeSelectFilterValue(filter.value ?? '') } } };
         case 'url':
         case 'text':
-        default:
-            return { textValueNormalized: filter.value?.toLowerCase() ?? '' };
+        default: {
+            const textValue = filter.value?.toLowerCase() ?? '';
+
+            if (filter.operator === 'notEquals') {
+                return { textValueNormalized: { not: textValue } };
+            }
+
+            if (filter.operator === 'contains') {
+                return { textValueNormalized: { contains: textValue } };
+            }
+
+            if (filter.operator === 'notContains') {
+                return { textValueNormalized: { not: { contains: textValue } } };
+            }
+
+            return { textValueNormalized: textValue };
+        }
     }
 };
 

--- a/packages/server/src/features/view/services/workspace.ts
+++ b/packages/server/src/features/view/services/workspace.ts
@@ -876,7 +876,8 @@ export const getViewSectionNotes = async (
     };
 };
 
-export const getNotesByProperties = async (
+export const getNotesByPropertiesWithDb = async (
+    db: ViewDbClient,
     input: ViewNotesQueryInput,
     pagination?: {
         limit?: number;
@@ -891,7 +892,7 @@ export const getNotesByProperties = async (
 
     const query = {
         ...normalizedQuery,
-        propertyFilters: await hydratePropertyFilters(models, normalizedQuery.propertyFilters, {
+        propertyFilters: await hydratePropertyFilters(db, normalizedQuery.propertyFilters, {
             validateSelectOptions: true,
         }),
     };
@@ -899,8 +900,8 @@ export const getNotesByProperties = async (
     const where = buildViewNotesWhere(query);
 
     const [totalCount, notes] = await Promise.all([
-        models.note.count({ where }),
-        models.note.findMany({
+        db.note.count({ where }),
+        db.note.findMany({
             orderBy: buildViewNotesOrderBy(query),
             where,
             take: normalizedPagination.limit,
@@ -912,6 +913,16 @@ export const getNotesByProperties = async (
         totalCount,
         notes,
     };
+};
+
+export const getNotesByProperties = async (
+    input: ViewNotesQueryInput,
+    pagination?: {
+        limit?: number;
+        offset?: number;
+    },
+): Promise<ViewSectionNotesResult> => {
+    return getNotesByPropertiesWithDb(models, input, pagination);
 };
 
 export const createViewTab = async (title: string) => {


### PR DESCRIPTION
## :dart: Goal
- Let saved views express more useful property queries with negative and text-search operators.
- Keep view editing usable after review feedback, especially URL partial matching and long operator labels.
- Fix sortable view tabs/sections so drag previews do not stretch when dragged across differently sized items.

## :hammer_and_wrench: Core Changes
- Added `is not`, `contains`, and `does not contain` support for view property filters across client models, GraphQL, and server query handling.
- Updated the view section dialog so URL `contains` filters accept partial text like `example.com`, filter controls have accessible labels, and long operator labels fit more safely.
- Kept negative filters scoped to notes that actually have the property, with service-level coverage for missing-property query shape.
- Switched view sortable transforms to translate-only transforms to avoid drag preview size distortion.

## :brain: Key Decisions
- Property filters remain combined with AND; tag AND/OR still applies only inside the tag filter group.
- URL equality still requires a full valid URL, while URL `contains`/`does not contain` accepts partial text for practical search.
- `is not` and `does not contain` do not match notes missing that property; `is empty` remains the explicit missing-property query.

## :test_tube: Verification Guide
### How to verify
1. Run `pnpm --filter ./packages/client exec vitest run src/components/view/ViewSectionDialog.spec.tsx --maxWorkers 1`.
2. Run `pnpm --filter ./packages/server test:ci -- src/features/view/services/workspace.test.ts`.
3. Run `pnpm --filter ./packages/client lint` and `pnpm --filter ./packages/server lint`.
4. Run `pnpm --filter ./packages/client type-check` and `pnpm --filter ./packages/server type-check`.

### Expected result
- Client dialog tests pass.
- Server test suite passes, including the view property filter missing-property coverage.
- Client/server lint and type-check pass.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (not needed; no docs changes)