### PR TITLE
🔖 Bump version to 0.6.2

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ocean-brain",
-    "version": "0.6.1",
+    "version": "0.6.2",
     "license": "MIT",
     "type": "module",
     "repository": {


### PR DESCRIPTION
## :dart: Goal
- Prepare the Ocean Brain `0.6.2` patch release.
- Publish the Views improvement work that landed after `v0.6.1`.

## :hammer_and_wrench: Core Changes
- Bumped the CLI package version from `0.6.1` to `0.6.2`.
- Planned release tag: `v0.6.2`.

## :brain: Key Decisions
- This is a patch release because the included work improves existing Views behavior without a migration or new setup requirement.
- Release will be triggered explicitly by pushing the `v0.6.2` tag after this PR is merged into `main`.

## :test_tube: Verification Guide
### How to verify
1. Confirm `packages/cli/package.json` reports `0.6.2`.
2. Confirm this PR CI passes.
3. Confirm CLI_SMOKE is green before tagging `v0.6.2`.

### Expected result
- CLI package version is `0.6.2`.
- PR CI passes.
- The release target is ready for the explicit `v0.6.2` tag.

## :white_check_mark: Checklist
- [x] Lint completed (not needed; version-only change)
- [x] Type-check completed (not needed; version-only change)
- [x] Tests completed (not needed; version-only change)
- [x] Documentation updated (not needed; release PR only)
