### PR TITLE
⚡ Reduce MCP write token waste

### DIFF
--- a/packages/cli/src/mcp-intent-write-tools.ts
+++ b/packages/cli/src/mcp-intent-write-tools.ts
@@ -104,6 +104,7 @@ const markdownWritePolicySchema = z.object({
     allowNoop: z.boolean().optional(),
     maxChangedChars: z.number().int().nonnegative().optional(),
     maxChangedLines: z.number().int().nonnegative().optional(),
+    diffPreviewMaxChars: z.number().int().nonnegative().optional(),
     preserveTags: z.union([z.boolean(), z.literal('warn')]).optional(),
     preserveReferences: z.union([z.boolean(), z.literal('warn')]).optional()
 }).optional();

--- a/packages/cli/src/mcp-intent-write-tools.ts
+++ b/packages/cli/src/mcp-intent-write-tools.ts
@@ -22,9 +22,18 @@ type JsonRequest = <TResponse extends Record<string, unknown>>(
     body: Record<string, unknown>
 ) => Promise<TResponse>;
 
+type FetchNoteWriteBaseline = (
+    id: string,
+    token: string
+) => Promise<{
+    id: string;
+    updatedAt: string;
+}>;
+
 type McpWriteSafetyCoordinator = ReturnType<typeof createMcpWriteSafetyCoordinator>;
 
 interface RegisterIntentWriteToolsInput {
+    fetchNoteWriteBaseline: FetchNoteWriteBaseline;
     jsonRequest: JsonRequest;
     requireWriteToken: (token: string | undefined, toolName: string) => string;
     serverUrl: string;
@@ -159,6 +168,27 @@ export const metadataPropertyPatchSchema = z.object({
 
 const sha256 = (value: string) => crypto.createHash('sha256').update(value).digest('hex');
 
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+};
+
+const stableJsonStringify = (value: unknown): string => {
+    if (Array.isArray(value)) {
+        return `[${value.map(stableJsonStringify).join(',')}]`;
+    }
+
+    if (isRecord(value)) {
+        const properties = Object.keys(value)
+            .filter((key) => value[key] !== undefined)
+            .sort()
+            .map((key) => `${JSON.stringify(key)}:${stableJsonStringify(value[key])}`);
+
+        return `{${properties.join(',')}}`;
+    }
+
+    return JSON.stringify(value) ?? 'null';
+};
+
 const normalizeServerUrl = (serverUrl: string) => {
     try {
         const url = new URL(serverUrl);
@@ -169,14 +199,25 @@ const normalizeServerUrl = (serverUrl: string) => {
     }
 };
 
+const normalizeIntentWritePayloadForFingerprint = (toolName: string, payload: Record<string, unknown>) => {
+    const normalizedPayload = { ...payload };
+
+    if (toolName === 'ocean_brain_append_note_markdown') {
+        normalizedPayload.placement ??= { type: 'end' };
+        normalizedPayload.separator ??= '\n\n';
+    }
+
+    return normalizedPayload;
+};
+
 export const createIntentWriteOperationFingerprint = (
     serverUrl: string,
     token: string | undefined,
     toolName: string,
     payload: Record<string, unknown>
 ) => {
-    return sha256(JSON.stringify({
-        payload,
+    return sha256(stableJsonStringify({
+        payload: normalizeIntentWritePayloadForFingerprint(toolName, payload),
         serverUrl: normalizeServerUrl(serverUrl),
         tokenDigest: token ? sha256(token) : null,
         toolName
@@ -185,6 +226,34 @@ export const createIntentWriteOperationFingerprint = (
 
 const getErrorDetail = (error: unknown) => {
     return error instanceof Error ? error.message : 'Unknown MCP write error';
+};
+
+const requireCommitConfirmationFields = (request: ConfirmedWriteRequest) => {
+    if (request.dryRun !== false) {
+        return;
+    }
+
+    if (!request.operationId || !request.confirmToken) {
+        throw new Error('Commit mode requires both operationId and confirmToken from the dry-run response.');
+    }
+};
+
+const resolvePayloadWithBaseline = async (
+    fetchNoteWriteBaseline: FetchNoteWriteBaseline,
+    writeToken: string,
+    id: string,
+    payload: Record<string, unknown>
+) => {
+    if (typeof payload.expectedUpdatedAt === 'string' || typeof payload.baseMarkdownSha256 === 'string') {
+        return payload;
+    }
+
+    const baseline = await fetchNoteWriteBaseline(id, writeToken);
+
+    return {
+        ...payload,
+        expectedUpdatedAt: baseline.updatedAt
+    };
 };
 
 const prepareConfirmedWriteOperation = (
@@ -269,6 +338,7 @@ const executeConfirmedWrite = async (
 export const registerIntentWriteTools = (
     server: McpServer,
     {
+        fetchNoteWriteBaseline,
         jsonRequest,
         requireWriteToken,
         serverUrl,
@@ -282,8 +352,8 @@ export const registerIntentWriteTools = (
         'Patch a small part of an Ocean Brain note. Dry-run is the default; commit requires operationId and confirmToken from the dry-run result.',
         {
             id: z.string().describe('Note ID to patch'),
-            expectedUpdatedAt: z.string().optional().describe('Expected note updatedAt from a prior read. Required unless baseMarkdownSha256 is provided.'),
-            baseMarkdownSha256: z.string().optional().describe('SHA-256 of the current markdown. Required unless expectedUpdatedAt is provided.'),
+            expectedUpdatedAt: z.string().optional().describe('Expected note updatedAt from a prior read. Auto-fetched when omitted unless baseMarkdownSha256 is provided.'),
+            baseMarkdownSha256: z.string().optional().describe('SHA-256 of the current markdown. Optional alternative to expectedUpdatedAt.'),
             intent: z.string().describe('Human-readable reason for the patch.'),
             selector: markdownPatchSelectorSchema.describe('Exact text or previously returned match candidate.'),
             operation: markdownPatchOperationSchema.describe('replace, insert_before, or insert_after.'),
@@ -292,7 +362,8 @@ export const registerIntentWriteTools = (
         },
         async ({ id, expectedUpdatedAt, baseMarkdownSha256, intent, selector, operation, policy, dryRun, operationId, confirmToken }) => {
             const writeToken = requireWriteToken(token, tools.patchNoteMarkdown);
-            const payload = {
+            requireCommitConfirmationFields({ dryRun, operationId, confirmToken });
+            const payload = await resolvePayloadWithBaseline(fetchNoteWriteBaseline, writeToken, id, {
                 id,
                 ...(expectedUpdatedAt ? { expectedUpdatedAt } : {}),
                 ...(baseMarkdownSha256 ? { baseMarkdownSha256 } : {}),
@@ -300,10 +371,10 @@ export const registerIntentWriteTools = (
                 selector,
                 operation,
                 ...(policy ? { policy } : {})
-            };
+            });
             const operationFingerprint = createIntentWriteOperationFingerprint(serverUrl, writeToken, tools.patchNoteMarkdown, payload);
 
-            if (dryRun) {
+            if (dryRun ?? true) {
                 const result = await jsonRequest<DryRunWriteResult>(serverUrl, writeToken, '/api/mcp/notes/patch-markdown', {
                     ...payload,
                     dryRun: true
@@ -355,8 +426,8 @@ export const registerIntentWriteTools = (
         'Append markdown to a note without replacing existing body content. Dry-run is the default; commit requires operationId and confirmToken.',
         {
             id: z.string().describe('Note ID to append to'),
-            expectedUpdatedAt: z.string().optional().describe('Expected note updatedAt from a prior read. Required unless baseMarkdownSha256 is provided.'),
-            baseMarkdownSha256: z.string().optional().describe('SHA-256 of the current markdown. Required unless expectedUpdatedAt is provided.'),
+            expectedUpdatedAt: z.string().optional().describe('Expected note updatedAt from a prior read. Auto-fetched when omitted unless baseMarkdownSha256 is provided.'),
+            baseMarkdownSha256: z.string().optional().describe('SHA-256 of the current markdown. Optional alternative to expectedUpdatedAt.'),
             intent: z.string().describe('Human-readable reason for the append.'),
             insertion: z.string().describe('Markdown to append. Tags are body tokens such as [@tag] or [#tag].'),
             placement: markdownAppendPlacementSchema.optional().describe('Default is end. after_heading requires one unique matching heading.'),
@@ -366,7 +437,8 @@ export const registerIntentWriteTools = (
         },
         async ({ id, expectedUpdatedAt, baseMarkdownSha256, intent, insertion, placement, separator, policy, dryRun, operationId, confirmToken }) => {
             const writeToken = requireWriteToken(token, tools.appendNoteMarkdown);
-            const payload = {
+            requireCommitConfirmationFields({ dryRun, operationId, confirmToken });
+            const payload = await resolvePayloadWithBaseline(fetchNoteWriteBaseline, writeToken, id, {
                 id,
                 ...(expectedUpdatedAt ? { expectedUpdatedAt } : {}),
                 ...(baseMarkdownSha256 ? { baseMarkdownSha256 } : {}),
@@ -375,10 +447,10 @@ export const registerIntentWriteTools = (
                 ...(placement ? { placement } : {}),
                 ...(separator ? { separator } : {}),
                 ...(policy ? { policy } : {})
-            };
+            });
             const operationFingerprint = createIntentWriteOperationFingerprint(serverUrl, writeToken, tools.appendNoteMarkdown, payload);
 
-            if (dryRun) {
+            if (dryRun ?? true) {
                 const result = await jsonRequest<DryRunWriteResult>(serverUrl, writeToken, '/api/mcp/notes/append-markdown', {
                     ...payload,
                     dryRun: true
@@ -430,7 +502,7 @@ export const registerIntentWriteTools = (
         'Update note title/layout/properties. For properties, call ocean_brain_list_properties first. Use existing property key and string value only; do not send valueType. select=option.value, date=YYYY-MM-DD, boolean=true/false, number=finite string, url=http(s). Use deleteKeys to remove values. Definitions are not created.',
         {
             id: z.string().describe('Note ID to update'),
-            expectedUpdatedAt: z.string().describe('Expected note updatedAt from a prior read.'),
+            expectedUpdatedAt: z.string().optional().describe('Expected note updatedAt from a prior read. Auto-fetched when omitted.'),
             title: z.string().optional().describe('New note title'),
             layout: z.enum(['narrow', 'wide', 'full']).optional().describe('New note layout'),
             properties: metadataPropertyPatchSchema.describe('Patch existing shared property values. Include set and/or deleteKeys; empty patches are rejected.'),
@@ -438,17 +510,18 @@ export const registerIntentWriteTools = (
         },
         async ({ id, expectedUpdatedAt, title, layout, properties, dryRun, operationId, confirmToken }) => {
             const writeToken = requireWriteToken(token, tools.updateNoteMetadata);
-            const payload = {
+            requireCommitConfirmationFields({ dryRun, operationId, confirmToken });
+            const payload = await resolvePayloadWithBaseline(fetchNoteWriteBaseline, writeToken, id, {
                 id,
-                expectedUpdatedAt,
+                ...(expectedUpdatedAt ? { expectedUpdatedAt } : {}),
                 ...(title !== undefined ? { title } : {}),
                 ...(layout ? { layout } : {}),
                 ...(properties ? { properties } : {})
-            };
+            });
             const summary = properties ? `Update note ${id} metadata and properties` : `Update note ${id} metadata`;
             const operationFingerprint = createIntentWriteOperationFingerprint(serverUrl, writeToken, tools.updateNoteMetadata, payload);
 
-            if (dryRun) {
+            if (dryRun ?? true) {
                 const result = await jsonRequest<DryRunWriteResult>(serverUrl, writeToken, '/api/mcp/notes/metadata', {
                     ...payload,
                     dryRun: true
@@ -500,8 +573,8 @@ export const registerIntentWriteTools = (
         'Replace a note body as a high-impact full overwrite. Dry-run returns a full diff; commit requires operationId and confirmToken.',
         {
             id: z.string().describe('Note ID to replace'),
-            expectedUpdatedAt: z.string().optional().describe('Expected note updatedAt from a prior read. Required unless baseMarkdownSha256 is provided.'),
-            baseMarkdownSha256: z.string().optional().describe('SHA-256 of the current markdown. Required unless expectedUpdatedAt is provided.'),
+            expectedUpdatedAt: z.string().optional().describe('Expected note updatedAt from a prior read. Auto-fetched when omitted unless baseMarkdownSha256 is provided.'),
+            baseMarkdownSha256: z.string().optional().describe('SHA-256 of the current markdown. Optional alternative to expectedUpdatedAt.'),
             intent: z.string().describe('Human-readable reason for the full replace.'),
             replacement: z.string().describe('Complete replacement markdown body. Tags are body tokens such as [@tag] or [#tag].'),
             policy: markdownWritePolicySchema,
@@ -509,17 +582,18 @@ export const registerIntentWriteTools = (
         },
         async ({ id, expectedUpdatedAt, baseMarkdownSha256, intent, replacement, policy, dryRun, operationId, confirmToken }) => {
             const writeToken = requireWriteToken(token, tools.replaceNoteMarkdown);
-            const payload = {
+            requireCommitConfirmationFields({ dryRun, operationId, confirmToken });
+            const payload = await resolvePayloadWithBaseline(fetchNoteWriteBaseline, writeToken, id, {
                 id,
                 ...(expectedUpdatedAt ? { expectedUpdatedAt } : {}),
                 ...(baseMarkdownSha256 ? { baseMarkdownSha256 } : {}),
                 intent,
                 replacement,
                 ...(policy ? { policy } : {})
-            };
+            });
             const operationFingerprint = createIntentWriteOperationFingerprint(serverUrl, writeToken, tools.replaceNoteMarkdown, payload);
 
-            if (dryRun) {
+            if (dryRun ?? true) {
                 const result = await jsonRequest<DryRunWriteResult>(serverUrl, writeToken, '/api/mcp/notes/replace-markdown', {
                     ...payload,
                     dryRun: true

--- a/packages/cli/src/mcp.ts
+++ b/packages/cli/src/mcp.ts
@@ -169,6 +169,22 @@ async function jsonRequest<TResponse extends Record<string, unknown>>(
     return result;
 }
 
+export const fetchMcpNoteWriteBaseline = async (
+    serverUrl: string,
+    token: string | undefined,
+    id: string,
+    request: typeof jsonRequest = jsonRequest
+) => {
+    const result = await request<{
+        note: {
+            id: string;
+            updatedAt: string;
+        };
+    }>(serverUrl, token, '/api/mcp/notes/baseline', { id });
+
+    return result.note;
+};
+
 const requireWriteToken = (token: string | undefined, toolName: string) => {
     if (token) {
         return token;
@@ -376,6 +392,7 @@ export async function startMcpServer(
     );
 
     registerIntentWriteTools(server, {
+        fetchNoteWriteBaseline: (id, writeToken) => fetchMcpNoteWriteBaseline(serverUrl, writeToken, id),
         jsonRequest,
         requireWriteToken,
         serverUrl,

--- a/packages/cli/test/mcp-intent-write-tools.test.ts
+++ b/packages/cli/test/mcp-intent-write-tools.test.ts
@@ -1,11 +1,17 @@
 import assert from 'node:assert/strict';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 import { describe, test } from 'node:test';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import {
     MCP_METADATA_PROPERTY_PATCH_LIMIT,
     createIntentWriteOperationFingerprint,
-    metadataPropertyPatchSchema
+    metadataPropertyPatchSchema,
+    registerIntentWriteTools
 } from '../src/mcp-intent-write-tools.js';
+import { createMcpWriteSafetyCoordinator } from '../src/mcp-write-safety.js';
 
 const payload = {
     id: '7',
@@ -18,6 +24,47 @@ const payload = {
         type: 'replace',
         replacement: 'Updated sentence.'
     }
+};
+
+interface RegisteredTool {
+    handler: (input: Record<string, unknown>) => Promise<{
+        content: Array<{
+            text: string;
+            type: string;
+        }>;
+    }>;
+}
+
+const TOOL_NAMES = {
+    appendNoteMarkdown: 'ocean_brain_append_note_markdown',
+    patchNoteMarkdown: 'ocean_brain_patch_note_markdown',
+    replaceNoteMarkdown: 'ocean_brain_replace_note_markdown',
+    updateNoteMetadata: 'ocean_brain_update_note_metadata'
+};
+
+const createTempRootDir = () => fs.mkdtempSync(path.join(os.tmpdir(), 'ocean-brain-mcp-intent-write-tools-'));
+
+const createFakeMcpServer = () => {
+    const registeredTools = new Map<string, RegisteredTool>();
+    const server = {
+        tool(
+            name: string,
+            _description: string,
+            _schema: unknown,
+            handler: RegisteredTool['handler']
+        ) {
+            registeredTools.set(name, { handler });
+        }
+    };
+
+    return {
+        registeredTools,
+        server: server as unknown as McpServer
+    };
+};
+
+const parseToolText = (result: Awaited<ReturnType<RegisteredTool['handler']>>) => {
+    return JSON.parse(result.content[0].text) as Record<string, unknown>;
 };
 
 describe('createIntentWriteOperationFingerprint', () => {
@@ -47,6 +94,339 @@ describe('createIntentWriteOperationFingerprint', () => {
         // Assert
         assert.notEqual(differentServerUrl, base);
         assert.notEqual(differentToken, base);
+    });
+
+    test('normalizes object key order before fingerprinting', () => {
+        // Arrange
+        const base = createIntentWriteOperationFingerprint(
+            'http://localhost:6683',
+            'token-a',
+            'ocean_brain_patch_note_markdown',
+            payload
+        );
+
+        // Act
+        const reordered = createIntentWriteOperationFingerprint(
+            'http://localhost:6683',
+            'token-a',
+            'ocean_brain_patch_note_markdown',
+            {
+                operation: {
+                    replacement: 'Updated sentence.',
+                    type: 'replace'
+                },
+                selector: {
+                    text: 'Original sentence.',
+                    type: 'exact_text'
+                },
+                intent: 'Replace one sentence',
+                id: '7'
+            }
+        );
+
+        // Assert
+        assert.equal(reordered, base);
+    });
+
+    test('treats omitted append defaults and explicit append defaults as the same operation', () => {
+        // Arrange
+        const dryRunPayload = {
+            id: '7',
+            expectedUpdatedAt: '2026-06-04T10:00:00.000Z',
+            intent: 'Append a backlink',
+            insertion: 'Related: [[Design Editor]]'
+        };
+
+        // Act
+        const dryRunFingerprint = createIntentWriteOperationFingerprint(
+            'http://localhost:6683',
+            'token-a',
+            'ocean_brain_append_note_markdown',
+            dryRunPayload
+        );
+        const commitFingerprint = createIntentWriteOperationFingerprint(
+            'http://localhost:6683',
+            'token-a',
+            'ocean_brain_append_note_markdown',
+            {
+                ...dryRunPayload,
+                placement: { type: 'end' },
+                separator: '\n\n'
+            }
+        );
+
+        // Assert
+        assert.equal(commitFingerprint, dryRunFingerprint);
+    });
+});
+
+describe('registerIntentWriteTools', () => {
+    test('auto-fetches expectedUpdatedAt and defaults to dry-run when omitted', async () => {
+        // Arrange
+        const { registeredTools, server } = createFakeMcpServer();
+        const requests: Array<{ pathName: string; body: Record<string, unknown> }> = [];
+        let baselineFetchCount = 0;
+
+        registerIntentWriteTools(server, {
+            fetchNoteWriteBaseline: async (id, token) => {
+                baselineFetchCount += 1;
+                assert.equal(id, '7');
+                assert.equal(token, 'token-a');
+                return {
+                    id,
+                    updatedAt: '2026-06-04T10:00:00.000Z'
+                };
+            },
+            jsonRequest: async (_serverUrl, _token, pathName, body) => {
+                requests.push({ pathName, body });
+
+                return {
+                    status: 'dry_run',
+                    note: {
+                        id: '7',
+                        title: 'Note',
+                        updatedAt: '2026-06-04T10:00:00.000Z'
+                    },
+                    proposed: {
+                        changedLineCount: 1
+                    },
+                    warnings: []
+                };
+            },
+            requireWriteToken: () => 'token-a',
+            serverUrl: 'http://localhost:6683',
+            token: 'token-a',
+            tools: TOOL_NAMES,
+            writeSafety: createMcpWriteSafetyCoordinator({
+                rootDir: createTempRootDir(),
+                randomBytes: (size) => Buffer.alloc(size, 1)
+            })
+        });
+        const handler = registeredTools.get(TOOL_NAMES.patchNoteMarkdown)?.handler;
+
+        // Act
+        assert.ok(handler);
+        const result = await handler({
+            id: '7',
+            intent: 'Patch one sentence',
+            selector: {
+                type: 'exact_text',
+                text: 'Original sentence.'
+            },
+            operation: {
+                type: 'replace',
+                replacement: 'Updated sentence.'
+            }
+        });
+        const parsedResult = parseToolText(result);
+
+        // Assert
+        assert.equal(baselineFetchCount, 1);
+        assert.deepEqual(requests, [
+            {
+                pathName: '/api/mcp/notes/patch-markdown',
+                body: {
+                    id: '7',
+                    expectedUpdatedAt: '2026-06-04T10:00:00.000Z',
+                    intent: 'Patch one sentence',
+                    selector: {
+                        type: 'exact_text',
+                        text: 'Original sentence.'
+                    },
+                    operation: {
+                        type: 'replace',
+                        replacement: 'Updated sentence.'
+                    },
+                    dryRun: true
+                }
+            }
+        ]);
+        assert.ok(parsedResult.operation);
+    });
+
+    test('skips baseline fetching when a markdown hash baseline is provided', async () => {
+        // Arrange
+        const { registeredTools, server } = createFakeMcpServer();
+        let baselineFetchCount = 0;
+
+        registerIntentWriteTools(server, {
+            fetchNoteWriteBaseline: async () => {
+                baselineFetchCount += 1;
+                return {
+                    id: '7',
+                    updatedAt: '2026-06-04T10:00:00.000Z'
+                };
+            },
+            jsonRequest: async (_serverUrl, _token, _pathName, body) => {
+                assert.equal(body.baseMarkdownSha256, 'hash-a');
+
+                return {
+                    status: 'dry_run',
+                    note: {
+                        id: '7',
+                        title: 'Note',
+                        updatedAt: '2026-06-04T10:00:00.000Z'
+                    },
+                    proposed: {
+                        changedLineCount: 1
+                    },
+                    warnings: []
+                };
+            },
+            requireWriteToken: () => 'token-a',
+            serverUrl: 'http://localhost:6683',
+            token: 'token-a',
+            tools: TOOL_NAMES,
+            writeSafety: createMcpWriteSafetyCoordinator({ rootDir: createTempRootDir() })
+        });
+        const handler = registeredTools.get(TOOL_NAMES.appendNoteMarkdown)?.handler;
+
+        // Act
+        assert.ok(handler);
+        await handler({
+            id: '7',
+            baseMarkdownSha256: 'hash-a',
+            intent: 'Append link',
+            insertion: 'Related: [[Design Editor]]'
+        });
+
+        // Assert
+        assert.equal(baselineFetchCount, 0);
+    });
+
+    test('accepts explicit append defaults during commit after dry-run omitted them', async () => {
+        // Arrange
+        const { registeredTools, server } = createFakeMcpServer();
+        const requests: Array<Record<string, unknown>> = [];
+
+        registerIntentWriteTools(server, {
+            fetchNoteWriteBaseline: async (id) => ({
+                id,
+                updatedAt: '2026-06-04T10:00:00.000Z'
+            }),
+            jsonRequest: async (_serverUrl, _token, _pathName, body) => {
+                requests.push(body);
+
+                if (body.dryRun === true) {
+                    return {
+                        status: 'dry_run',
+                        note: {
+                            id: '7',
+                            title: 'Note',
+                            updatedAt: '2026-06-04T10:00:00.000Z'
+                        },
+                        proposed: {
+                            changedLineCount: 1
+                        },
+                        warnings: []
+                    };
+                }
+
+                return {
+                    status: 'applied',
+                    note: {
+                        id: '7',
+                        updatedAt: '2026-06-04T10:00:01.000Z'
+                    }
+                };
+            },
+            requireWriteToken: () => 'token-a',
+            serverUrl: 'http://localhost:6683',
+            token: 'token-a',
+            tools: TOOL_NAMES,
+            writeSafety: createMcpWriteSafetyCoordinator({
+                rootDir: createTempRootDir(),
+                randomBytes: (size) => Buffer.alloc(size, 2)
+            })
+        });
+        const handler = registeredTools.get(TOOL_NAMES.appendNoteMarkdown)?.handler;
+
+        // Act
+        assert.ok(handler);
+        const dryRunResult = parseToolText(await handler({
+            id: '7',
+            intent: 'Append link',
+            insertion: 'Related: [[Design Editor]]'
+        }));
+        const operation = dryRunResult.operation as {
+            confirmToken: string;
+            operationId: string;
+        };
+        const commitResult = parseToolText(await handler({
+            id: '7',
+            intent: 'Append link',
+            insertion: 'Related: [[Design Editor]]',
+            placement: { type: 'end' },
+            separator: '\n\n',
+            dryRun: false,
+            operationId: operation.operationId,
+            confirmToken: operation.confirmToken
+        }));
+
+        // Assert
+        assert.equal(commitResult.status, 'applied');
+        assert.equal(requests.length, 2);
+        assert.deepEqual(requests[0], {
+            id: '7',
+            expectedUpdatedAt: '2026-06-04T10:00:00.000Z',
+            intent: 'Append link',
+            insertion: 'Related: [[Design Editor]]',
+            dryRun: true
+        });
+        assert.deepEqual(requests[1], {
+            id: '7',
+            expectedUpdatedAt: '2026-06-04T10:00:00.000Z',
+            intent: 'Append link',
+            insertion: 'Related: [[Design Editor]]',
+            placement: { type: 'end' },
+            separator: '\n\n',
+            dryRun: false
+        });
+    });
+
+    test('rejects commit mode without confirmation before fetching a baseline', async () => {
+        // Arrange
+        const { registeredTools, server } = createFakeMcpServer();
+        let baselineFetchCount = 0;
+
+        registerIntentWriteTools(server, {
+            fetchNoteWriteBaseline: async (id) => {
+                baselineFetchCount += 1;
+                return {
+                    id,
+                    updatedAt: '2026-06-04T10:00:00.000Z'
+                };
+            },
+            jsonRequest: async () => {
+                throw new Error('jsonRequest should not be called.');
+            },
+            requireWriteToken: () => 'token-a',
+            serverUrl: 'http://localhost:6683',
+            token: 'token-a',
+            tools: TOOL_NAMES,
+            writeSafety: createMcpWriteSafetyCoordinator({ rootDir: createTempRootDir() })
+        });
+        const handler = registeredTools.get(TOOL_NAMES.patchNoteMarkdown)?.handler;
+
+        // Act & Assert
+        assert.ok(handler);
+        await assert.rejects(
+            () => handler({
+                id: '7',
+                intent: 'Patch one sentence',
+                selector: {
+                    type: 'exact_text',
+                    text: 'Original sentence.'
+                },
+                operation: {
+                    type: 'replace',
+                    replacement: 'Updated sentence.'
+                },
+                dryRun: false
+            }),
+            /Commit mode requires both operationId and confirmToken/,
+        );
+        assert.equal(baselineFetchCount, 0);
     });
 });
 

--- a/packages/cli/test/mcp.test.ts
+++ b/packages/cli/test/mcp.test.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { fetchMcpNoteWriteBaseline } from '../src/mcp.js';
+
+test('fetchMcpNoteWriteBaseline requests the side-effect-free MCP HTTP baseline endpoint', async () => {
+    const requests: Array<{
+        body: Record<string, unknown>;
+        pathName: string;
+        serverUrl: string;
+        token: string | undefined;
+    }> = [];
+
+    const note = await fetchMcpNoteWriteBaseline(
+        'http://localhost:6683',
+        'token-a',
+        '7',
+        async (serverUrl, token, pathName, body) => {
+            requests.push({ serverUrl, token, pathName, body });
+
+            return {
+                note: {
+                    id: '7',
+                    updatedAt: '2026-06-04T10:00:00.000Z',
+                },
+            };
+        },
+    );
+
+    assert.deepEqual(note, {
+        id: '7',
+        updatedAt: '2026-06-04T10:00:00.000Z',
+    });
+    assert.deepEqual(requests, [
+        {
+            serverUrl: 'http://localhost:6683',
+            token: 'token-a',
+            pathName: '/api/mcp/notes/baseline',
+            body: {
+                id: '7',
+            },
+        },
+    ]);
+});

--- a/packages/server/src/features/note/http/mcp-authoring.test.ts
+++ b/packages/server/src/features/note/http/mcp-authoring.test.ts
@@ -5,6 +5,7 @@ import { AppError } from '~/modules/error-handler.js';
 import {
     createMcpAppendNoteMarkdownHandler,
     createMcpCreateNoteHandler,
+    createMcpNoteWriteBaselineHandler,
     createMcpPatchNoteMarkdownHandler,
     createMcpReplaceNoteMarkdownHandler,
     createMcpUpdateNoteHandler,
@@ -290,6 +291,54 @@ test('mcp update note handler forwards MCP snapshot metadata without requiring a
         title: 'Renamed',
         snapshotMeta: '{"entrypoint":"mcp","label":"MCP"}',
     });
+});
+
+test('mcp note write baseline handler returns only the note write version', async () => {
+    const handler = createMcpNoteWriteBaselineHandler(async (id) => ({
+        id,
+        updatedAt: new Date('2026-06-04T10:00:00.000Z'),
+    }));
+    const response = createResponse();
+
+    await handler(
+        {
+            body: {
+                id: '7',
+            },
+        } as never,
+        response as never,
+    );
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(response.body, {
+        note: {
+            id: '7',
+            updatedAt: '2026-06-04T10:00:00.000Z',
+        },
+    });
+});
+
+test('mcp note write baseline handler returns not found when the note is missing', async () => {
+    const handler = createMcpNoteWriteBaselineHandler(async () => null);
+
+    await assert.rejects(
+        () =>
+            handler(
+                {
+                    body: {
+                        id: '7',
+                    },
+                } as never,
+                createResponse() as never,
+            ),
+        (error: unknown) => {
+            assert.ok(error instanceof AppError);
+            assert.equal(error.status, 404);
+            assert.equal(error.code, 'NOTE_NOT_FOUND');
+            assert.equal(error.message, 'The requested note was not found.');
+            return true;
+        },
+    );
 });
 
 test('mcp update note handler rejects empty updates', async () => {

--- a/packages/server/src/features/note/http/mcp.ts
+++ b/packages/server/src/features/note/http/mcp.ts
@@ -181,6 +181,13 @@ const resolveMarkdownWritePolicy = (value: unknown): MarkdownChangePolicy | unde
         policy.maxChangedLines = value.maxChangedLines;
     }
 
+    if (value.diffPreviewMaxChars !== undefined) {
+        if (!isNonNegativeInteger(value.diffPreviewMaxChars)) {
+            throw createAppError(400, 'INVALID_MARKDOWN_POLICY', 'diffPreviewMaxChars must be a non-negative integer.');
+        }
+        policy.diffPreviewMaxChars = value.diffPreviewMaxChars;
+    }
+
     if (value.preserveTags !== undefined) {
         if (!PRESERVATION_POLICIES.has(value.preserveTags)) {
             throw createAppError(400, 'INVALID_MARKDOWN_POLICY', 'preserveTags must be boolean or warn.');

--- a/packages/server/src/features/note/http/mcp.ts
+++ b/packages/server/src/features/note/http/mcp.ts
@@ -18,7 +18,7 @@ import type {
 } from '~/features/note/services/markdown-patch.js';
 import type { NotePropertiesByKeyPatchInput } from '~/features/note/services/properties.js';
 import { MCP_SNAPSHOT_META } from '~/features/note/services/snapshot.js';
-import type { NoteLayout } from '~/models.js';
+import models, { type NoteLayout } from '~/models.js';
 import { createAppError } from '~/modules/error-handler.js';
 import { emitServerEvent, type ServerEventInput } from '~/modules/server-events.js';
 import type { Controller } from '~/types/index.js';
@@ -132,6 +132,13 @@ const resolvePositiveNoteId = (value: unknown) => {
     }
 
     return noteId;
+};
+
+const serializeNoteWriteBaseline = (note: { id: number | string; updatedAt: Date | string }) => {
+    return {
+        id: String(note.id),
+        updatedAt: note.updatedAt instanceof Date ? note.updatedAt.toISOString() : note.updatedAt,
+    };
 };
 
 const isNonNegativeInteger = (value: unknown): value is number => {
@@ -455,6 +462,32 @@ export const createMcpUpdateNoteHandler = (
 
             throw error;
         }
+    };
+};
+
+export const createMcpNoteWriteBaselineHandler = (
+    findNoteBaseline: (id: number) => Promise<{ id: number; updatedAt: Date } | null> = async (id) =>
+        models.note.findUnique({
+            where: { id },
+            select: {
+                id: true,
+                updatedAt: true,
+            },
+        }),
+): Controller => {
+    return async (req, res) => {
+        const noteId = resolvePositiveNoteId(req.body?.id);
+        const note = await findNoteBaseline(noteId);
+
+        if (!note) {
+            throw createAppError(404, 'NOTE_NOT_FOUND', 'The requested note was not found.');
+        }
+
+        res.status(200)
+            .json({
+                note: serializeNoteWriteBaseline(note),
+            })
+            .end();
     };
 };
 

--- a/packages/server/src/features/note/services/markdown-intent-write.test.ts
+++ b/packages/server/src/features/note/services/markdown-intent-write.test.ts
@@ -111,7 +111,8 @@ test('markdown intent write refuses apply when the note changed after preview ba
     assert.deepEqual(result, {
         status: 'failed',
         reason: 'BASELINE_MISMATCH',
-        message: 'The markdown write baseline does not match the current note.',
+        message:
+            'The markdown write baseline does not match the current note. expectedUpdatedAt accepts an ISO datetime string or epoch milliseconds string.',
     });
 });
 
@@ -176,6 +177,9 @@ test('markdown intent write refuses apply when structured references would be lo
         operation: {
             type: 'replace',
             replacement: 'Updated sentence.',
+        },
+        policy: {
+            preserveReferences: true,
         },
         dryRun: false,
     });
@@ -287,8 +291,137 @@ test('markdown intent write maps guarded update conflicts to baseline mismatch f
     assert.deepEqual(result, {
         status: 'failed',
         reason: 'BASELINE_MISMATCH',
-        message: 'The markdown write baseline does not match the current note.',
+        message:
+            'The markdown write baseline does not match the current note. expectedUpdatedAt accepts an ISO datetime string or epoch milliseconds string.',
     });
+});
+
+test('markdown intent write allows intentional reference loss when preserveReferences is false', async () => {
+    const updates: unknown[] = [];
+    const service = createMarkdownIntentWriteService({
+        findNoteById: async () => createNote({ content: 'before-content' }),
+        renderMarkdown: async () => 'See [[Shared Title]]\n\nOriginal sentence.',
+        parseMarkdownToContentJson: async () => 'after-content',
+        extractTagIds: () => [],
+        countReferenceInlines: (content) => (content === 'before-content' ? 1 : 0),
+        updateNote: async (input) => {
+            updates.push(input);
+            return {
+                note: {
+                    id: input.id,
+                    title: 'Existing',
+                    content: input.data.content ?? '',
+                    layout: 'wide',
+                    pinned: false,
+                    order: 0,
+                    createdAt: new Date('2026-05-28T00:00:00.000Z'),
+                    updatedAt: new Date('2026-05-28T00:00:01.000Z'),
+                },
+                snapshot: {
+                    id: '14',
+                    createdAt: '2026-05-28T00:00:00.500Z',
+                    meta: { label: 'MCP' },
+                },
+            };
+        },
+    });
+
+    const result = await service.patchNoteMarkdown({
+        id: 7,
+        expectedUpdatedAt: '2026-05-28T00:00:00.000Z',
+        intent: 'Remove reference intentionally',
+        selector: {
+            type: 'exact_text',
+            text: 'See [[Shared Title]]\n\n',
+        },
+        operation: {
+            type: 'replace',
+            replacement: '',
+        },
+        policy: {
+            preserveReferences: false,
+        },
+        dryRun: false,
+    });
+
+    assert.equal(result.status, 'applied');
+    assert.equal(updates.length, 1);
+});
+
+test('markdown intent write reports required minimum limits when change limits are exceeded', async () => {
+    const service = createMarkdownIntentWriteService({
+        findNoteById: async () => createNote({ content: 'Original sentence.' }),
+        renderMarkdown: async (content) => content,
+        parseMarkdownToContentJson: async () => {
+            throw new Error('should not parse');
+        },
+        extractTagIds: () => [],
+        updateNote: async () => {
+            throw new Error('should not update');
+        },
+    });
+
+    const result = await service.appendNoteMarkdown({
+        id: 7,
+        expectedUpdatedAt: '2026-05-28T00:00:00.000Z',
+        intent: 'Append longer section',
+        insertion: 'Line 1\nLine 2\nLine 3',
+        policy: {
+            maxChangedLines: 1,
+            maxChangedChars: 5,
+        },
+    });
+
+    assert.deepEqual(result, {
+        status: 'failed',
+        reason: 'CHANGE_LIMIT_EXCEEDED',
+        message:
+            'The markdown write exceeds the configured change limit. Increase maxChangedLines/maxChangedChars to at least the requiredMinimum values or omit them for this write.',
+        details: {
+            configured: {
+                maxChangedLines: 1,
+                maxChangedChars: 5,
+            },
+            requiredMinimum: {
+                maxChangedLines: 4,
+                maxChangedChars: 20,
+            },
+        },
+    });
+});
+
+test('markdown intent write can truncate dry-run diff previews', async () => {
+    const service = createMarkdownIntentWriteService({
+        findNoteById: async () => createNote({ content: 'Original sentence.' }),
+        renderMarkdown: async (content) => content,
+        parseMarkdownToContentJson: async () => {
+            throw new Error('should not parse during dry run');
+        },
+        extractTagIds: () => [],
+        updateNote: async () => {
+            throw new Error('should not update');
+        },
+    });
+
+    const result = await service.appendNoteMarkdown({
+        id: 7,
+        expectedUpdatedAt: '2026-05-28T00:00:00.000Z',
+        intent: 'Append with short diff',
+        insertion: 'A long appended sentence that should be hidden from the short diff preview.',
+        policy: {
+            diffPreviewMaxChars: 24,
+        },
+    });
+
+    assert.equal(result.status, 'dry_run');
+
+    if (result.status !== 'dry_run') {
+        throw new Error('expected dry run');
+    }
+
+    assert.equal(result.proposed.diff.length, 24);
+    assert.equal(result.proposed.diffTruncated, true);
+    assert.ok((result.proposed.diffCharCount ?? 0) > result.proposed.diff.length);
 });
 
 test('metadata update accepts epoch millisecond note versions', async () => {

--- a/packages/server/src/features/note/services/markdown-intent-write.ts
+++ b/packages/server/src/features/note/services/markdown-intent-write.ts
@@ -96,6 +96,7 @@ export interface MarkdownWritePolicy {
     allowNoop?: boolean;
     maxChangedChars?: number;
     maxChangedLines?: number;
+    diffPreviewMaxChars?: number;
     preserveReferences?: boolean | 'warn';
     preserveTags?: boolean | 'warn';
 }
@@ -248,7 +249,8 @@ const toTagIds = (tagIds: string[]) => {
 const baselineMismatchFailure = (): MarkdownChangeFailure => ({
     status: 'failed',
     reason: 'BASELINE_MISMATCH',
-    message: 'The markdown write baseline does not match the current note.',
+    message:
+        'The markdown write baseline does not match the current note. expectedUpdatedAt accepts an ISO datetime string or epoch milliseconds string.',
 });
 
 const missingBaselineFailure = (): MarkdownChangeFailure => ({
@@ -367,7 +369,7 @@ const applyMarkdownPlan = async (
     const beforeReferenceCount = deps.countReferenceInlines?.(input.beforeContentJson) ?? 0;
     const afterReferenceCount = deps.countReferenceInlines?.(content) ?? 0;
 
-    if (input.policy?.preserveReferences !== false && afterReferenceCount < beforeReferenceCount) {
+    if (input.policy?.preserveReferences === true && afterReferenceCount < beforeReferenceCount) {
         return referenceStructureFailure();
     }
 
@@ -588,7 +590,8 @@ export const createMarkdownIntentWriteService = (deps: MarkdownIntentWriteDeps) 
             return {
                 status: 'failed',
                 reason: input.expectedUpdatedAt ? 'BASELINE_MISMATCH' : 'MISSING_BASELINE',
-                message: 'The metadata update baseline does not match the current note.',
+                message:
+                    'The metadata update baseline does not match the current note. expectedUpdatedAt accepts an ISO datetime string or epoch milliseconds string.',
             };
         }
 

--- a/packages/server/src/features/note/services/markdown-patch.ts
+++ b/packages/server/src/features/note/services/markdown-patch.ts
@@ -54,6 +54,7 @@ export interface MarkdownChangePolicy {
     allowNoop?: boolean;
     maxChangedChars?: number;
     maxChangedLines?: number;
+    diffPreviewMaxChars?: number;
     preserveReferences?: boolean | 'warn';
     preserveTags?: boolean | 'warn';
 }
@@ -134,6 +135,8 @@ export interface MarkdownChangeDryRun {
         beforeMarkdownSha256: string;
         afterMarkdownSha256: string;
         diff: string;
+        diffTruncated?: boolean;
+        diffCharCount?: number;
     };
     warnings: string[];
 }
@@ -171,6 +174,7 @@ export interface MarkdownChangeFailure {
         | 'TARGET_NOT_FOUND'
         | 'UNSUPPORTED_MARKDOWN_STRUCTURE';
     message: string;
+    details?: Record<string, unknown>;
 }
 
 export type MarkdownPatchPreviewResult =
@@ -513,7 +517,8 @@ const validateBaseline = (
         return {
             status: 'failed',
             reason: 'BASELINE_MISMATCH',
-            message: 'The markdown write baseline does not match the current note.',
+            message:
+                'The markdown write baseline does not match the current note. expectedUpdatedAt accepts an ISO datetime string or epoch milliseconds string.',
         };
     }
 
@@ -527,19 +532,46 @@ const validateChangeLimits = (
     policy: MarkdownChangePolicy | undefined,
 ): MarkdownChangeFailure | null => {
     const changedLineCount = countChangedLines(beforeMarkdown, afterMarkdown);
+    const exceededLines = policy?.maxChangedLines !== undefined && changedLineCount > policy.maxChangedLines;
+    const exceededChars = policy?.maxChangedChars !== undefined && changedCharCount > policy.maxChangedChars;
 
-    if (
-        (policy?.maxChangedLines !== undefined && changedLineCount > policy.maxChangedLines) ||
-        (policy?.maxChangedChars !== undefined && changedCharCount > policy.maxChangedChars)
-    ) {
+    if (exceededLines || exceededChars) {
         return {
             status: 'failed',
             reason: 'CHANGE_LIMIT_EXCEEDED',
-            message: 'The markdown write exceeds the configured change limit.',
+            message:
+                'The markdown write exceeds the configured change limit. Increase maxChangedLines/maxChangedChars to at least the requiredMinimum values or omit them for this write.',
+            details: {
+                configured: {
+                    ...(policy?.maxChangedLines !== undefined ? { maxChangedLines: policy.maxChangedLines } : {}),
+                    ...(policy?.maxChangedChars !== undefined ? { maxChangedChars: policy.maxChangedChars } : {}),
+                },
+                requiredMinimum: {
+                    maxChangedLines: changedLineCount,
+                    maxChangedChars: changedCharCount,
+                },
+            },
         };
     }
 
     return null;
+};
+
+const buildDiffPreview = (diff: string, policy: MarkdownChangePolicy | undefined) => {
+    const maxChars = policy?.diffPreviewMaxChars;
+
+    if (maxChars === undefined || diff.length <= maxChars) {
+        return {
+            diff,
+            ...(maxChars !== undefined ? { diffCharCount: diff.length } : {}),
+        };
+    }
+
+    return {
+        diff: diff.slice(0, maxChars),
+        diffTruncated: true,
+        diffCharCount: diff.length,
+    };
 };
 
 const createChangePlan = ({
@@ -579,6 +611,11 @@ const createChangePlan = ({
         return limitFailure;
     }
 
+    const diffPreview = buildDiffPreview(
+        createUnifiedMarkdownDiff(note.markdown, afterMarkdown, diffContextLines),
+        policy,
+    );
+
     return {
         status: 'dry_run',
         note: {
@@ -593,7 +630,7 @@ const createChangePlan = ({
             changedCharCount,
             beforeMarkdownSha256: calculateMarkdownSha256(note.markdown),
             afterMarkdownSha256: calculateMarkdownSha256(afterMarkdown),
-            diff: createUnifiedMarkdownDiff(note.markdown, afterMarkdown, diffContextLines),
+            ...diffPreview,
         },
         warnings: collectWarnings(note.markdown, afterMarkdown, policy),
         afterMarkdown,

--- a/packages/server/src/routes/mcp.ts
+++ b/packages/server/src/routes/mcp.ts
@@ -4,6 +4,7 @@ import {
     createMcpAppendNoteMarkdownHandler,
     createMcpCreateNoteHandler,
     createMcpDeleteNoteHandler,
+    createMcpNoteWriteBaselineHandler,
     createMcpPatchNoteMarkdownHandler,
     createMcpReplaceNoteMarkdownHandler,
     createMcpUpdateNoteHandler,
@@ -27,6 +28,11 @@ export const createMcpRouter = (authConfig: AuthConfig, mcpAdminService: McpRout
             '/notes/update',
             createMcpAuthMiddleware(authConfig, mcpAdminService),
             useAsync(createMcpUpdateNoteHandler()),
+        )
+        .post(
+            '/notes/baseline',
+            createMcpAuthMiddleware(authConfig, mcpAdminService),
+            useAsync(createMcpNoteWriteBaselineHandler()),
         )
         .post(
             '/notes/patch-markdown',

--- a/packages/server/test/mcp-auth.test.ts
+++ b/packages/server/test/mcp-auth.test.ts
@@ -125,6 +125,22 @@ const updateNoteRequest = async (baseUrl: string, body: Record<string, unknown>,
     };
 };
 
+const noteWriteBaselineRequest = async (baseUrl: string, body: Record<string, unknown>, bearerToken?: string) => {
+    const response = await fetch(`${baseUrl}/api/mcp/notes/baseline`, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            ...(bearerToken ? { Authorization: `Bearer ${bearerToken}` } : {}),
+        },
+        body: JSON.stringify(body),
+    });
+
+    return {
+        status: response.status,
+        body: (await response.json()) as Record<string, unknown>,
+    };
+};
+
 const createMcpAdminAuth = (options: {
     enabled: boolean;
     expectedToken?: string;
@@ -302,6 +318,26 @@ test('enabled state still requires a valid bearer token on the MCP note update e
     assert.equal(authorized.body.code, 'INVALID_NOTE_ID');
 });
 
+test('enabled state still requires a valid bearer token on the MCP note write baseline endpoint', async (t) => {
+    const { baseUrl } = await startServer(
+        t,
+        createOpenAuthConfig(),
+        createMcpAdminAuth({ enabled: true, expectedToken: 'mcp-secret' }),
+    );
+
+    const unauthorized = await noteWriteBaselineRequest(baseUrl, { id: 'abc' });
+    assert.equal(unauthorized.status, 401);
+    assert.equal(unauthorized.body.code, 'UNAUTHORIZED');
+
+    const forbidden = await noteWriteBaselineRequest(baseUrl, { id: 'abc' }, 'wrong-token');
+    assert.equal(forbidden.status, 403);
+    assert.equal(forbidden.body.code, 'FORBIDDEN');
+
+    const authorized = await noteWriteBaselineRequest(baseUrl, { id: 'abc' }, 'mcp-secret');
+    assert.equal(authorized.status, 400);
+    assert.equal(authorized.body.code, 'INVALID_NOTE_ID');
+});
+
 test('enabled state still requires a valid bearer token on the MCP tag create endpoint', async (t) => {
     const { baseUrl } = await startServer(
         t,
@@ -354,6 +390,18 @@ test('password mode returns configuration error on the MCP note update endpoint 
     );
 
     const response = await updateNoteRequest(baseUrl, { id: '1', title: 'Draft' }, 'mcp-secret');
+    assert.equal(response.status, 503);
+    assert.equal(response.body.code, 'MCP_AUTH_NOT_CONFIGURED');
+});
+
+test('password mode returns configuration error on the MCP note write baseline endpoint when no bearer token is configured', async (t) => {
+    const { baseUrl } = await startServer(
+        t,
+        createPasswordAuthConfig(),
+        createMcpAdminAuth({ enabled: true, configured: false }),
+    );
+
+    const response = await noteWriteBaselineRequest(baseUrl, { id: '1' }, 'mcp-secret');
     assert.equal(response.status, 503);
     assert.equal(response.body.code, 'MCP_AUTH_NOT_CONFIGURED');
 });


### PR DESCRIPTION
## :dart: Goal
- Reduce unnecessary token and request overhead in MCP intent write workflows.
- Avoid requiring agents to perform full note reads only to obtain write baselines before dry-run/commit flows.
- Prevent avoidable confirmation failures caused by equivalent payloads with different key order or append defaults.
- Make write safety failures more actionable so small note cleanup work can finish without repeated trial-and-error tool calls.

## :hammer_and_wrench: Core Changes
- Auto-fetches a compact note write baseline when `expectedUpdatedAt` and `baseMarkdownSha256` are omitted.
- Adds `/api/mcp/notes/baseline` as a side-effect-free MCP HTTP endpoint that returns only `id` and `updatedAt`.
- Defaults intent write tools to dry-run mode when `dryRun` is omitted.
- Stabilizes write operation fingerprints by sorting JSON object keys and normalizing append defaults.
- Rejects commit mode without `operationId` and `confirmToken` before any baseline fetch or write request.
- Allows intentional reference reduction when `preserveReferences: false` is explicitly provided, while `preserveReferences: true` still blocks it.
- Adds `diffPreviewMaxChars` to markdown write policy so dry-run responses can return short diff previews for large appends/replacements.
- Returns `CHANGE_LIMIT_EXCEEDED` details with configured limits and required minimum `maxChangedLines`/`maxChangedChars`.
- Clarifies baseline mismatch messages to state that `expectedUpdatedAt` accepts ISO datetime strings or epoch millisecond strings.
- Adds CLI, handler, MCP HTTP auth, policy, and markdown intent write coverage for the new flow.

## :brain: Key Decisions
- Use a dedicated MCP HTTP baseline endpoint instead of GraphQL `note` reads so baseline lookup does not trigger read-time note repair side effects.
- Keep `baseMarkdownSha256` as an escape hatch; baseline auto-fetch is skipped when a markdown hash baseline is provided.
- Normalize only known append defaults for fingerprint compatibility instead of broad schema-dependent rewriting.
- Preserve the two-step dry-run/confirm safety model while reducing the reads agents need to perform manually.
- Keep destructive/delete/full replace confirmation semantics strong, but make append/patch dry-run output easier to bound with `diffPreviewMaxChars`.
- Treat `preserveReferences: false` as an explicit user/agent override for intentional link structure cleanup.
- Do not add batch writes in this PR; the baseline auto-fetch, actionable limit errors, diff preview limit, and explicit reference override address the observed repeated-call cases without adding multi-write transaction semantics.

## :test_tube: Verification Guide
### How to verify
1. Run `pnpm check:encoding`.
2. Run `pnpm lint`.
3. Run `pnpm type-check`.
4. Run `pnpm test:ci`.
5. Run `pnpm build`.
6. Run `pnpm --filter ocean-brain test`.
7. Run `pnpm --filter ocean-brain type-check`.
8. Run `pnpm --filter ocean-brain build`.

### Expected result
- Encoding check passes for tracked text files.
- Lint completes with no fixes required.
- Client, server, and CLI type-checks pass.
- Full test suite passes, including CLI MCP intent write tests and server MCP HTTP auth tests.
- Server markdown intent write tests cover reference override, change limit detail, diff preview truncation, and epoch baseline handling.
- Client, server, and CLI builds complete successfully.

### Local result
- `pnpm check:encoding`: passed.
- `pnpm lint`: passed.
- `pnpm type-check`: passed.
- `pnpm --filter @ocean-brain/server test:ci`: passed, 256 tests.
- `pnpm --filter ocean-brain test`: passed, 37 tests.
- `pnpm --filter ocean-brain type-check`: passed.
- `pnpm build`: passed.
- `pnpm --filter ocean-brain build`: passed.
- Local HTTP MCP smoke with `/tmp` SQLite DB: passed.
  - `/api/mcp/notes/baseline` returned only `id` and `updatedAt`.
  - `diffPreviewMaxChars` returned a truncated 24-character diff with `diffTruncated: true` and `diffCharCount`.
  - `CHANGE_LIMIT_EXCEEDED` returned `details.configured` and `details.requiredMinimum`.
  - `preserveReferences: true` blocked reference removal; `preserveReferences: false` allowed intentional removal.
- Local CLI MCP stdio smoke against the same local server: passed.
  - `ocean_brain_append_note_markdown` succeeded without caller-provided `expectedUpdatedAt`, proving automatic baseline fetch.
  - Dry-run returned `operationId` and `confirmToken`; commit with those fields returned `status: "applied"`.
  - Write safety log recorded `prepared → confirmed → executed`.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Build completed
- [x] Documentation updated (not needed; no docs, script, or env changes)
- [x] Release impact label selected: `release: minor`

