### PR TITLE
✨ Support note-id wiki references

### DIFF
--- a/docs/process/DEV_CONVENTION.md
+++ b/docs/process/DEV_CONVENTION.md
@@ -1,6 +1,6 @@
 # Ocean Brain Dev Convention
 
-Updated: 2026-03-06
+Updated: 2026-06-05
 
 ## 1. Base Environment
 - Node.js: `22`
@@ -30,6 +30,7 @@ Updated: 2026-03-06
    - Body sections: write each section as a Markdown H2 heading using the exact shortcode labels, for example `## :dart: Goal`
    - Required section labels: `:dart: Goal`, `:hammer_and_wrench: Core Changes`, `:brain: Key Decisions`, `:test_tube: Verification Guide`, `:white_check_mark: Checklist` (shortcode only)
    - Commit format: `<emoji> <subject>` (Unicode emoji only)
+   - Release impact label: exactly one of `release: major`, `release: minor`, or `release: patch`
 
 ## 5. Server and Release Linked Rules
 - Server start script includes `prisma migrate deploy`.

--- a/docs/process/GIT_CONVENTION.md
+++ b/docs/process/GIT_CONVENTION.md
@@ -1,6 +1,6 @@
 # Ocean Brain Git Convention
 
-Updated: 2026-03-06
+Updated: 2026-06-05
 
 ## 1. Scope
 - This document defines commit and PR conventions for the Ocean Brain repository.
@@ -74,9 +74,22 @@ Use these shortcode labels exactly:
 1. CI checks (`lint`, `type-check`, `build`) pass
 2. Local validation for the changed scope is complete
 3. Any docs/scripts/env changes are documented in PR body
-4. Release-impacting changes include version/tag plan
+4. Exactly one release impact label is applied: `release: major`, `release: minor`, or `release: patch`
+5. Release-impacting changes include version/tag plan
 
-### 3-5. Release-Impact PR
+### 3-5. Release Impact Labels
+Every PR must have exactly one release impact label before review/merge. Pick the highest applicable impact.
+
+- `release: major`: breaking change, migration requirement, removed/renamed public behavior, or incompatible API/CLI/config change
+- `release: minor`: backward-compatible feature, new endpoint/tool/command, new user-visible capability, or backward-compatible output enrichment
+- `release: patch`: backward-compatible bug fix, documentation-only change, tests, refactor, maintenance, or performance improvement without a new capability
+
+Examples:
+- Preserving Markdown hard breaks: `release: patch`
+- Adding `[[title]](note:id)` reference Markdown support: `release: minor`
+- Removing or changing an existing MCP/CLI contract incompatibly: `release: major`
+
+### 3-6. Release-Impact PR
 Changes in the files below are treated as release-impacting.
 1. `packages/cli/package.json`
 2. `scripts/release/prepublish.mjs`, `scripts/release/bump-version.mjs`
@@ -88,17 +101,18 @@ Release-impact PRs must include:
 2. tag plan (`vX.Y.Z`)
 3. verification result (`CLI_SMOKE` pass)
 
-### 3-6. Merge Policy
+### 3-7. Merge Policy
 - Default: merge commit
 - Squash merge is allowed for single-commit-style changes
 
-### 3-7. PR Submission Guardrail (Required)
+### 3-8. PR Submission Guardrail (Required)
 Before sharing a PR URL, confirm all of the following:
 1. Title follows `<emoji> <subject>` and subject starts with an English verb.
 2. Body section headings exactly match the template headings.
 3. PR body heading emojis must use shortcode form (`:dart:`, `:hammer_and_wrench:`, etc.).
 4. `Verification Guide` contains concrete commands and expected results.
 5. The `Checklist` state is intentionally set (not left ambiguous).
+6. Exactly one release impact label is applied: `release: major`, `release: minor`, or `release: patch`.
 
 ## 4. PR Template Path
 - Use `.github/PULL_REQUEST_TEMPLATE.md` as the official PR template.

--- a/packages/server/src/features/note/graphql/note.query.resolver.test.ts
+++ b/packages/server/src/features/note/graphql/note.query.resolver.test.ts
@@ -5,7 +5,22 @@ import {
     createAllNotesQueryResolver,
     createBackReferencesQueryResolver,
     createNoteGraphQueryResolver,
+    createNoteQueryResolver,
 } from './note.query.resolver.js';
+
+const createNoteRecord = (input: { id: number; title: string; content: string; updatedAt?: Date }) =>
+    ({
+        id: input.id,
+        title: input.title,
+        content: input.content,
+        searchableText: '',
+        searchableTextVersion: 0,
+        createdAt: new Date('2026-06-04T00:00:00.000Z'),
+        updatedAt: input.updatedAt ?? new Date('2026-06-04T00:00:00.000Z'),
+        pinned: false,
+        order: 0,
+        layout: 'wide',
+    }) as const;
 
 test('allNotes resolver uses stored searchable text with DB pagination when no stale notes exist', async () => {
     const findCalls: unknown[] = [];
@@ -229,6 +244,94 @@ test('allNotes resolver leaves unfiltered queries on the fast default path', asy
     });
     assert.equal(result.totalCount, 3);
     assert.deepEqual(result.notes, []);
+});
+
+test('note resolver lazily repairs structured reference titles after target note rename', async () => {
+    const sourceUpdatedAt = new Date('2026-06-04T00:00:00.000Z');
+    const sourceContent = JSON.stringify([
+        {
+            id: 'paragraph-1',
+            type: 'paragraph',
+            props: {},
+            content: [
+                { type: 'text', text: 'See ', styles: {} },
+                {
+                    type: 'reference',
+                    props: {
+                        id: '2',
+                        title: 'Old target title',
+                    },
+                },
+            ],
+            children: [],
+        },
+    ]);
+    const updates: unknown[] = [];
+
+    const resolver = createNoteQueryResolver({
+        findNote: async (id) =>
+            createNoteRecord({ id, title: 'Source note', content: sourceContent, updatedAt: sourceUpdatedAt }) as never,
+        findReferenceNotes: async (ids) => {
+            assert.deepEqual(ids, [2]);
+            return [createNoteRecord({ id: 2, title: 'Renamed target title', content: '[]' })] as never;
+        },
+        updateNoteContent: async (input) => {
+            updates.push(input);
+            return createNoteRecord({
+                id: input.id,
+                title: 'Source note',
+                content: input.content,
+                updatedAt: new Date('2026-06-04T00:00:01.000Z'),
+            }) as never;
+        },
+        isRecordNotFoundError: () => false,
+    });
+
+    const result = await resolver(null, { id: '1' });
+
+    assert.equal(JSON.parse(result.content)[0].content[1].props.title, 'Renamed target title');
+    assert.deepEqual(updates, [
+        {
+            id: 1,
+            updatedAt: sourceUpdatedAt,
+            content: result.content,
+            searchableText: 'source note see renamed target title',
+            searchableTextVersion: 1,
+        },
+    ]);
+});
+
+test('note resolver cannot repair unresolved plain-text wiki links after target note rename', async () => {
+    const sourceContent = JSON.stringify([
+        {
+            id: 'paragraph-1',
+            type: 'paragraph',
+            props: {},
+            content: [{ type: 'text', text: 'See [[Old target title]]', styles: {} }],
+            children: [],
+        },
+    ]);
+    let didFindReferences = false;
+    let didUpdate = false;
+
+    const resolver = createNoteQueryResolver({
+        findNote: async (id) => createNoteRecord({ id, title: 'Source note', content: sourceContent }) as never,
+        findReferenceNotes: async () => {
+            didFindReferences = true;
+            return [];
+        },
+        updateNoteContent: async () => {
+            didUpdate = true;
+            throw new Error('should not update unresolved plain text links');
+        },
+        isRecordNotFoundError: () => false,
+    });
+
+    const result = await resolver(null, { id: '1' });
+
+    assert.equal(result.content, sourceContent);
+    assert.equal(didFindReferences, false);
+    assert.equal(didUpdate, false);
 });
 
 test('backReferences resolver finds structurally valid references in formatted note JSON', async () => {

--- a/packages/server/src/features/note/graphql/note.query.resolver.ts
+++ b/packages/server/src/features/note/graphql/note.query.resolver.ts
@@ -37,6 +37,31 @@ interface AllNotesResolverDeps {
     triggerSearchBackfill: () => void;
 }
 
+const MAX_SQLITE_INT_ID = 2_147_483_647;
+
+const isValidNoteIdString = (id: string) => {
+    if (!/^[1-9]\d*$/.test(id)) {
+        return false;
+    }
+
+    const numericId = Number(id);
+
+    return Number.isSafeInteger(numericId) && numericId <= MAX_SQLITE_INT_ID;
+};
+
+interface NoteResolverDeps {
+    findNote: (id: number) => Promise<Note | null>;
+    findReferenceNotes: (ids: number[]) => Promise<Note[]>;
+    updateNoteContent: (input: {
+        id: number;
+        updatedAt: Date;
+        content: string;
+        searchableText: string;
+        searchableTextVersion: number;
+    }) => Promise<Note>;
+    isRecordNotFoundError: (error: unknown) => boolean;
+}
+
 const buildAllNotesOrderBy = (searchFilter: SearchFilter) => {
     const sortBy = searchFilter.sortBy || 'updatedAt';
     const sortOrder = searchFilter.sortOrder || 'desc';
@@ -291,6 +316,83 @@ export const createNoteGraphQueryResolver = (
     };
 };
 
+export const createNoteQueryResolver = (
+    deps: NoteResolverDeps = {
+        findNote: (id) => models.note.findUnique({ where: { id } }),
+        findReferenceNotes: (ids) => models.note.findMany({ where: { id: { in: ids } } }),
+        updateNoteContent: ({ id, updatedAt, content, searchableText, searchableTextVersion }) =>
+            models.note.update({
+                where: {
+                    id,
+                    updatedAt,
+                },
+                data: {
+                    content,
+                    searchableText,
+                    searchableTextVersion,
+                },
+            }),
+        isRecordNotFoundError,
+    },
+) => {
+    return async (_: unknown, { id }: { id: string }) => {
+        const note = await deps.findNote(Number(id));
+
+        if (!note) {
+            throw 'NOT FOUND';
+        }
+
+        if (!note.content) {
+            return note;
+        }
+
+        const blocks = extractReferenceBlocksFromContent(note.content);
+
+        if (blocks.length === 0) {
+            return note;
+        }
+
+        const referenceIds = Array.from(
+            new Set(
+                blocks
+                    .map((block) => normalizeReferenceId(block.props?.id))
+                    .filter(
+                        (referenceId): referenceId is string =>
+                            referenceId !== null && isValidNoteIdString(referenceId),
+                    )
+                    .map(Number),
+            ),
+        );
+        const references = await deps.findReferenceNotes(referenceIds);
+        const titlesById = new Map(
+            references.map((referenceNote: Note) => [String(referenceNote.id), referenceNote.title]),
+        );
+        const newContent = syncReferenceTitlesInContent(note.content, titlesById);
+
+        if (!newContent || newContent === note.content) {
+            return note;
+        }
+
+        try {
+            return await deps.updateNoteContent({
+                id: note.id,
+                updatedAt: note.updatedAt,
+                content: newContent,
+                ...buildNoteSearchProjection({
+                    title: note.title,
+                    content: newContent,
+                }),
+            });
+        } catch (error) {
+            if (deps.isRecordNotFoundError(error)) {
+                return note;
+            }
+
+            throw error;
+        }
+    };
+};
+
 export const noteQueryResolvers: NoteQueryResolvers = {
     allNotes: createAllNotesQueryResolver(),
     notesInDateRange: async (
@@ -394,64 +496,7 @@ export const noteQueryResolvers: NoteQueryResolvers = {
             where: { content: { contains: src } },
         }),
     backReferences: createBackReferencesQueryResolver(),
-    note: async (_, { id }: { id: string }) => {
-        const note = await models.note.findUnique({ where: { id: Number(id) } });
-
-        if (!note) {
-            throw 'NOT FOUND';
-        }
-
-        if (!note.content) {
-            return note;
-        }
-
-        const blocks = extractReferenceBlocksFromContent(note.content);
-
-        if (blocks.length === 0) {
-            return note;
-        }
-
-        const referenceIds = Array.from(
-            new Set(
-                blocks
-                    .map((block) => normalizeReferenceId(block.props?.id))
-                    .filter((referenceId): referenceId is string => referenceId !== null)
-                    .map(Number)
-                    .filter(Number.isFinite),
-            ),
-        );
-        const references = await models.note.findMany({ where: { id: { in: referenceIds } } });
-        const titlesById = new Map(
-            references.map((referenceNote: Note) => [String(referenceNote.id), referenceNote.title]),
-        );
-        const newContent = syncReferenceTitlesInContent(note.content, titlesById);
-
-        if (!newContent || newContent === note.content) {
-            return note;
-        }
-
-        try {
-            return await models.note.update({
-                where: {
-                    id: note.id,
-                    updatedAt: note.updatedAt,
-                },
-                data: {
-                    content: newContent,
-                    ...buildNoteSearchProjection({
-                        title: note.title,
-                        content: newContent,
-                    }),
-                },
-            });
-        } catch (error) {
-            if (isRecordNotFoundError(error)) {
-                return note;
-            }
-
-            throw error;
-        }
-    },
+    note: createNoteQueryResolver(),
     noteCleanupCandidates: async (
         _,
         {

--- a/packages/server/src/modules/blocknote.ts
+++ b/packages/server/src/modules/blocknote.ts
@@ -57,11 +57,17 @@ interface MarkdownImportDeps {
             title: string;
         }>
     >;
+    findNoteById?: (id: string) => Promise<{
+        id: string;
+        title: string;
+    } | null>;
 }
 
 const UNSUPPORTED_MARKDOWN_BLOCK_TYPES = new Set(['tableOfContents']);
 const TAG_PLACEHOLDER_PREFIX = 'OCEAN_BRAIN_TAG_';
 const TAG_PLACEHOLDER_SUFFIX = '_TOKEN';
+const REFERENCE_PLACEHOLDER_PREFIX = 'OCEAN_BRAIN_REFERENCE_';
+const REFERENCE_PLACEHOLDER_SUFFIX = '_TOKEN';
 
 const defaultMarkdownImportDeps: MarkdownImportDeps = {
     ensureTag: async (name) => ensureTagByName(name),
@@ -80,6 +86,28 @@ const defaultMarkdownImportDeps: MarkdownImportDeps = {
             id: String(note.id),
             title: note.title,
         }));
+    },
+    findNoteById: async (id) => {
+        if (!isValidNoteIdString(id)) {
+            return null;
+        }
+
+        const numericId = Number(id);
+
+        const note = await models.note.findUnique({
+            select: {
+                id: true,
+                title: true,
+            },
+            where: { id: numericId },
+        });
+
+        return note
+            ? {
+                  id: String(note.id),
+                  title: note.title,
+              }
+            : null;
     },
 };
 
@@ -114,6 +142,20 @@ function visitBlocks(blocks: BlockNote[], visit: (block: BlockNote) => void) {
 
 function createTagPlaceholder(index: number) {
     return `${TAG_PLACEHOLDER_PREFIX}${index}${TAG_PLACEHOLDER_SUFFIX}`;
+}
+
+function createReferencePlaceholder(index: number) {
+    return `${REFERENCE_PLACEHOLDER_PREFIX}${index}${REFERENCE_PLACEHOLDER_SUFFIX}`;
+}
+
+function isValidNoteIdString(id: string) {
+    if (!/^[1-9]\d*$/.test(id)) {
+        return false;
+    }
+
+    const numericId = Number(id);
+
+    return Number.isSafeInteger(numericId) && numericId <= MAX_SQLITE_INT_ID;
 }
 
 function isTableContent(content: BlockNoteContent | undefined): content is BlockNoteTableContent {
@@ -204,19 +246,6 @@ function mapBlocks(
     }));
 }
 
-async function mapBlocksAsync(
-    blocks: BlockNote[],
-    mapContent: (content: BlockNoteContent | undefined) => Promise<BlockNoteContent | undefined>,
-): Promise<BlockNote[]> {
-    return Promise.all(
-        blocks.map(async (block) => ({
-            ...block,
-            content: await mapContent(block.content),
-            children: block.children?.length ? await mapBlocksAsync(block.children, mapContent) : [],
-        })),
-    );
-}
-
 function preprocessCustomInlineContent(
     blocks: BlockNote[],
     placeholderToTag: Map<string, string>,
@@ -225,9 +254,12 @@ function preprocessCustomInlineContent(
     return mapBlocks(blocks, (content) =>
         mapBlockContent(content, (inline) => {
             if (inline.type === 'reference') {
+                const id = String(inline.props?.id || '');
+                const title = String(inline.props?.title || inline.props?.id || '');
+
                 return {
                     type: 'text',
-                    text: `[[${inline.props?.title || inline.props?.id || ''}]]`,
+                    text: isValidNoteIdString(id) ? `[[${title}]](note:${id})` : `[[${title}]]`,
                     styles: {},
                 };
             }
@@ -271,6 +303,77 @@ function preprocessMarkdownExplicitTags(markdown: string) {
     };
 }
 
+function preprocessMarkdownExplicitReferences(markdown: string) {
+    const placeholderToReference = new Map<string, { id: string; title: string; token: string }>();
+    let activeFence: { marker: '`' | '~'; length: number } | null = null;
+
+    const preprocessedLines = markdown.split(/(?<=\n)/).map((line) => {
+        const { body: lineBody, lineEnding } = splitMarkdownLineEnding(line);
+        const fenceMatch = lineBody.match(MARKDOWN_FENCED_CODE_PATTERN);
+
+        if (activeFence) {
+            if (isClosingFenceLine(lineBody, activeFence)) {
+                activeFence = null;
+            }
+
+            return line;
+        }
+
+        if (fenceMatch?.[1]) {
+            activeFence = {
+                marker: fenceMatch[1][0] as '`' | '~',
+                length: fenceMatch[1].length,
+            };
+            return line;
+        }
+
+        if (/^(?: {4,}|\t)/.test(lineBody)) {
+            return line;
+        }
+
+        return `${replaceMarkdownLineExplicitReferences(lineBody, placeholderToReference)}${lineEnding}`;
+    });
+
+    return {
+        markdown: preprocessedLines.join(''),
+        placeholderToReference,
+    };
+}
+
+function replaceMarkdownLineExplicitReferences(
+    line: string,
+    placeholderToReference: Map<string, { id: string; title: string; token: string }>,
+) {
+    let result = '';
+    let cursor = 0;
+
+    while (cursor < line.length) {
+        const codeSpan = findNextInlineCodeSpan(line, cursor);
+
+        if (!codeSpan) {
+            result += replaceExplicitReferenceTokens(line.slice(cursor), placeholderToReference);
+            break;
+        }
+
+        result += replaceExplicitReferenceTokens(line.slice(cursor, codeSpan.start), placeholderToReference);
+        result += line.slice(codeSpan.start, codeSpan.end);
+        cursor = codeSpan.end;
+    }
+
+    return result;
+}
+
+function replaceExplicitReferenceTokens(
+    text: string,
+    placeholderToReference: Map<string, { id: string; title: string; token: string }>,
+) {
+    return text.replace(/\[\[([^\]\n]+)\]\]\(note:([^)\s]+)\)/g, (token, title: string, id: string) => {
+        const placeholder = createReferencePlaceholder(placeholderToReference.size);
+        placeholderToReference.set(placeholder, { id, title, token });
+        return placeholder;
+    });
+}
+
 const MARKDOWN_ANGLE_BRACKET_TOKEN_PATTERN = /<([^<>\n]+)>/g;
 const MARKDOWN_NUMERIC_TILDE_RANGE_PATTERN = /(\d)~(?=\d)/g;
 const MARKDOWN_FENCED_CODE_PATTERN = /^ {0,3}(`{3,}|~{3,})/;
@@ -278,6 +381,7 @@ const ANGLE_BRACKET_PLACEHOLDER_PREFIX = '\uE000OBANGLE';
 const ANGLE_BRACKET_PLACEHOLDER_SUFFIX = '\uE001';
 const NUMERIC_TILDE_RANGE_PLACEHOLDER_PREFIX = '\uE000OBTILDE';
 const NUMERIC_TILDE_RANGE_PLACEHOLDER_SUFFIX = '\uE001';
+const MAX_SQLITE_INT_ID = 2_147_483_647;
 
 function isMarkdownAutolinkAngleBracketText(innerText: string) {
     if (innerText !== innerText.trim()) {
@@ -610,6 +714,23 @@ function findTagPlaceholderAtCursor(text: string, cursor: number, placeholderToT
     return null;
 }
 
+function findReferencePlaceholderAtCursor(
+    text: string,
+    cursor: number,
+    placeholderToReference: Map<string, { id: string; title: string; token: string }>,
+) {
+    for (const [placeholder, reference] of placeholderToReference.entries()) {
+        if (text.startsWith(placeholder, cursor)) {
+            return {
+                placeholder,
+                reference,
+            };
+        }
+    }
+
+    return null;
+}
+
 function restoreRemainingTagPlaceholders(blocks: BlockNote[], placeholderToTag: Map<string, string>): BlockNote[] {
     return mapBlocks(blocks, (content) =>
         mapBlockContent(content, (inline) => {
@@ -701,9 +822,11 @@ async function restoreCustomInlineContent(
     blocks: BlockNote[],
     deps: MarkdownImportDeps,
     placeholderToTag: Map<string, string>,
+    placeholderToReference: Map<string, { id: string; title: string; token: string }> = new Map(),
 ): Promise<BlockNote[]> {
     const tagCache = new Map<string, Promise<{ id: string; tag: string }>>();
     const noteCache = new Map<string, Promise<Array<{ id: string; title: string }>>>();
+    const noteByIdCache = new Map<string, Promise<{ id: string; title: string } | null>>();
 
     const getTag = (token: string) => {
         const normalizedToken = token.startsWith('#') ? `@${token.slice(1)}` : token;
@@ -731,6 +854,17 @@ async function restoreCustomInlineContent(
         return existing;
     };
 
+    const getNoteById = (id: string) => {
+        let existing = noteByIdCache.get(id);
+
+        if (!existing) {
+            existing = deps.findNoteById ? deps.findNoteById(id) : Promise.resolve(null);
+            noteByIdCache.set(id, existing);
+        }
+
+        return existing;
+    };
+
     const restoreTextInline = async (inline: BlockNoteInline): Promise<BlockNoteInline[]> => {
         if (inline.type !== 'text' || typeof inline.text !== 'string' || !inline.text || inline.styles?.code === true) {
             return [inline];
@@ -741,6 +875,37 @@ async function restoreCustomInlineContent(
         let cursor = 0;
 
         while (cursor < inline.text.length) {
+            const referencePlaceholderMatch = findReferencePlaceholderAtCursor(
+                inline.text,
+                cursor,
+                placeholderToReference,
+            );
+
+            if (referencePlaceholderMatch) {
+                if (!isValidNoteIdString(referencePlaceholderMatch.reference.id)) {
+                    appendInline(restored, createTextInline(referencePlaceholderMatch.reference.token, styles));
+                    cursor += referencePlaceholderMatch.placeholder.length;
+                    continue;
+                }
+
+                const note = await getNoteById(referencePlaceholderMatch.reference.id);
+
+                if (note) {
+                    appendInline(restored, {
+                        type: 'reference',
+                        props: {
+                            id: note.id,
+                            title: note.title,
+                        },
+                    });
+                } else {
+                    appendInline(restored, createTextInline(referencePlaceholderMatch.reference.token, styles));
+                }
+
+                cursor += referencePlaceholderMatch.placeholder.length;
+                continue;
+            }
+
             if (inline.text.startsWith('[[', cursor)) {
                 const closeIndex = inline.text.indexOf(']]', cursor + 2);
 
@@ -790,6 +955,14 @@ async function restoreCustomInlineContent(
                 }
             }
 
+            for (const placeholder of placeholderToReference.keys()) {
+                const nextPlaceholderCursor = inline.text.indexOf(placeholder, cursor + 1);
+
+                if (nextPlaceholderCursor !== -1) {
+                    nextCursor = Math.min(nextCursor, nextPlaceholderCursor);
+                }
+            }
+
             appendInline(restored, createTextInline(inline.text.slice(cursor, nextCursor), styles));
             cursor = nextCursor;
         }
@@ -797,7 +970,26 @@ async function restoreCustomInlineContent(
         return restored;
     };
 
-    return mapBlocksAsync(blocks, (content) => mapBlockContentAsync(content, restoreTextInline));
+    const restoreBlocks = async (items: BlockNote[]): Promise<BlockNote[]> => {
+        return Promise.all(
+            items.map(async (block) => {
+                if (block.type === 'codeBlock') {
+                    return {
+                        ...block,
+                        children: block.children?.length ? await restoreBlocks(block.children) : [],
+                    };
+                }
+
+                return {
+                    ...block,
+                    content: await mapBlockContentAsync(block.content, restoreTextInline),
+                    children: block.children?.length ? await restoreBlocks(block.children) : [],
+                };
+            }),
+        );
+    };
+
+    return restoreBlocks(blocks);
 }
 
 function collectTagIds(blocks: BlockNote[]): string[] {
@@ -852,20 +1044,27 @@ export async function markdownToBlocksJson(
 ): Promise<string> {
     const editor = getEditor();
     const preprocessedMarkdown = preprocessMarkdownExplicitTags(markdown);
-    const tildeProtectedMarkdown = protectMarkdownNumericTildeRanges(preprocessedMarkdown.markdown);
+    const preprocessedReferenceMarkdown = preprocessMarkdownExplicitReferences(preprocessedMarkdown.markdown);
+    const tildeProtectedMarkdown = protectMarkdownNumericTildeRanges(preprocessedReferenceMarkdown.markdown);
     const contentJson = await parseMarkdownToContentJson(
         editor,
         tildeProtectedMarkdown.markdown,
         deps,
         preprocessedMarkdown.placeholderToTag,
+        preprocessedReferenceMarkdown.placeholderToReference,
         tildeProtectedMarkdown.placeholderToToken,
     );
 
-    if (extractLiteralAngleBracketTextTokens(preprocessedMarkdown.markdown).length === 0) {
+    if (extractLiteralAngleBracketTextTokens(preprocessedReferenceMarkdown.markdown).length === 0) {
         return contentJson;
     }
 
-    if (!hasLiteralAngleBracketTextTokenLoss(preprocessedMarkdown.markdown, await blocksToMarkdown(contentJson))) {
+    if (
+        !hasLiteralAngleBracketTextTokenLoss(
+            preprocessedReferenceMarkdown.markdown,
+            await blocksToMarkdown(contentJson),
+        )
+    ) {
         return contentJson;
     }
 
@@ -880,6 +1079,7 @@ export async function markdownToBlocksJson(
         protectedMarkdown.markdown,
         deps,
         preprocessedMarkdown.placeholderToTag,
+        preprocessedReferenceMarkdown.placeholderToReference,
         placeholderToToken,
     );
 }
@@ -889,10 +1089,16 @@ async function parseMarkdownToContentJson(
     markdown: string,
     deps: MarkdownImportDeps,
     placeholderToTag: Map<string, string>,
+    placeholderToReference: Map<string, { id: string; title: string; token: string }> = new Map(),
     placeholderToProtectedTextToken: Map<string, string> = new Map(),
 ) {
     const blocks = await editor.tryParseMarkdownToBlocks(markdown);
-    const restoredBlocks = await restoreCustomInlineContent(blocks as BlockNote[], deps, placeholderToTag);
+    const restoredBlocks = await restoreCustomInlineContent(
+        blocks as BlockNote[],
+        deps,
+        placeholderToTag,
+        placeholderToReference,
+    );
     const restoredTagBlocks = restoreRemainingTagPlaceholders(restoredBlocks, placeholderToTag);
     const restoredProtectedTextBlocks = restoreProtectedTextPlaceholders(
         restoredTagBlocks,

--- a/packages/server/test/blocknote.test.ts
+++ b/packages/server/test/blocknote.test.ts
@@ -200,7 +200,7 @@ test('blocksToMarkdown serializes tags using explicit bracket syntax', async () 
     const markdown = await blocksToMarkdown(content);
 
     assert.match(markdown, /\[@project\]/);
-    assert.match(markdown, /\[\[Reference Note\]\]/);
+    assert.match(markdown, /\[\[Reference Note\]\]\(note:44\)/);
 });
 
 test('blocksToMarkdown serializes custom inline content inside table cells', async () => {
@@ -303,7 +303,147 @@ test('blocksToMarkdown serializes custom inline content inside table cells', asy
     const markdown = await blocksToMarkdown(content);
 
     assert.match(markdown, /\[@project\]/);
-    assert.match(markdown, /\[\[Reference Note\]\]/);
+    assert.match(markdown, /\[\[Reference Note\]\]\(note:44\)/);
+});
+
+test('markdownToBlocksJson restores note-id references with current note title', async () => {
+    const contentJson = await markdownToBlocksJson('See [[Old Title]](note:44)', {
+        ensureTag: async () => {
+            throw new Error('should not ensure tags');
+        },
+        findNotesByTitle: async () => {
+            throw new Error('should not look up title-based references');
+        },
+        findNoteById: async (id) =>
+            id === '44'
+                ? {
+                      id: '44',
+                      title: 'Current Title',
+                  }
+                : null,
+    });
+
+    const blocks = JSON.parse(contentJson);
+
+    assert.deepEqual(blocks[0].content, [
+        {
+            type: 'text',
+            text: 'See ',
+            styles: {},
+        },
+        {
+            type: 'reference',
+            props: {
+                id: '44',
+                title: 'Current Title',
+            },
+        },
+    ]);
+});
+
+test('markdownToBlocksJson leaves missing note-id references as text', async () => {
+    const contentJson = await markdownToBlocksJson('See [[Missing Title]](note:404)', {
+        ensureTag: async () => {
+            throw new Error('should not ensure tags');
+        },
+        findNotesByTitle: async () => {
+            throw new Error('should not look up title-based references');
+        },
+        findNoteById: async () => null,
+    });
+
+    const blocks = JSON.parse(contentJson);
+
+    assert.deepEqual(blocks[0].content, [
+        {
+            type: 'text',
+            text: 'See [[Missing Title]](note:404)',
+            styles: {},
+        },
+    ]);
+});
+
+test('markdownToBlocksJson preserves note-id reference syntax inside inline code', async () => {
+    const contentJson = await markdownToBlocksJson('Use `[[Old Title]](note:44)` as an example.', {
+        ensureTag: async () => {
+            throw new Error('should not ensure tags');
+        },
+        findNotesByTitle: async () => {
+            throw new Error('should not look up title-based references');
+        },
+        findNoteById: async () => {
+            throw new Error('should not look up references inside code');
+        },
+    });
+
+    const roundTripMarkdown = await blocksToMarkdown(contentJson);
+
+    assert.match(roundTripMarkdown, /`\[\[Old Title\]\]\(note:44\)`/);
+});
+
+test('markdownToBlocksJson preserves note-id reference syntax inside fenced code', async () => {
+    const markdown = '```md\n[[Old Title]](note:44)\n```';
+    const contentJson = await markdownToBlocksJson(markdown, {
+        ensureTag: async () => {
+            throw new Error('should not ensure tags');
+        },
+        findNotesByTitle: async () => {
+            throw new Error('should not look up title-based references');
+        },
+        findNoteById: async () => {
+            throw new Error('should not look up references inside code');
+        },
+    });
+
+    const roundTripMarkdown = await blocksToMarkdown(contentJson);
+
+    assert.match(roundTripMarkdown, /\[\[Old Title\]\]\(note:44\)/);
+});
+
+test('markdownToBlocksJson leaves malformed note-id references as text', async () => {
+    const contentJson = await markdownToBlocksJson('See [[Decimal]](note:1.5) and [[Huge]](note:9007199254740993)', {
+        ensureTag: async () => {
+            throw new Error('should not ensure tags');
+        },
+        findNotesByTitle: async () => {
+            throw new Error('should not look up title-based references');
+        },
+        findNoteById: async () => null,
+    });
+
+    const blocks = JSON.parse(contentJson);
+
+    assert.deepEqual(blocks[0].content, [
+        {
+            type: 'text',
+            text: 'See [[Decimal]](note:1.5) and [[Huge]](note:9007199254740993)',
+            styles: {},
+        },
+    ]);
+});
+
+test('blocksToMarkdown falls back to title-only references when reference ids are invalid', async () => {
+    const content = JSON.stringify([
+        {
+            id: 'paragraph-1',
+            type: 'paragraph',
+            props: {},
+            content: [
+                {
+                    type: 'reference',
+                    props: {
+                        title: 'Broken Reference',
+                    },
+                },
+            ],
+            children: [],
+        },
+    ]);
+
+    const markdown = await blocksToMarkdown(content);
+
+    assert.match(markdown, /\[\[Broken Reference\]\]/);
+    assert.doesNotMatch(markdown, /note:/);
 });
 
 test('markdownToBlocksJson restores custom tag and reference inline content from explicit @ tags', async () => {


### PR DESCRIPTION
## :dart: Goal
- Preserve Ocean Brain note links across title renames by supporting ID-backed wiki reference Markdown.
- Make structured note references round-trip through MCP Markdown as `[[title]](note:id)` while keeping existing `[[title]]` behavior compatible.
- Document the required release impact labels for future PRs.

## :hammer_and_wrench: Core Changes
- Serialize structured note references as `[[title]](note:id)` when converting BlockNote content to Markdown.
- Parse `[[title]](note:id)` back into structured reference inlines using the note ID and current note title.
- Keep missing or malformed `note:id` references as plain text instead of creating broken references.
- Preserve literal `[[title]](note:id)` text inside inline code and fenced code blocks.
- Lazily repair stored structured reference titles during note reads after target note renames.
- Add PR convention rules requiring exactly one `release: major`, `release: minor`, or `release: patch` label.

## :brain: Key Decisions
- Treat `note:id` as the source of truth when present; the visible title is display text only.
- Preserve existing title-based `[[title]]` imports for backward compatibility.
- Use strict positive integer validation before looking up note IDs to avoid failed imports from malformed reference syntax.
- Scope this PR to Markdown round-trip and structured reference title sync; rename dry-run warnings and ID-list write safety can follow separately.
- Mark this PR as `release: minor` because it adds backward-compatible user-visible Markdown/reference behavior.

## :test_tube: Verification Guide
### How to verify
1. Run `pnpm --filter @ocean-brain/server type-check`.
2. Run `pnpm --filter @ocean-brain/server lint`.
3. Run `pnpm --filter @ocean-brain/server test:ci`.
4. Run `pnpm build`.

### Expected result
- Server type-check passes.
- Server lint passes with no fixes required.
- Server test suite passes, including note-id reference Markdown, code block preservation, malformed ID fallback, and lazy title repair coverage.
- Client and server production builds complete successfully.

### Local result
- `pnpm --filter @ocean-brain/server type-check`: passed.
- `pnpm --filter @ocean-brain/server lint`: passed.
- `pnpm --filter @ocean-brain/server test:ci`: passed, 257 tests.
- `pnpm build`: passed.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Build completed
- [x] Documentation updated
- [x] Release impact label selected: `release: minor`
