### PR TITLE
✨ Add snapshot diff review

### DIFF
--- a/packages/client/src/apis/note.api.ts
+++ b/packages/client/src/apis/note.api.ts
@@ -537,6 +537,29 @@ export interface NoteSnapshotDetail extends NoteSnapshot {
     contentAsMarkdown: string;
 }
 
+export interface NoteSnapshotDiffEndpoint {
+    kind: 'snapshot' | 'current_note';
+    id: string;
+    title: string;
+    createdAt?: string;
+    updatedAt?: string;
+    meta?: NoteSnapshotMeta | null;
+}
+
+export interface NoteSnapshotDiff {
+    noteId: string;
+    mode: 'snapshot_to_snapshot' | 'snapshot_to_current';
+    before: NoteSnapshotDiffEndpoint;
+    after: NoteSnapshotDiffEndpoint;
+    diff: {
+        markdown: string;
+        changedLineCount: number;
+        changedCharCount: number;
+        beforeMarkdownSha256: string;
+        afterMarkdownSha256: string;
+    };
+}
+
 export interface TrashedNote {
     id: string;
     title: string;
@@ -634,6 +657,52 @@ export function fetchNoteSnapshot(id: string) {
             }
         }`,
         { id },
+    );
+}
+
+export function fetchNoteSnapshotDiff(id: string, target: 'next' | 'previous' | 'current' = 'current') {
+    return graphQuery<
+        {
+            noteSnapshotDiff: NoteSnapshotDiff | null;
+        },
+        { id: string; target: 'NEXT' | 'PREVIOUS' | 'CURRENT'; contextLines: number }
+    >(
+        `query FetchNoteSnapshotDiff($id: ID!, $target: NoteSnapshotDiffTarget, $contextLines: Int) {
+            noteSnapshotDiff(id: $id, target: $target, contextLines: $contextLines) {
+                noteId
+                mode
+                before {
+                    kind
+                    id
+                    title
+                    createdAt
+                    updatedAt
+                    meta {
+                        entrypoint
+                        label
+                    }
+                }
+                after {
+                    kind
+                    id
+                    title
+                    createdAt
+                    updatedAt
+                    meta {
+                        entrypoint
+                        label
+                    }
+                }
+                diff {
+                    markdown
+                    changedLineCount
+                    changedCharCount
+                    beforeMarkdownSha256
+                    afterMarkdownSha256
+                }
+            }
+        }`,
+        { id, target: target.toUpperCase() as 'NEXT' | 'PREVIOUS' | 'CURRENT', contextLines: 3 },
     );
 }
 

--- a/packages/client/src/components/note/RestoreSnapshotModal.spec.tsx
+++ b/packages/client/src/components/note/RestoreSnapshotModal.spec.tsx
@@ -3,13 +3,14 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { ComponentProps } from 'react';
 
-import { fetchNoteSnapshot, fetchNoteSnapshots, restoreNoteSnapshot } from '~/apis/note.api';
+import { fetchNoteSnapshot, fetchNoteSnapshotDiff, fetchNoteSnapshots, restoreNoteSnapshot } from '~/apis/note.api';
 import { ToastProvider } from '~/components/ui';
 import { createTestQueryClient } from '~/test/test-utils';
 import RestoreSnapshotModal from './RestoreSnapshotModal';
 
 vi.mock('~/apis/note.api', () => ({
     fetchNoteSnapshot: vi.fn(),
+    fetchNoteSnapshotDiff: vi.fn(),
     fetchNoteSnapshots: vi.fn(),
     restoreNoteSnapshot: vi.fn(),
 }));
@@ -53,6 +54,22 @@ describe('<RestoreSnapshotModal />', () => {
             type: 'success',
             noteSnapshot: snapshot,
         } as never);
+        vi.mocked(fetchNoteSnapshotDiff).mockResolvedValue({
+            type: 'success',
+            noteSnapshotDiff: {
+                noteId: '7',
+                mode: 'snapshot_to_current',
+                before: { kind: 'snapshot', id: 'snapshot-1', title: 'Project note before edit' },
+                after: { kind: 'current_note', id: '7', title: 'Current note' },
+                diff: {
+                    markdown: '--- before.md\n+++ after.md\n@@ -1 +1 @@\n-Old line\n+New line',
+                    changedLineCount: 1,
+                    changedCharCount: 16,
+                    beforeMarkdownSha256: 'before-hash',
+                    afterMarkdownSha256: 'after-hash',
+                },
+            },
+        } as never);
         vi.mocked(restoreNoteSnapshot).mockResolvedValue({
             type: 'success',
             restoreNoteSnapshot: {
@@ -66,6 +83,19 @@ describe('<RestoreSnapshotModal />', () => {
         } as never);
     });
 
+    it('shows a git-style snapshot diff', async () => {
+        const user = userEvent.setup();
+
+        renderModal();
+
+        await user.click(await screen.findByRole('button', { name: /compare/i }));
+
+        expect(screen.getByRole('dialog', { name: 'Snapshot Diff' })).toBeInTheDocument();
+        await waitFor(() => expect(fetchNoteSnapshotDiff).toHaveBeenCalledWith('snapshot-1', 'current'));
+        expect(await screen.findByText('-Old line')).toBeInTheDocument();
+        expect(screen.getByText('+New line')).toBeInTheDocument();
+    });
+
     it('shows snapshot content before restoring', async () => {
         const user = userEvent.setup();
 
@@ -73,19 +103,22 @@ describe('<RestoreSnapshotModal />', () => {
 
         expect(await screen.findByText('First paragraph preview.')).toBeInTheDocument();
 
+        await user.click(screen.getByRole('button', { name: /compare/i }));
+        expect(screen.getByRole('button', { name: /^back$/i })).toHaveFocus();
+
         await user.click(screen.getByRole('button', { name: /view content/i }));
 
         expect(screen.getByRole('dialog', { name: 'Snapshot Content' })).toBeInTheDocument();
         await waitFor(() => expect(fetchNoteSnapshot).toHaveBeenCalledWith('snapshot-1'));
         expect(await screen.findByText(/Second paragraph with details/)).toBeInTheDocument();
-        expect(screen.getByRole('button', { name: /^back$/i })).toHaveFocus();
     });
 
     it('restores from the content preview screen', async () => {
         const user = userEvent.setup();
         const { onClose, onRestored } = renderModal();
 
-        await user.click(await screen.findByRole('button', { name: /view content/i }));
+        await user.click(await screen.findByRole('button', { name: /compare/i }));
+        await user.click(screen.getByRole('button', { name: /view content/i }));
         await user.click(screen.getByRole('button', { name: /restore this version/i }));
 
         await waitFor(() => expect(restoreNoteSnapshot).toHaveBeenCalledWith('snapshot-1', expect.anything()));

--- a/packages/client/src/components/note/RestoreSnapshotModal.tsx
+++ b/packages/client/src/components/note/RestoreSnapshotModal.tsx
@@ -2,7 +2,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import dayjs from 'dayjs';
 import { useEffect, useRef, useState } from 'react';
 
-import { fetchNoteSnapshot, fetchNoteSnapshots, restoreNoteSnapshot } from '~/apis/note.api';
+import { fetchNoteSnapshot, fetchNoteSnapshotDiff, fetchNoteSnapshots, restoreNoteSnapshot } from '~/apis/note.api';
 import { Button, Modal, ModalActionRow, SurfaceCard } from '~/components/shared';
 import { Text, useToast } from '~/components/ui';
 import type { Note } from '~/models/note.model';
@@ -35,6 +35,7 @@ export default function RestoreSnapshotModal({ isOpen, noteId, onClose, onRestor
     const toast = useToast();
     const queryClient = useQueryClient();
     const [selectedSnapshotId, setSelectedSnapshotId] = useState<string | null>(null);
+    const [selectedSnapshotView, setSelectedSnapshotView] = useState<'diff' | 'content'>('diff');
     const backButtonRef = useRef<HTMLButtonElement>(null);
 
     const snapshotQuery = useQuery({
@@ -108,6 +109,26 @@ export default function RestoreSnapshotModal({ isOpen, noteId, onClose, onRestor
     });
 
     const selectedSnapshot = snapshotQuery.data?.find((snapshot) => snapshot.id === selectedSnapshotId) ?? null;
+    const selectedSnapshotDiffQuery = useQuery({
+        queryKey: [...queryKeys.notes.snapshotDetail(selectedSnapshotId ?? 'pending'), 'diff'],
+        queryFn: async () => {
+            if (!selectedSnapshotId) {
+                throw new Error('SNAPSHOT_NOT_SELECTED');
+            }
+
+            const response = await fetchNoteSnapshotDiff(selectedSnapshotId, 'current');
+            if (response.type === 'error') {
+                throw response;
+            }
+
+            if (!response.noteSnapshotDiff) {
+                throw new Error('SNAPSHOT_DIFF_NOT_FOUND');
+            }
+
+            return response.noteSnapshotDiff;
+        },
+        enabled: Boolean(selectedSnapshotId) && selectedSnapshotView === 'diff',
+    });
     const selectedSnapshotQuery = useQuery({
         queryKey: queryKeys.notes.snapshotDetail(selectedSnapshotId ?? 'pending'),
         queryFn: async () => {
@@ -126,7 +147,7 @@ export default function RestoreSnapshotModal({ isOpen, noteId, onClose, onRestor
 
             return response.noteSnapshot;
         },
-        enabled: Boolean(selectedSnapshotId),
+        enabled: Boolean(selectedSnapshotId) && selectedSnapshotView === 'content',
     });
     const selectedSnapshotContent = selectedSnapshotQuery.data?.contentAsMarkdown.trim() ?? '';
 
@@ -136,20 +157,34 @@ export default function RestoreSnapshotModal({ isOpen, noteId, onClose, onRestor
         }
     }, [selectedSnapshotId]);
 
+    const openSnapshot = (id: string, view: 'diff' | 'content') => {
+        setSelectedSnapshotView(view);
+        setSelectedSnapshotId(id);
+    };
+
     const handleClose = () => {
         setSelectedSnapshotId(null);
+        setSelectedSnapshotView('diff');
         onClose();
     };
 
     return (
         <Modal isOpen={isOpen} onClose={handleClose} variant="inspect">
             <Modal.Header
-                title={selectedSnapshot ? 'Snapshot Content' : 'Restore Previous Version'}
+                title={
+                    selectedSnapshot
+                        ? selectedSnapshotView === 'diff'
+                            ? 'Snapshot Diff'
+                            : 'Snapshot Content'
+                        : 'Restore Previous Version'
+                }
                 onClose={handleClose}
             />
             <Modal.Description className="sr-only">
                 {selectedSnapshot
-                    ? 'Read this snapshot content before restoring it.'
+                    ? selectedSnapshotView === 'diff'
+                        ? 'Review the markdown diff between this snapshot and the current note.'
+                        : 'Read this snapshot content before restoring it.'
                     : 'Choose a previous snapshot to restore.'}
             </Modal.Description>
             <Modal.Body>
@@ -165,7 +200,71 @@ export default function RestoreSnapshotModal({ isOpen, noteId, onClose, onRestor
                                 edit - {dayjs(selectedSnapshot.createdAt).format('YYYY-MM-DD HH:mm:ss')}
                             </Text>
                         </div>
-                        {selectedSnapshotQuery.isLoading ? (
+                        <div className="flex flex-wrap gap-2">
+                            <Button
+                                variant={selectedSnapshotView === 'diff' ? 'primary' : 'subtle'}
+                                size="sm"
+                                onClick={() => setSelectedSnapshotView('diff')}
+                            >
+                                Show diff
+                            </Button>
+                            <Button
+                                variant={selectedSnapshotView === 'content' ? 'primary' : 'subtle'}
+                                size="sm"
+                                onClick={() => setSelectedSnapshotView('content')}
+                            >
+                                View content
+                            </Button>
+                        </div>
+                        {selectedSnapshotView === 'diff' ? (
+                            selectedSnapshotDiffQuery.isLoading ? (
+                                <Text
+                                    as="p"
+                                    variant="meta"
+                                    tone="secondary"
+                                    className="rounded-[14px] border border-border-subtle bg-hover-subtle/50 px-4 py-3"
+                                >
+                                    Loading snapshot diff...
+                                </Text>
+                            ) : selectedSnapshotDiffQuery.isError ? (
+                                <Text
+                                    as="p"
+                                    variant="meta"
+                                    tone="secondary"
+                                    className="rounded-[14px] border border-border-subtle bg-hover-subtle/50 px-4 py-3"
+                                >
+                                    Snapshot diff could not be loaded.
+                                </Text>
+                            ) : selectedSnapshotDiffQuery.data ? (
+                                <div className="flex flex-col gap-2">
+                                    <Text as="p" variant="meta" tone="secondary">
+                                        Changes from this snapshot to the current note. Red lines were in the snapshot;
+                                        green lines are in the current note.
+                                    </Text>
+                                    <pre className="max-h-[60vh] overflow-y-auto overflow-x-hidden whitespace-pre-wrap break-words rounded-[14px] border border-border-subtle bg-hover-subtle/50 px-0 py-3 text-xs leading-5 text-fg-secondary">
+                                        {selectedSnapshotDiffQuery.data.diff.markdown.split('\n').map((line, index) => {
+                                            const tone =
+                                                line.startsWith('+') && !line.startsWith('+++')
+                                                    ? 'bg-emerald-500/12 text-emerald-700 dark:text-emerald-200'
+                                                    : line.startsWith('-') && !line.startsWith('---')
+                                                      ? 'bg-rose-500/12 text-rose-700 dark:text-rose-200'
+                                                      : line.startsWith('@@')
+                                                        ? 'bg-sky-500/12 text-sky-700 dark:text-sky-200'
+                                                        : 'text-fg-secondary';
+
+                                            return (
+                                                <span
+                                                    key={`${index}-${line}`}
+                                                    className={`block min-w-full whitespace-pre-wrap break-words px-4 ${tone}`}
+                                                >
+                                                    {line || ' '}
+                                                </span>
+                                            );
+                                        })}
+                                    </pre>
+                                </div>
+                            ) : null
+                        ) : selectedSnapshotQuery.isLoading ? (
                             <Text
                                 as="p"
                                 variant="meta"
@@ -223,48 +322,53 @@ export default function RestoreSnapshotModal({ isOpen, noteId, onClose, onRestor
                             <div className="flex flex-col gap-2">
                                 {snapshotQuery.data.map((snapshot) => (
                                     <SurfaceCard key={snapshot.id} padding="compact">
-                                        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                                            <div className="min-w-0">
-                                                <Text as="p" variant="body" weight="semibold">
-                                                    Before{' '}
-                                                    {formatSnapshotLabel(snapshot.meta.label, snapshot.meta.entrypoint)}{' '}
-                                                    edit
-                                                </Text>
-                                                <Text as="p" variant="meta" truncate tone="secondary">
-                                                    {snapshot.title}
-                                                </Text>
-                                                <Text as="p" variant="label" tone="tertiary">
-                                                    {dayjs(snapshot.createdAt).format('YYYY-MM-DD HH:mm:ss')}
-                                                </Text>
-                                                {snapshot.contentPreview && (
-                                                    <div className="mt-3 rounded-[14px] border border-border-subtle bg-hover-subtle/50 px-3 py-2">
-                                                        <Text
-                                                            as="p"
-                                                            variant="meta"
-                                                            tone="secondary"
-                                                            className="line-clamp-4 whitespace-pre-wrap break-words"
-                                                        >
-                                                            {snapshot.contentPreview}
-                                                        </Text>
-                                                    </div>
-                                                )}
+                                        <div className="flex flex-col gap-3">
+                                            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                                                <div className="min-w-0">
+                                                    <Text as="p" variant="body" weight="semibold">
+                                                        Before{' '}
+                                                        {formatSnapshotLabel(
+                                                            snapshot.meta.label,
+                                                            snapshot.meta.entrypoint,
+                                                        )}{' '}
+                                                        edit
+                                                    </Text>
+                                                    <Text as="p" variant="meta" truncate tone="secondary">
+                                                        {snapshot.title}
+                                                    </Text>
+                                                    <Text as="p" variant="label" tone="tertiary">
+                                                        {dayjs(snapshot.createdAt).format('YYYY-MM-DD HH:mm:ss')}
+                                                    </Text>
+                                                </div>
+                                                <div className="flex shrink-0 flex-wrap gap-2 sm:justify-end">
+                                                    <Button
+                                                        variant="subtle"
+                                                        size="sm"
+                                                        onClick={() => openSnapshot(snapshot.id, 'diff')}
+                                                    >
+                                                        Compare
+                                                    </Button>
+                                                    <Button
+                                                        size="sm"
+                                                        isLoading={restoreMutation.isPending}
+                                                        onClick={() => restoreMutation.mutate(snapshot.id)}
+                                                    >
+                                                        Restore
+                                                    </Button>
+                                                </div>
                                             </div>
-                                            <div className="flex shrink-0 flex-wrap gap-2 sm:justify-end">
-                                                <Button
-                                                    variant="subtle"
-                                                    size="sm"
-                                                    onClick={() => setSelectedSnapshotId(snapshot.id)}
-                                                >
-                                                    View content
-                                                </Button>
-                                                <Button
-                                                    size="sm"
-                                                    isLoading={restoreMutation.isPending}
-                                                    onClick={() => restoreMutation.mutate(snapshot.id)}
-                                                >
-                                                    Restore
-                                                </Button>
-                                            </div>
+                                            {snapshot.contentPreview && (
+                                                <div className="rounded-[14px] border border-border-subtle bg-hover-subtle/50 px-3 py-2">
+                                                    <Text
+                                                        as="p"
+                                                        variant="meta"
+                                                        tone="secondary"
+                                                        className="line-clamp-4 whitespace-pre-wrap break-words"
+                                                    >
+                                                        {snapshot.contentPreview}
+                                                    </Text>
+                                                </div>
+                                            )}
                                         </div>
                                     </SurfaceCard>
                                 ))}
@@ -276,11 +380,17 @@ export default function RestoreSnapshotModal({ isOpen, noteId, onClose, onRestor
             {selectedSnapshot && (
                 <Modal.Footer>
                     <ModalActionRow>
-                        <Button ref={backButtonRef} variant="subtle" onClick={() => setSelectedSnapshotId(null)}>
+                        <Button
+                            ref={backButtonRef}
+                            variant="subtle"
+                            onClick={() => {
+                                setSelectedSnapshotId(null);
+                                setSelectedSnapshotView('diff');
+                            }}
+                        >
                             Back
                         </Button>
                         <Button
-                            disabled={!selectedSnapshotQuery.data || selectedSnapshotQuery.isError}
                             isLoading={restoreMutation.isPending}
                             onClick={() => restoreMutation.mutate(selectedSnapshot.id)}
                         >

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -20,6 +20,7 @@
         "@graphql-tools/schema": "^10.0.31",
         "@graphql-tools/utils": "^11.0.0",
         "@prisma/client": "^6.19.3",
+        "diff": "^9.0.0",
         "express": "^5.2.1",
         "express-rate-limit": "8.5.1",
         "express-session": "^1.19.0",

--- a/packages/server/src/features/note/graphql/note.query.resolver.ts
+++ b/packages/server/src/features/note/graphql/note.query.resolver.ts
@@ -14,7 +14,7 @@ import {
     NOTE_SEARCH_TEXT_SCHEMA_VERSION,
     parseNoteSearchQuery,
 } from '~/features/note/services/search.js';
-import { getNoteSnapshot, listNoteSnapshots } from '~/features/note/services/snapshot.js';
+import { diffNoteSnapshot, getNoteSnapshot, listNoteSnapshots } from '~/features/note/services/snapshot.js';
 import {
     buildNoteTagNamesWhere,
     type NoteTagMatchMode,
@@ -495,6 +495,32 @@ export const noteQueryResolvers: NoteQueryResolvers = {
     },
     noteSnapshot: async (_, { id }: { id: string }) => {
         return getNoteSnapshot(Number(id));
+    },
+    noteSnapshotDiff: async (
+        _,
+        {
+            id,
+            compareToSnapshotId,
+            target,
+            contextLines,
+        }: {
+            id: string;
+            compareToSnapshotId?: string;
+            target?: 'NEXT' | 'PREVIOUS' | 'CURRENT';
+            contextLines?: number | null;
+        },
+    ) => {
+        const normalizedContextLines = contextLines ?? 3;
+
+        if (normalizedContextLines < 0 || normalizedContextLines > 20) {
+            throw new Error('INVALID_SNAPSHOT_DIFF_CONTEXT_LINES');
+        }
+
+        return diffNoteSnapshot(Number(id), {
+            ...(compareToSnapshotId !== undefined ? { compareToSnapshotId: Number(compareToSnapshotId) } : {}),
+            ...(target !== undefined ? { target: target.toLowerCase() as 'next' | 'previous' | 'current' } : {}),
+            contextLines: normalizedContextLines,
+        });
     },
     notePropertyKeys: async (
         _,

--- a/packages/server/src/features/note/graphql/note.type-defs.ts
+++ b/packages/server/src/features/note/graphql/note.type-defs.ts
@@ -200,6 +200,37 @@ export const noteType = gql`
         meta: NoteSnapshotMeta!
     }
 
+    enum NoteSnapshotDiffTarget {
+        NEXT
+        PREVIOUS
+        CURRENT
+    }
+
+    type NoteSnapshotDiffEndpoint {
+        kind: String!
+        id: ID!
+        title: String!
+        createdAt: String
+        updatedAt: String
+        meta: NoteSnapshotMeta
+    }
+
+    type NoteSnapshotDiffDetail {
+        markdown: String!
+        changedLineCount: Int!
+        changedCharCount: Int!
+        beforeMarkdownSha256: String!
+        afterMarkdownSha256: String!
+    }
+
+    type NoteSnapshotDiff {
+        noteId: ID!
+        mode: String!
+        before: NoteSnapshotDiffEndpoint!
+        after: NoteSnapshotDiffEndpoint!
+        diff: NoteSnapshotDiffDetail!
+    }
+
     type DeletedNote {
         id: ID!
         title: String!
@@ -250,6 +281,7 @@ export const noteQuery = gql`
         noteCleanupPreview(id: ID!): NoteCleanupPreview
         noteSnapshots(id: ID!, limit: Int): [NoteSnapshot!]!
         noteSnapshot(id: ID!): NoteSnapshot
+        noteSnapshotDiff(id: ID!, compareToSnapshotId: ID, target: NoteSnapshotDiffTarget, contextLines: Int): NoteSnapshotDiff
         notePropertyKeys(query: String, pagination: PaginationInput): NotePropertyKeys!
         trashedNote(id: ID!): DeletedNote
         trashedNotes(pagination: PaginationInput): DeletedNotes!

--- a/packages/server/src/features/note/services/snapshot.test.ts
+++ b/packages/server/src/features/note/services/snapshot.test.ts
@@ -775,3 +775,202 @@ test('getSnapshot returns full markdown content for one snapshot', async () => {
     assert.match(snapshot?.contentAsMarkdown ?? '', /Full snapshot body/);
     assert.match(snapshot?.contentPreview ?? '', /Full snapshot body/);
 });
+
+test('diffSnapshot compares a write baseline snapshot to the next snapshot', async () => {
+    const firstContent = JSON.stringify([
+        {
+            type: 'paragraph',
+            content: [{ type: 'text', text: 'Before body', styles: {} }],
+        },
+    ]);
+    const secondContent = JSON.stringify([
+        {
+            type: 'paragraph',
+            content: [{ type: 'text', text: 'After body', styles: {} }],
+        },
+    ]);
+    const snapshots = [
+        {
+            id: 1,
+            noteId: 7,
+            title: 'Before title',
+            payload: JSON.stringify({
+                title: 'Before title',
+                content: firstContent,
+                pinned: false,
+                order: 0,
+                layout: 'wide',
+            }),
+            editSessionId: null,
+            meta: '{"label":"MCP"}',
+            createdAt: new Date('2026-03-31T00:00:00.000Z'),
+        },
+        {
+            id: 2,
+            noteId: 7,
+            title: 'After title',
+            payload: JSON.stringify({
+                title: 'After title',
+                content: secondContent,
+                pinned: false,
+                order: 0,
+                layout: 'wide',
+            }),
+            editSessionId: null,
+            meta: '{"label":"MCP"}',
+            createdAt: new Date('2026-03-31T00:01:00.000Z'),
+        },
+    ];
+    const service = createNoteSnapshotService({
+        findNoteById: async () => null,
+        findSnapshotByEditSessionId: async () => null,
+        findLatestSnapshot: async () => null,
+        createSnapshot: async () => {
+            throw new Error('should not create');
+        },
+        purgeExpiredSnapshots: async () => 0,
+        trimOverflowSnapshots: async () => 0,
+        listSnapshots: async () => snapshots,
+        findSnapshotById: async (id) => snapshots.find((snapshot) => snapshot.id === id) ?? null,
+        findNextSnapshot: async (snapshot) => snapshots.find((candidate) => candidate.id > snapshot.id) ?? null,
+        updateNote: async () => {
+            throw new Error('should not update');
+        },
+    });
+
+    const diff = await service.diffSnapshot(1);
+
+    assert.equal(diff?.mode, 'snapshot_to_snapshot');
+    assert.equal(diff?.before.id, '1');
+    assert.equal(diff?.after.id, '2');
+    assert.match(diff?.diff.markdown ?? '', /Before body/);
+    assert.match(diff?.diff.markdown ?? '', /After body/);
+    assert.equal(diff?.diff.changedLineCount, 2);
+});
+
+test('diffSnapshot compares the latest snapshot to the current note when no next snapshot exists', async () => {
+    const snapshotContent = JSON.stringify([
+        {
+            type: 'paragraph',
+            content: [{ type: 'text', text: 'Snapshot body', styles: {} }],
+        },
+    ]);
+    const currentContent = JSON.stringify([
+        {
+            type: 'paragraph',
+            content: [{ type: 'text', text: 'Current body', styles: {} }],
+        },
+    ]);
+    const snapshot = {
+        id: 3,
+        noteId: 7,
+        title: 'Snapshot title',
+        payload: JSON.stringify({
+            title: 'Snapshot title',
+            content: snapshotContent,
+            pinned: false,
+            order: 0,
+            layout: 'wide',
+        }),
+        editSessionId: null,
+        meta: null,
+        createdAt: new Date('2026-03-31T00:00:00.000Z'),
+    };
+    const service = createNoteSnapshotService({
+        findNoteById: async () => ({
+            id: 7,
+            title: 'Current title',
+            content: currentContent,
+            pinned: false,
+            order: 0,
+            layout: 'wide',
+            updatedAt: new Date('2026-03-31T00:02:00.000Z'),
+        }),
+        findSnapshotByEditSessionId: async () => null,
+        findLatestSnapshot: async () => null,
+        createSnapshot: async () => {
+            throw new Error('should not create');
+        },
+        purgeExpiredSnapshots: async () => 0,
+        trimOverflowSnapshots: async () => 0,
+        listSnapshots: async () => [snapshot],
+        findSnapshotById: async () => snapshot,
+        findNextSnapshot: async () => null,
+        updateNote: async () => {
+            throw new Error('should not update');
+        },
+    });
+
+    const diff = await service.diffSnapshot(3);
+
+    assert.equal(diff?.mode, 'snapshot_to_current');
+    assert.equal(diff?.after.kind, 'current_note');
+    assert.match(diff?.diff.markdown ?? '', /Snapshot body/);
+    assert.match(diff?.diff.markdown ?? '', /Current body/);
+});
+
+test('diffSnapshot renders separate hunks for distant changes', async () => {
+    const toContent = (...lines: string[]) =>
+        JSON.stringify(
+            lines.map((line) => ({
+                type: 'paragraph',
+                content: [{ type: 'text', text: line, styles: {} }],
+            })),
+        );
+    const snapshots = [
+        {
+            id: 10,
+            noteId: 7,
+            title: 'Before title',
+            payload: JSON.stringify({
+                title: 'Before title',
+                content: toContent('Top old', 'same 1', 'same 2', 'same 3', 'same 4', 'Bottom old'),
+                pinned: false,
+                order: 0,
+                layout: 'wide',
+            }),
+            editSessionId: null,
+            meta: null,
+            createdAt: new Date('2026-03-31T00:00:00.000Z'),
+        },
+        {
+            id: 11,
+            noteId: 7,
+            title: 'After title',
+            payload: JSON.stringify({
+                title: 'After title',
+                content: toContent('Top new', 'same 1', 'same 2', 'same 3', 'same 4', 'Bottom new'),
+                pinned: false,
+                order: 0,
+                layout: 'wide',
+            }),
+            editSessionId: null,
+            meta: null,
+            createdAt: new Date('2026-03-31T00:01:00.000Z'),
+        },
+    ];
+    const service = createNoteSnapshotService({
+        findNoteById: async () => null,
+        findSnapshotByEditSessionId: async () => null,
+        findLatestSnapshot: async () => null,
+        createSnapshot: async () => {
+            throw new Error('should not create');
+        },
+        purgeExpiredSnapshots: async () => 0,
+        trimOverflowSnapshots: async () => 0,
+        listSnapshots: async () => snapshots,
+        findSnapshotById: async (id) => snapshots.find((snapshot) => snapshot.id === id) ?? null,
+        findNextSnapshot: async (snapshot) => snapshots.find((candidate) => candidate.id > snapshot.id) ?? null,
+        updateNote: async () => {
+            throw new Error('should not update');
+        },
+    });
+
+    const diff = await service.diffSnapshot(10, { contextLines: 1 });
+    const hunkCount = diff?.diff.markdown.split('\n').filter((line) => line.startsWith('@@')).length;
+
+    assert.equal(hunkCount, 2);
+    assert.match(diff?.diff.markdown ?? '', /Top old/);
+    assert.match(diff?.diff.markdown ?? '', /Bottom new/);
+    assert.doesNotMatch(diff?.diff.markdown ?? '', /same 2/);
+});

--- a/packages/server/src/features/note/services/snapshot.ts
+++ b/packages/server/src/features/note/services/snapshot.ts
@@ -1,3 +1,4 @@
+import { FILE_HEADERS_ONLY, formatPatch, structuredPatch } from 'diff';
 import { ensureTagByName } from '~/features/tag/services/organization.js';
 import models, { type NoteLayout, type PropertyValueType } from '~/models.js';
 import { blocksToMarkdown, extractTagIdsFromContentJson } from '~/modules/blocknote.js';
@@ -8,6 +9,7 @@ import {
     SNAPSHOT_MAX_PER_NOTE,
     SNAPSHOT_RETENTION_DAYS,
 } from '~/modules/recovery-retention.js';
+import { calculateMarkdownSha256 } from './markdown-patch.js';
 import { buildNoteSearchProjection, extractVisibleSearchTextFromContent } from './search.js';
 
 const SNAPSHOT_CONTENT_PREVIEW_MAX_LENGTH = 240;
@@ -60,6 +62,8 @@ interface NoteSnapshotDeps {
     }) => Promise<NoteSnapshotRecord>;
     listSnapshots: (noteId: number, limit: number) => Promise<NoteSnapshotRecord[]>;
     findSnapshotById: (id: number) => Promise<NoteSnapshotRecord | null>;
+    findNextSnapshot?: (snapshot: NoteSnapshotRecord) => Promise<NoteSnapshotRecord | null>;
+    findPreviousSnapshot?: (snapshot: NoteSnapshotRecord) => Promise<NoteSnapshotRecord | null>;
     purgeExpiredSnapshots: (before: Date, limit: number) => Promise<number>;
     trimOverflowSnapshots: (noteId: number, keep: number, limit: number) => Promise<number>;
     resolveRestoredTags?: (content: string) => Promise<ResolvedRestoredSnapshotTags | null>;
@@ -116,6 +120,31 @@ export interface NoteSnapshotSummary {
     payload?: string;
 }
 
+export type NoteSnapshotDiffTarget = 'next' | 'previous' | 'current';
+
+export interface NoteSnapshotDiffEndpoint {
+    kind: 'snapshot' | 'current_note';
+    id: string;
+    title: string;
+    createdAt?: string;
+    updatedAt?: string;
+    meta?: NoteSnapshotMeta;
+}
+
+export interface NoteSnapshotDiffResult {
+    noteId: string;
+    mode: 'snapshot_to_snapshot' | 'snapshot_to_current';
+    before: NoteSnapshotDiffEndpoint;
+    after: NoteSnapshotDiffEndpoint;
+    diff: {
+        markdown: string;
+        changedLineCount: number;
+        changedCharCount: number;
+        beforeMarkdownSha256: string;
+        afterMarkdownSha256: string;
+    };
+}
+
 const parseMeta = (value?: string | null): NoteSnapshotMeta => {
     if (!value) {
         return {};
@@ -137,6 +166,14 @@ const readSnapshotContent = (payload: string) => {
         return parsePayload(payload).content;
     } catch {
         return '';
+    }
+};
+
+const readSnapshotTitle = (payload: string, fallback: string) => {
+    try {
+        return parsePayload(payload).title;
+    } catch {
+        return fallback;
     }
 };
 
@@ -316,6 +353,82 @@ export const renderNoteSnapshotContentAsMarkdown = async (payload: string) => {
     }
 };
 
+const renderNoteRecordContentAsMarkdown = async (note: NoteRecord) => {
+    try {
+        return blocksToMarkdown(note.content);
+    } catch {
+        return '';
+    }
+};
+
+const createSnapshotMarkdownDiff = (beforeMarkdown: string, afterMarkdown: string, contextLines: number | null = 3) => {
+    const patch = structuredPatch('before.md', 'after.md', beforeMarkdown, afterMarkdown, undefined, undefined, {
+        context: contextLines === null ? Number.MAX_SAFE_INTEGER : contextLines,
+    });
+    const changedLines = patch.hunks.flatMap((hunk) =>
+        hunk.lines.filter((line) => (line.startsWith('+') && !line.startsWith('+++')) || line.startsWith('-')),
+    );
+
+    return {
+        markdown: formatPatch(patch, FILE_HEADERS_ONLY).trimEnd(),
+        changedLineCount: changedLines.length,
+        changedCharCount: changedLines.reduce((total, line) => total + line.slice(1).length, 0),
+    };
+};
+
+const snapshotToDiffEndpoint = (snapshot: NoteSnapshotRecord): NoteSnapshotDiffEndpoint => ({
+    kind: 'snapshot',
+    id: String(snapshot.id),
+    title: readSnapshotTitle(snapshot.payload, snapshot.title),
+    createdAt: snapshot.createdAt.toISOString(),
+    meta: parseMeta(snapshot.meta),
+});
+
+const noteToDiffEndpoint = (note: NoteRecord): NoteSnapshotDiffEndpoint => ({
+    kind: 'current_note',
+    id: String(note.id),
+    title: note.title,
+    ...(note.updatedAt ? { updatedAt: note.updatedAt.toISOString() } : {}),
+});
+
+const buildSnapshotDiff = async ({
+    beforeSnapshot,
+    afterSnapshot,
+    afterNote,
+    contextLines,
+}: {
+    beforeSnapshot: NoteSnapshotRecord;
+    afterSnapshot?: NoteSnapshotRecord;
+    afterNote?: NoteRecord;
+    contextLines?: number | null;
+}): Promise<NoteSnapshotDiffResult | null> => {
+    if (!afterSnapshot && !afterNote) {
+        return null;
+    }
+
+    const beforeMarkdown = await renderNoteSnapshotContentAsMarkdown(beforeSnapshot.payload);
+    const afterMarkdown = afterSnapshot
+        ? await renderNoteSnapshotContentAsMarkdown(afterSnapshot.payload)
+        : afterNote
+          ? await renderNoteRecordContentAsMarkdown(afterNote)
+          : '';
+    const diff = createSnapshotMarkdownDiff(beforeMarkdown, afterMarkdown, contextLines ?? 3);
+
+    return {
+        noteId: String(beforeSnapshot.noteId),
+        mode: afterSnapshot ? 'snapshot_to_snapshot' : 'snapshot_to_current',
+        before: snapshotToDiffEndpoint(beforeSnapshot),
+        after: afterSnapshot ? snapshotToDiffEndpoint(afterSnapshot) : noteToDiffEndpoint(afterNote as NoteRecord),
+        diff: {
+            markdown: diff.markdown,
+            changedLineCount: diff.changedLineCount,
+            changedCharCount: diff.changedCharCount,
+            beforeMarkdownSha256: calculateMarkdownSha256(beforeMarkdown),
+            afterMarkdownSha256: calculateMarkdownSha256(afterMarkdown),
+        },
+    };
+};
+
 const serializeSnapshotWithContent = async (snapshot: NoteSnapshotRecord): Promise<NoteSnapshotSummary> => {
     const contentAsMarkdown = await renderNoteSnapshotContentAsMarkdown(snapshot.payload);
 
@@ -440,6 +553,86 @@ export const createNoteSnapshotService = (deps: NoteSnapshotDeps) => ({
         }
 
         return serializeSnapshotWithContent(snapshot);
+    },
+
+    diffSnapshot: async (
+        snapshotId: number,
+        options: {
+            compareToSnapshotId?: number;
+            target?: NoteSnapshotDiffTarget;
+            contextLines?: number | null;
+        } = {},
+    ) => {
+        await deps.purgeExpiredSnapshots(createRetentionCutoff(SNAPSHOT_RETENTION_DAYS), RECOVERY_CLEANUP_BATCH_LIMIT);
+        const snapshot = await deps.findSnapshotById(snapshotId);
+
+        if (!snapshot) {
+            return null;
+        }
+
+        if (options.compareToSnapshotId !== undefined) {
+            const comparedSnapshot = await deps.findSnapshotById(options.compareToSnapshotId);
+
+            if (!comparedSnapshot || comparedSnapshot.noteId !== snapshot.noteId) {
+                return null;
+            }
+
+            return buildSnapshotDiff({
+                beforeSnapshot: snapshot,
+                afterSnapshot: comparedSnapshot,
+                contextLines: options.contextLines,
+            });
+        }
+
+        if (options.target === 'previous') {
+            const previousSnapshot = deps.findPreviousSnapshot ? await deps.findPreviousSnapshot(snapshot) : null;
+
+            if (!previousSnapshot) {
+                return null;
+            }
+
+            return buildSnapshotDiff({
+                beforeSnapshot: previousSnapshot,
+                afterSnapshot: snapshot,
+                contextLines: options.contextLines,
+            });
+        }
+
+        if (options.target === 'current') {
+            const note = await deps.findNoteById(snapshot.noteId);
+
+            if (!note) {
+                return null;
+            }
+
+            return buildSnapshotDiff({
+                beforeSnapshot: snapshot,
+                afterNote: note,
+                contextLines: options.contextLines,
+            });
+        }
+
+        const nextSnapshot = deps.findNextSnapshot ? await deps.findNextSnapshot(snapshot) : null;
+
+        if (nextSnapshot) {
+            return buildSnapshotDiff({
+                beforeSnapshot: snapshot,
+                afterSnapshot: nextSnapshot,
+                contextLines: options.contextLines,
+            });
+        }
+
+        const note = await deps.findNoteById(snapshot.noteId);
+
+        if (!note) {
+            return null;
+        }
+
+        return buildSnapshotDiff({
+            beforeSnapshot: snapshot,
+            afterNote: note,
+            contextLines: options.contextLines,
+        });
     },
 
     restoreSnapshot: async (snapshotId: number, options?: { meta?: string }) => {
@@ -582,6 +775,36 @@ export const defaultNoteSnapshotService = createNoteSnapshotService({
     findSnapshotById: async (id) => {
         return models.noteSnapshot.findUnique({ where: { id } });
     },
+    findNextSnapshot: async (snapshot) => {
+        return models.noteSnapshot.findFirst({
+            where: {
+                noteId: snapshot.noteId,
+                OR: [
+                    { createdAt: { gt: snapshot.createdAt } },
+                    {
+                        createdAt: snapshot.createdAt,
+                        id: { gt: snapshot.id },
+                    },
+                ],
+            },
+            orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+        });
+    },
+    findPreviousSnapshot: async (snapshot) => {
+        return models.noteSnapshot.findFirst({
+            where: {
+                noteId: snapshot.noteId,
+                OR: [
+                    { createdAt: { lt: snapshot.createdAt } },
+                    {
+                        createdAt: snapshot.createdAt,
+                        id: { lt: snapshot.id },
+                    },
+                ],
+            },
+            orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+        });
+    },
     updateNote: async (id, input) => {
         const { tagIds, properties, ...noteInput } = input;
 
@@ -673,6 +896,17 @@ export const listNoteSnapshots = async (noteId: number, limit?: number) => {
 
 export const getNoteSnapshot = async (snapshotId: number) => {
     return defaultNoteSnapshotService.getSnapshot(snapshotId);
+};
+
+export const diffNoteSnapshot = async (
+    snapshotId: number,
+    options?: {
+        compareToSnapshotId?: number;
+        target?: NoteSnapshotDiffTarget;
+        contextLines?: number | null;
+    },
+) => {
+    return defaultNoteSnapshotService.diffSnapshot(snapshotId, options);
 };
 
 export const restoreNoteSnapshot = async (snapshotId: number, options?: { meta?: string }) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,6 +235,9 @@ importers:
       '@prisma/client':
         specifier: ^6.19.3
         version: 6.19.3(prisma@6.19.3(typescript@5.9.3))(typescript@5.9.3)
+      diff:
+        specifier: ^9.0.0
+        version: 9.0.0
       express:
         specifier: ^5.2.1
         version: 5.2.1
@@ -3187,6 +3190,10 @@ packages:
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  diff@9.0.0:
+    resolution: {integrity: sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==}
+    engines: {node: '>=0.3.1'}
 
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -8456,6 +8463,8 @@ snapshots:
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
+
+  diff@9.0.0: {}
 
   dir-glob@3.0.1:
     dependencies:


### PR DESCRIPTION
## :dart: Goal
- Let users review what changed between a saved snapshot and the current note before restoring an older version.
- Reduce restore risk by showing a git-style diff first instead of forcing users to inspect the full snapshot content.

## :hammer_and_wrench: Core Changes
- Added a server-side note snapshot diff query backed by the `diff` library.
- Added client API support for fetching snapshot diffs.
- Updated the restore modal so snapshot cards expose `Compare` and `Restore`, with full content available only inside the compare detail view.
- Rendered note diffs with wrapped lines, full-width previews, and semantic add/remove/hunk colors.
- Added server and client tests for snapshot diff behavior and restore modal flows.

## :brain: Key Decisions
- This PR is scoped to user-visible snapshot diff review; it does not add MCP or CLI snapshot tools despite the historical branch name.
- The restore UI uses the selected snapshot to current note diff as the primary comparison.
- Diff generation uses the maintained `diff` package instead of a custom LCS implementation.
- Long note lines wrap instead of requiring horizontal scrolling because this is prose-oriented note content, not code review.
- Diff colors use semantic emerald/rose/sky tones for readability while keeping the container aligned with the app theme.

## :test_tube: Verification Guide
### How to verify
1. Run `pnpm check:encoding`.
2. Run `pnpm --filter @ocean-brain/server lint` and `pnpm --filter @ocean-brain/client lint`.
3. Run `pnpm --filter @ocean-brain/server type-check` and `pnpm --filter @ocean-brain/client type-check`.
4. Run `pnpm --filter @ocean-brain/server test:ci` and `pnpm --filter @ocean-brain/client test:ci`.
5. Run `pnpm --filter @ocean-brain/server build` and `pnpm --filter @ocean-brain/client build`.
6. Manually open a note with snapshots, open restore previous version, click `Compare`, and confirm the selected snapshot to current note diff is shown before restore.

### Expected result
- All commands pass.
- Snapshot cards show `Compare` and `Restore` only.
- `Compare` opens a wrapped diff view where removed snapshot lines are red, current note additions are green, and hunk headers are blue.
- The full snapshot content remains available from the compare detail view via `View content`.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)
