### PR TITLE
🛠 Patch Hono security advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "overrides": {
             "express-rate-limit": "8.5.1",
             "fast-uri": "3.1.2",
-            "hono": "4.12.18",
+            "hono": "4.12.21",
             "ip-address": "10.1.1",
             "postcss": "8.5.10",
             "qs": "6.15.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,12 +7,12 @@ settings:
 overrides:
   express-rate-limit: 8.5.1
   fast-uri: 3.1.2
-  hono: 4.12.18
+  hono: 4.12.21
   ip-address: 10.1.1
   postcss: 8.5.10
-  ws: 8.20.1
   qs: 6.15.2
   uuid: 11.1.1
+  ws: 8.20.1
 
 importers:
 
@@ -1441,7 +1441,7 @@ packages:
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: 4.12.18
+      hono: 4.12.21
 
   '@isaacs/fs-minipass@4.0.1':
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
@@ -3590,8 +3590,8 @@ packages:
   hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
-  hono@4.12.18:
-    resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
+  hono@4.12.21:
+    resolution: {integrity: sha512-uV63apnb0kyPtAUwoWgaGh9HyIFcv8lgmzPZSiTBQAFOFGIzka5EZ1dZocmGnn0XdX0+XTqJ6Tqv7selMuGLRQ==}
     engines: {node: '>=16.9.0'}
 
   html-encoding-sniffer@4.0.0:
@@ -6754,9 +6754,9 @@ snapshots:
       prosemirror-transform: 1.12.0
       prosemirror-view: 1.41.8
 
-  '@hono/node-server@1.19.14(hono@4.12.18)':
+  '@hono/node-server@1.19.14(hono@4.12.21)':
     dependencies:
-      hono: 4.12.18
+      hono: 4.12.21
 
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
@@ -6805,7 +6805,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.18)
+      '@hono/node-server': 1.19.14(hono@4.12.21)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -6815,7 +6815,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.5.1(express@5.2.1)
-      hono: 4.12.18
+      hono: 4.12.21
       jose: 6.2.0
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -8997,7 +8997,7 @@ snapshots:
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
 
-  hono@4.12.18: {}
+  hono@4.12.21: {}
 
   html-encoding-sniffer@4.0.0:
     dependencies:


### PR DESCRIPTION
## :dart: Goal
- Resolve open Dependabot alerts for the transitive `hono` runtime dependency used through the MCP SDK.
- Move the workspace override from the vulnerable `hono@4.12.18` release to the patched `hono@4.12.21` release.

## :hammer_and_wrench: Core Changes
- Updated the root pnpm override for `hono` to `4.12.21`.
- Refreshed `pnpm-lock.yaml` so `@modelcontextprotocol/sdk` and `@hono/node-server` resolve against the patched Hono version.

## :brain: Key Decisions
- Kept this as a dependency-only security patch with no application behavior changes.
- Used the minimum patched version reported by the advisories (`>=4.12.21`) to reduce update risk.
- Classified this as `release: patch` because it resolves security advisories without adding user-facing features.

## :test_tube: Verification Guide
### How to verify
1. Run `pnpm audit --prod`.
2. Run `pnpm check:encoding`.
3. Run `pnpm lint`.
4. Run `pnpm --filter ocean-brain type-check`, `pnpm --filter ocean-brain test:ci`, and `pnpm --filter ocean-brain build`.
5. Run `pnpm --filter @ocean-brain/server type-check`, `pnpm --filter @ocean-brain/server test:ci`, and `pnpm --filter @ocean-brain/server build`.

### Expected result
- `pnpm audit --prod` reports no known vulnerabilities.
- Encoding, lint, type-check, tests, and builds pass.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)
