### PR TITLE
🔖 Bump version to 0.6.3

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ocean-brain",
-    "version": "0.6.2",
+    "version": "0.6.3",
     "license": "MIT",
     "type": "module",
     "repository": {


### PR DESCRIPTION
## :dart: Goal
- Prepare the `0.6.3` patch release after merging the Markdown hard-break fix and Hono security advisory patch.
- Trigger a patch release with tag `v0.6.3` after this version bump reaches `main`.

## :hammer_and_wrench: Core Changes
- Bumped the published CLI package version from `0.6.2` to `0.6.3`.

## :brain: Key Decisions
- This is a patch release because it contains bug/security fixes only.
- Expected release tag: `v0.6.3`.
- Release trigger will be an explicit `v0.6.3` tag push from merged `main`.

## :test_tube: Verification Guide
### How to verify
1. Confirm the version in `packages/cli/package.json` is `0.6.3`.
2. Confirm PR CI passes.
3. Confirm `CLI SMOKE` passes for this release bump PR before tagging.

### Expected result
- The CLI package version is `0.6.3`.
- CI and CLI smoke checks pass.
- After merge, pushing `v0.6.3` starts the `RELEASE` workflow.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)
