### PR TITLE
✨ Improve Markdown portability

### DIFF
--- a/packages/cli/src/mcp-note-output.ts
+++ b/packages/cli/src/mcp-note-output.ts
@@ -1,87 +1,99 @@
 export interface McpReadNoteTag {
-    id: string;
-    name: string;
+	id: string;
+	name: string;
 }
 
 export interface McpReadNoteProperty {
-    key: string;
-    name: string;
-    value: string;
-    valueType: string;
-    option?: { label: string; value: string } | null;
+	key: string;
+	name: string;
+	value: string;
+	valueType: string;
+	option?: { label: string; value: string } | null;
 }
 
 export interface McpReadNote {
-    id: string;
-    title: string;
-    contentAsMarkdown: string;
-    createdAt: string;
-    updatedAt: string;
-    tags: McpReadNoteTag[];
-    properties?: McpReadNoteProperty[];
+	id: string;
+	title: string;
+	contentAsMarkdown: string;
+	createdAt: string;
+	updatedAt: string;
+	tags: McpReadNoteTag[];
+	properties?: McpReadNoteProperty[];
 }
 
 export interface McpReadNoteBackReference {
-    id: string;
-    title: string;
-    updatedAt?: string;
+	id: string;
+	title: string;
+	updatedAt?: string;
 }
 
-const formatBackReferenceLine = (backReference: McpReadNoteBackReference) => {
-    if (backReference.updatedAt) {
-        return `- ${backReference.id}: ${backReference.title} (updated: ${backReference.updatedAt})`;
-    }
+const formatBackReferenceLink = (backReference: McpReadNoteBackReference) => {
+	return `[[${backReference.title}]](note:${backReference.id})`;
+};
 
-    return `- ${backReference.id}: ${backReference.title}`;
+const formatBackReferenceLine = (backReference: McpReadNoteBackReference) => {
+	const referenceLink = formatBackReferenceLink(backReference);
+
+	if (backReference.updatedAt) {
+		return `- ${referenceLink} (updated: ${backReference.updatedAt})`;
+	}
+
+	return `- ${referenceLink}`;
 };
 
 const formatPropertyLine = (property: McpReadNoteProperty) => {
-    const displayValue = (property.option?.label ?? property.value) || '(empty)';
-    const rawValue = property.option?.value ?? property.value;
-    const rawValueLabel = rawValue ? `, value=${rawValue}` : '';
+	const displayValue = (property.option?.label ?? property.value) || "(empty)";
+	const rawValue = property.option?.value ?? property.value;
+	const rawValueLabel = rawValue ? `, value=${rawValue}` : "";
 
-    return `- ${property.key} (${property.name}): ${displayValue} [${property.valueType}${rawValueLabel}]`;
+	return `- ${property.key} (${property.name}): ${displayValue} [${property.valueType}${rawValueLabel}]`;
 };
 
 export const formatMcpReadNoteOutput = ({
-    note,
-    backReferences,
-    maxLength
+	note,
+	backReferences,
+	maxLength,
 }: {
-    note: McpReadNote;
-    backReferences: McpReadNoteBackReference[];
-    maxLength: number;
+	note: McpReadNote;
+	backReferences: McpReadNoteBackReference[];
+	maxLength: number;
 }) => {
-    let markdown = note.contentAsMarkdown;
-    const totalLength = markdown.length;
-    const truncated = maxLength > 0 && markdown.length > maxLength;
+	let markdown = note.contentAsMarkdown;
+	const totalLength = markdown.length;
+	const truncated = maxLength > 0 && markdown.length > maxLength;
 
-    if (truncated) {
-        markdown = markdown.slice(0, maxLength);
-    }
+	if (truncated) {
+		markdown = markdown.slice(0, maxLength);
+	}
 
-    const backReferenceLines = backReferences.length > 0
-        ? backReferences.map(formatBackReferenceLine)
-        : ['- (none)'];
-    const propertyLines = note.properties && note.properties.length > 0
-        ? note.properties.map(formatPropertyLine)
-        : ['- (none)'];
+	const backReferenceLines =
+		backReferences.length > 0
+			? backReferences.map(formatBackReferenceLine)
+			: ["- (none)"];
+	const propertyLines =
+		note.properties && note.properties.length > 0
+			? note.properties.map(formatPropertyLine)
+			: ["- (none)"];
 
-    return [
-        `# ${note.title}`,
-        '',
-        `Tags: ${note.tags.map((tag) => tag.name).join(', ') || '(none)'}`,
-        '',
-        'Properties:',
-        ...propertyLines,
-        `Created: ${note.createdAt}`,
-        `Updated: ${note.updatedAt}`,
-        ...(truncated ? [`Content: ${totalLength} chars (showing first ${maxLength})`] : []),
-        '',
-        'Back References:',
-        ...backReferenceLines,
-        '',
-        markdown,
-        ...(truncated ? ['\n... (truncated, use maxLength: 0 to read full content)'] : [])
-    ].join('\n');
+	return [
+		`# ${note.title}`,
+		"",
+		`Tags: ${note.tags.map((tag) => tag.name).join(", ") || "(none)"}`,
+		"",
+		"Properties:",
+		...propertyLines,
+		`Created: ${note.createdAt}`,
+		`Updated: ${note.updatedAt}`,
+		...(truncated
+			? [`Content: ${totalLength} chars (showing first ${maxLength})`]
+			: []),
+		"",
+		"Back References:",
+		...backReferenceLines,
+		"",
+		markdown,
+		...(truncated
+			? ["\n... (truncated, use maxLength: 0 to read full content)"]
+			: []),
+	].join("\n");
 };

--- a/packages/cli/test/mcp-note-output.test.ts
+++ b/packages/cli/test/mcp-note-output.test.ts
@@ -23,7 +23,10 @@ test('formatMcpReadNoteOutput includes a back reference summary before the markd
         maxLength: 0
     });
 
-    assert.match(output, /Back References:\n- 31: Sprint Summary\n- 32: Reference Hub\n\nBody line 1\nBody line 2$/);
+    assert.match(
+        output,
+        /Back References:\n- \[\[Sprint Summary\]\]\(note:31\)\n- \[\[Reference Hub\]\]\(note:32\)\n\nBody line 1\nBody line 2$/,
+    );
 });
 
 test('formatMcpReadNoteOutput truncates markdown and shows an empty back reference state', () => {

--- a/packages/client/src/modules/blocknote-markdown.spec.ts
+++ b/packages/client/src/modules/blocknote-markdown.spec.ts
@@ -9,7 +9,7 @@ describe('blocknote markdown helpers', () => {
                 content: [
                     { type: 'tag', props: { tag: '@project' } },
                     { type: 'text', text: ' ', styles: {} },
-                    { type: 'reference', props: { title: 'Reference Note' } },
+                    { type: 'reference', props: { id: '44', title: 'Reference Note' } },
                 ],
                 children: [],
             },
@@ -20,11 +20,26 @@ describe('blocknote markdown helpers', () => {
         expect(prepared.blocks[0].content).toEqual([
             { type: 'text', text: 'OCEAN_BRAIN_TAG_0_TOKEN', styles: {} },
             { type: 'text', text: ' ', styles: {} },
-            { type: 'text', text: '[[Reference Note]]', styles: {} },
+            { type: 'text', text: '[[Reference Note]](note:44)', styles: {} },
         ]);
         expect(
-            restoreTagPlaceholdersInMarkdown('OCEAN_BRAIN_TAG_0_TOKEN [[Reference Note]]', prepared.placeholderToTag),
-        ).toBe('[@project] [[Reference Note]]');
+            restoreTagPlaceholdersInMarkdown(
+                'OCEAN_BRAIN_TAG_0_TOKEN [[Reference Note]](note:44)',
+                prepared.placeholderToTag,
+            ),
+        ).toBe('[@project] [[Reference Note]](note:44)');
+    });
+
+    it('falls back to title-only references when a reference id is missing', () => {
+        const prepared = prepareBlocksForMarkdown([
+            {
+                type: 'paragraph',
+                content: [{ type: 'reference', props: { title: 'Title Only Note' } }],
+                children: [],
+            },
+        ]);
+
+        expect(prepared.blocks[0].content).toEqual([{ type: 'text', text: '[[Title Only Note]]', styles: {} }]);
     });
 
     it('strips unsupported table of contents blocks', () => {
@@ -49,7 +64,7 @@ describe('blocknote markdown helpers', () => {
                                 {
                                     content: [
                                         { type: 'tag', props: { tag: '#topic' } },
-                                        { type: 'reference', props: { title: 'Table Note' } },
+                                        { type: 'reference', props: { id: '45', title: 'Table Note' } },
                                     ],
                                 },
                             ],
@@ -67,7 +82,7 @@ describe('blocknote markdown helpers', () => {
                         {
                             content: [
                                 { type: 'text', text: 'OCEAN_BRAIN_TAG_0_TOKEN', styles: {} },
-                                { type: 'text', text: '[[Table Note]]', styles: {} },
+                                { type: 'text', text: '[[Table Note]](note:45)', styles: {} },
                             ],
                         },
                     ],

--- a/packages/client/src/modules/blocknote-markdown.ts
+++ b/packages/client/src/modules/blocknote-markdown.ts
@@ -83,9 +83,13 @@ export function prepareBlocksForMarkdown(blocks: MarkdownBlock[]) {
     const markdownBlocks = mapBlocks(blocks, (content) =>
         mapBlockContent(content, (inline) => {
             if (inline.type === 'reference') {
+                const id = String(inline.props?.id || '');
+                const title = String(inline.props?.title || inline.props?.id || '');
+                const text = id ? `[[${title}]](note:${id})` : `[[${title}]]`;
+
                 return {
                     type: 'text',
-                    text: `[[${inline.props?.title || inline.props?.id || ''}]]`,
+                    text,
                     styles: {},
                 };
             }

--- a/packages/server/test/blocknote.test.ts
+++ b/packages/server/test/blocknote.test.ts
@@ -407,6 +407,35 @@ test('markdownToBlocksJson preserves note-id reference syntax inside fenced code
     assert.match(roundTripMarkdown, /\[\[Old Title\]\]\(note:44\)/);
 });
 
+test('markdownToBlocksJson keeps portable tags, note-id references, hard breaks, and code text together', async () => {
+    const markdown = [
+        'See [[Old Title]](note:44) with [@project]\\',
+        'Next line keeps the hard break.',
+        '',
+        '```md',
+        'Keep [#literal] and [[Code Title]](note:55) as code.',
+        '```',
+    ].join('\n');
+
+    const contentJson = await markdownToBlocksJson(markdown, {
+        ensureTag: async (name) => ({ id: name === 'project' ? '12' : '13', name: `@${name}` }),
+        findNotesByTitle: async () => [],
+        findNoteById: async (id) =>
+            id === '44'
+                ? {
+                      id: '44',
+                      title: 'Current Title',
+                  }
+                : null,
+    });
+    const roundTripMarkdown = await blocksToMarkdown(contentJson);
+
+    assert.match(roundTripMarkdown, /\[\[Current Title\]\]\(note:44\)/);
+    assert.match(roundTripMarkdown, /\[@project\]/);
+    assert.match(roundTripMarkdown, /with \[@project\]\\\nNext line keeps the hard break/);
+    assert.match(roundTripMarkdown, /Keep \[#literal\] and \[\[Code Title\]\]\(note:55\) as code/);
+});
+
 test('markdownToBlocksJson leaves malformed note-id references as text', async () => {
     const contentJson = await markdownToBlocksJson('See [[Decimal]](note:1.5) and [[Huge]](note:9007199254740993)', {
         ensureTag: async () => {


### PR DESCRIPTION
## :dart: Goal
- Improve Markdown portability for note references, tags, and MCP read output after the recent note-id reference work.
- Make exported Markdown easier to preserve outside Ocean Brain without adding a broad vault export or import UI.

## :hammer_and_wrench: Core Changes
- Updated client Markdown export so reference inlines with IDs render as `[[Title]](note:id)`.
- Kept title-only reference export as `[[Title]]` when no reference ID is available.
- Updated MCP read output Back References to use the same `[[Title]](note:id)` portable link format.
- Added tests for table-cell tag/reference export and mixed server round-trip cases covering note-id links, tags, hard breaks, and fenced code.

## :brain: Key Decisions
- This is a first Markdown portability pass, not the full completion of the vault/export roadmap.
- No new MCP tool, import UI, zip export, or external app-specific compatibility layer is included.
- Back References output is user-visible text, so the format change is documented here: `- id: Title` becomes `- [[Title]](note:id)`.

## :test_tube: Verification Guide
### How to verify
1. Run `pnpm --filter @ocean-brain/client test -- blocknote-markdown.spec.ts note-export.spec.ts`.
2. Run `pnpm --filter ocean-brain test:ci`.
3. Run `pnpm --filter @ocean-brain/server exec tsx --tsconfig tsconfig.json --test test/blocknote.test.ts`.
4. Run client, CLI, and server lint/type-check/build commands.
5. Manually export a note containing a reference and confirm ID-backed links render as `[[Title]](note:id)`.

### Expected result
- All commands pass.
- ID-backed note references keep their ID in exported Markdown.
- Title-only references remain title-only.
- MCP Back References use portable note links.
- Tags, hard breaks, and fenced code remain stable in the covered round-trip tests.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)
