### PR TITLE
🐛 Include diff in CLI runtime dependencies

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,6 +38,7 @@
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@prisma/client": "^6.19.3",
         "commander": "^14.0.3",
+        "diff": "^9.0.0",
         "express": "^5.2.1",
         "express-rate-limit": "8.5.1",
         "express-session": "^1.19.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       commander:
         specifier: ^14.0.3
         version: 14.0.3
+      diff:
+        specifier: ^9.0.0
+        version: 9.0.0
       express:
         specifier: ^5.2.1
         version: 5.2.1


### PR DESCRIPTION
## :dart: Goal
- Fix the packaged CLI startup failure caused by the snapshot diff runtime dependency not being installed with the published `ocean-brain` package.
- Unblock the `0.7.0` release by making the npx smoke test pass from the packed tarball.

## :hammer_and_wrench: Core Changes
- Added `diff` to the `ocean-brain` CLI package runtime dependencies.
- Updated the lockfile importer entry for the CLI package.

## :brain: Key Decisions
- Keep `diff` in the server package as the source dependency for server development and tests.
- Also declare it in the CLI package because release artifacts copy the built server into the published CLI package, and runtime imports resolve from the installed CLI package.
- This is a patch fix because it restores the expected packaged CLI startup behavior without adding a new user-facing capability.

## :test_tube: Verification Guide
### How to verify
1. Run `pnpm install --frozen-lockfile`.
2. Run `node scripts/release/prepublish.mjs`.
3. Run `node scripts/ci/pack-cli-tarball.mjs`.
4. Run `CLI_SMOKE_PORT=6684 node scripts/ci/smoke-cli-npx.mjs .tmp/ocean-brain-0.6.3.tgz`.
5. Confirm PR CI passes.

### Expected result
- The packed CLI package includes the `diff` runtime dependency.
- The npx smoke test starts the bundled server successfully.
- CI passes.

### Local result
- `pnpm install --frozen-lockfile`: passed.
- `node scripts/release/prepublish.mjs`: passed.
- `node scripts/ci/pack-cli-tarball.mjs`: passed.
- `CLI_SMOKE_PORT=6684 node scripts/ci/smoke-cli-npx.mjs .tmp/ocean-brain-0.6.3.tgz`: passed.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)
- [x] Release impact label selected: `release: patch`
