### PR TITLE
🐛 Fix local demo tag notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Ocean Brain keeps that connection close to the writing flow. You can write a not
 
 **[Live Demo](https://demo-ocean-brain.baejino.com/)** - Try the hosted demo
 
+The hosted demo runs in local-only mode: your edits stay in your browser, so feel free to create, edit, delete, and reset notes while testing.
+
 ## Quick Start
 
 `npx ocean-brain` / `docker run baealex/ocean-brain` now require explicit auth configuration.

--- a/packages/client/src/modules/local-demo/plugins/notes.spec.ts
+++ b/packages/client/src/modules/local-demo/plugins/notes.spec.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+
+import { createLocalDemoSeed } from '../seed';
+import type { LocalDemoState, LocalTag } from '../types';
+import { notesLocalPlugin } from './notes';
+
+const createState = (): LocalDemoState => {
+    const tags: LocalTag[] = [
+        { id: 'tag-guide', name: '@guide' },
+        { id: 'tag-demo', name: '@demo' },
+        { id: 'tag-graph', name: '@graph' },
+        { id: 'tag-project', name: '@project' },
+        { id: 'tag-task', name: '@task' },
+        { id: 'tag-research', name: '@research' },
+        { id: 'tag-meeting', name: '@meeting' },
+        { id: 'tag-editor', name: '@editor' },
+        { id: 'tag-media', name: '@media' },
+        { id: 'tag-archive', name: '@archive' },
+    ];
+    const seed = createLocalDemoSeed({ tags, nowMs: 1_710_000_000_000 });
+
+    return {
+        version: 4,
+        notes: seed.notes,
+        trashedNotes: [],
+        tags,
+        reminders: seed.reminders,
+        placeholders: [],
+        images: [],
+        cache: {},
+        propertyDefinitions: seed.propertyDefinitions,
+        mcp: {
+            enabled: false,
+            hasActiveToken: false,
+            token: null,
+        },
+        viewWorkspace: {
+            activeTabId: seed.viewTabs[0]?.id ?? null,
+            tabs: seed.viewTabs,
+        },
+    };
+};
+
+describe('notesLocalPlugin', () => {
+    it('filters tagged notes by tag id for the tag notes page', () => {
+        const handler = notesLocalPlugin.graphHandlers?.FetchTagNotes;
+        expect(handler).toBeDefined();
+
+        const response = handler?.({
+            state: createState(),
+            variables: {
+                searchFilter: { query: 'tag-guide' },
+                pagination: { limit: 25, offset: 0 },
+            },
+            save: () => undefined,
+        });
+
+        const tagNotes =
+            response && 'tagNotes' in response
+                ? (response.tagNotes as
+                      | { totalCount: number; notes: Array<{ tags: Array<{ id: string }> }> }
+                      | undefined)
+                : undefined;
+
+        expect(tagNotes?.totalCount).toBe(3);
+        expect(tagNotes?.notes).toHaveLength(3);
+        expect(tagNotes?.notes.every((note) => note.tags.some((tag) => tag.id === 'tag-guide'))).toBe(true);
+    });
+});

--- a/packages/client/src/modules/local-demo/plugins/notes.ts
+++ b/packages/client/src/modules/local-demo/plugins/notes.ts
@@ -33,8 +33,10 @@ export const notesLocalPlugin: LocalDemoPlugin = {
             return success({ allNotes: { totalCount: filtered.length, notes: paginate(filtered, variables) } });
         },
         FetchTagNotes: ({ state, variables }) => {
-            const filtered = state.notes.filter(
-                (note) => note.tags.length > 0 && noteMatchesQuery(note, getQueryText(variables)),
+            const tagId = getQueryText(variables);
+            const filtered = sortNotes(
+                state.notes.filter((note) => note.tags.some((tag) => tag.id.toLowerCase() === tagId)),
+                { ...variables, searchFilter: { sortBy: 'updatedAt', sortOrder: 'desc' } },
             );
             return success({ tagNotes: { totalCount: filtered.length, notes: paginate(filtered, variables) } });
         },

--- a/packages/client/src/modules/local-demo/seed.spec.ts
+++ b/packages/client/src/modules/local-demo/seed.spec.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { createLocalDemoSeed } from './seed';
+import type { LocalTag } from './types';
+
+const tags: LocalTag[] = [
+    { id: 'tag-guide', name: '@guide' },
+    { id: 'tag-demo', name: '@demo' },
+    { id: 'tag-graph', name: '@graph' },
+    { id: 'tag-project', name: '@project' },
+    { id: 'tag-task', name: '@task' },
+    { id: 'tag-research', name: '@research' },
+    { id: 'tag-meeting', name: '@meeting' },
+    { id: 'tag-editor', name: '@editor' },
+    { id: 'tag-media', name: '@media' },
+    { id: 'tag-archive', name: '@archive' },
+];
+
+describe('createLocalDemoSeed', () => {
+    it('keeps seeded note timestamps in the past', () => {
+        const nowMs = 1_710_000_000_000;
+        const seed = createLocalDemoSeed({ tags, nowMs });
+
+        expect(seed.notes.length).toBeGreaterThan(0);
+        expect(seed.notes.every((note) => Number(note.createdAt) <= nowMs && Number(note.updatedAt) <= nowMs)).toBe(
+            true,
+        );
+    });
+});

--- a/packages/client/src/modules/local-demo/seed.ts
+++ b/packages/client/src/modules/local-demo/seed.ts
@@ -195,7 +195,8 @@ const refBullet = (id: string, label: string, noteId: string, title: string) =>
     bullet(id, [text(label), reference(noteId, title)]);
 
 export const createLocalDemoSeed = ({ tags, nowMs }: SeedInput): SeedOutput => {
-    const createdAt = timestamp(nowMs);
+    const seedStartMs = nowMs - 30 * 60 * 1000;
+    const createdAt = timestamp(seedStartMs);
     const guide = findTag(tags, '@guide');
     const demo = findTag(tags, '@demo');
     const graph = findTag(tags, '@graph');
@@ -236,7 +237,7 @@ export const createLocalDemoSeed = ({ tags, nowMs }: SeedInput): SeedOutput => {
         createNote({
             id: '2',
             title: 'Note Linking & Backlinks',
-            createdAt: plusMinutes(nowMs, 1),
+            createdAt: plusMinutes(seedStartMs, 1),
             pinned: true,
             order: 1,
             layout: 'wide',
@@ -262,7 +263,7 @@ export const createLocalDemoSeed = ({ tags, nowMs }: SeedInput): SeedOutput => {
         createNote({
             id: '3',
             title: 'Project: Personal Knowledge Hub',
-            createdAt: plusMinutes(nowMs, 2),
+            createdAt: plusMinutes(seedStartMs, 2),
             pinned: true,
             order: 2,
             layout: 'wide',
@@ -302,7 +303,7 @@ export const createLocalDemoSeed = ({ tags, nowMs }: SeedInput): SeedOutput => {
         createNote({
             id: '4',
             title: 'Task Management Demo',
-            createdAt: plusMinutes(nowMs, 3),
+            createdAt: plusMinutes(seedStartMs, 3),
             order: 3,
             layout: 'wide',
             tags: [task, project],
@@ -334,7 +335,7 @@ export const createLocalDemoSeed = ({ tags, nowMs }: SeedInput): SeedOutput => {
         createNote({
             id: '5',
             title: 'Research: Local-first Demo',
-            createdAt: plusMinutes(nowMs, 4),
+            createdAt: plusMinutes(seedStartMs, 4),
             order: 4,
             layout: 'wide',
             tags: [research, demo],
@@ -367,7 +368,7 @@ export const createLocalDemoSeed = ({ tags, nowMs }: SeedInput): SeedOutput => {
         createNote({
             id: '6',
             title: 'Meeting Notes Template',
-            createdAt: plusMinutes(nowMs, 5),
+            createdAt: plusMinutes(seedStartMs, 5),
             order: 5,
             layout: 'wide',
             tags: [meeting, project],
@@ -402,7 +403,7 @@ export const createLocalDemoSeed = ({ tags, nowMs }: SeedInput): SeedOutput => {
         createNote({
             id: '7',
             title: 'Editing Playground',
-            createdAt: plusMinutes(nowMs, 6),
+            createdAt: plusMinutes(seedStartMs, 6),
             order: 6,
             layout: 'full',
             tags: [editor, guide],
@@ -429,7 +430,7 @@ export const createLocalDemoSeed = ({ tags, nowMs }: SeedInput): SeedOutput => {
         createNote({
             id: '8',
             title: 'Media & Attachments Example',
-            createdAt: plusMinutes(nowMs, 7),
+            createdAt: plusMinutes(seedStartMs, 7),
             order: 7,
             layout: 'wide',
             tags: [media, demo],
@@ -455,7 +456,7 @@ export const createLocalDemoSeed = ({ tags, nowMs }: SeedInput): SeedOutput => {
         createNote({
             id: '9',
             title: 'Done: Prepare Seed Workspace',
-            createdAt: plusMinutes(nowMs, 8),
+            createdAt: plusMinutes(seedStartMs, 8),
             order: 8,
             layout: 'wide',
             tags: [archive, project],

--- a/packages/client/src/modules/local-demo/store.ts
+++ b/packages/client/src/modules/local-demo/store.ts
@@ -1,8 +1,8 @@
 import { createLocalDemoSeed } from './seed';
 import type { LocalDemoState } from './types';
 
-const STORAGE_KEY = 'ocean-brain:local-only-demo:v4';
-const CURRENT_VERSION = 4 as const;
+const STORAGE_KEY = 'ocean-brain:local-only-demo:v5';
+const CURRENT_VERSION = 5 as const;
 
 const createSeedState = (): LocalDemoState => {
     const tags = [

--- a/packages/client/src/modules/local-demo/types.ts
+++ b/packages/client/src/modules/local-demo/types.ts
@@ -27,7 +27,7 @@ export interface LocalPropertyDefinition {
 }
 
 export interface LocalDemoState {
-    version: 4;
+    version: 5;
     notes: Note[];
     trashedNotes: LocalTrashNote[];
     tags: LocalTag[];


### PR DESCRIPTION
## :dart: Goal
Fix local-only demo issues found during manual browser testing.

## :hammer_and_wrench: Core Changes
- Filter local-only demo tag note pages by tag id, matching the server resolver behavior.
- Keep seeded demo note timestamps in the past so relative time labels do not get stuck at `just now` / `0 seconds ago`.
- Bump the local-only demo storage key/version so existing browser demo data is refreshed.
- Clarify in `README.md` that the hosted demo runs in browser-local mode and can be tested freely.

## :brain: Key Decisions
- Treat this as a demo-only patch because it fixes local-only demo behavior without changing server data contracts.
- Refresh demo localStorage via a version bump instead of trying to migrate incorrect future timestamps.

## :test_tube: Verification Guide
- `pnpm --filter @ocean-brain/client exec vitest run src/modules/local-demo/seed.spec.ts src/modules/local-demo/plugins/notes.spec.ts` — passed
- `pnpm --filter @ocean-brain/client lint` — passed
- `pnpm --filter @ocean-brain/client type-check` — passed
- `pnpm --filter @ocean-brain/client build` — passed
- Manual check in `VITE_DEMO_MODE=local-only` dev server — tag notes and relative timestamps worked as expected

## :white_check_mark: Checklist
- [x] PR title follows `<emoji> <subject>` and starts with an English verb
- [x] Body follows `.github/PULL_REQUEST_TEMPLATE.md` headings
- [x] Local validation for the changed scope is complete
- [x] Documentation update is included in the PR body
- [x] Release impact label is applied: `release: patch`
