### PR TITLE
🐛 Fix BlockNote heading drag alignment

### DIFF
--- a/packages/client/src/components/shared/AuxiliaryPanel.tsx
+++ b/packages/client/src/components/shared/AuxiliaryPanel.tsx
@@ -27,7 +27,7 @@ export default function AuxiliaryPanel({
     const header = <AuxiliaryPanelHeader icon={icon} title={title} className="text-fg-tertiary" />;
 
     return (
-        <section className={classNames('surface-base mb-5 p-4', className)} aria-label={ariaLabel ?? title}>
+        <section className={classNames('surface-base p-4', className)} aria-label={ariaLabel ?? title}>
             <div className={classNames('relative', hasAction && 'pr-44 sm:pr-48', hasBody && 'mb-3')}>
                 {titleButtonProps ? (
                     <button

--- a/packages/client/src/pages/Note.tsx
+++ b/packages/client/src/pages/Note.tsx
@@ -122,10 +122,13 @@ const NOTE_LAYOUT_WIDTH: Record<NoteLayout, string> = {
 const notePageFallback = (
     <PageLayout title="Loading note" variant="none">
         <main className="mx-auto max-w-[896px]">
-            <Skeleton className="mb-8" height="66px" />
-            <Skeleton className="ml-12 mb-8" height="150px" />
-            <Skeleton className="mb-5" height="80px" />
-            <Skeleton height="80px" />
+            <Skeleton className="mb-8" height={123} />
+            <div className="flex flex-col gap-5">
+                <Skeleton height={135} />
+                <Skeleton className="ml-12" height={320} />
+                <Skeleton height={107} />
+                <Skeleton height={100} />
+            </div>
         </main>
     </PageLayout>
 );
@@ -1402,112 +1405,114 @@ export function NoteContent({ id }: NoteContentProps) {
                     </Callout>
                 )}
 
-                <NotePropertiesPanel
-                    noteId={id}
-                    properties={note.properties}
-                    expectedUpdatedAt={serverUpdatedAtRef.current}
-                    editSessionId={editSessionIdRef.current}
-                    disabled={saveStatus !== 'saved'}
-                    onSaved={(updatedNote) => {
-                        appliedNoteVersionRef.current = updatedNote.updatedAt;
-                        setServerUpdatedAt(updatedNote.updatedAt);
-                        updateLastSavedAt(updatedNote.updatedAt);
-                        setShowSavedConfirmation(true);
-                        queryClient.setQueryData<NoteDetailCache>(queryKeys.notes.detail(id), (current) => {
-                            if (!current) {
-                                return current;
-                            }
-
-                            return {
-                                ...current,
-                                updatedAt: updatedNote.updatedAt,
-                                properties: updatedNote.properties,
-                            };
-                        });
-                        publishClientNoteUpdatedEvent({
-                            noteId: id,
-                            updatedAt: updatedNote.updatedAt,
-                            editSessionId: editSessionIdRef.current,
-                        });
-                    }}
-                />
-
-                <Editor
-                    key={`${id}:${editorRevision}`}
-                    ref={editorRef}
-                    content={editorContentOverride ?? note.content}
-                    currentNoteId={id}
-                    onChange={handleChange}
-                />
-
-                <QueryBoundary
-                    fallback={<Skeleton className="mb-5" height="80px" />}
-                    errorTitle="Failed to load reminders"
-                    errorDescription="Retry loading reminder details for this note."
-                    renderError={({ error, retry }) => (
-                        <QueryErrorView
-                            title="Failed to load reminders"
-                            description="Retry loading reminder details for this note."
-                            error={error}
-                            onRetry={retry}
-                            showBackAction={false}
-                            showHomeAction={false}
-                        />
-                    )}
-                >
-                    <ReminderPanel noteId={id} />
-                </QueryBoundary>
-
-                <QueryBoundary
-                    fallback={<Skeleton height="80px" />}
-                    errorTitle="Failed to load back references"
-                    errorDescription="Retry loading notes that link back here."
-                    renderError={({ error, retry }) => (
-                        <QueryErrorView
-                            title="Failed to load back references"
-                            description="Retry loading notes that link back here."
-                            error={error}
-                            onRetry={retry}
-                            showBackAction={false}
-                            showHomeAction={false}
-                        />
-                    )}
-                >
-                    <BackReferences
+                <div className="flex flex-col gap-5">
+                    <NotePropertiesPanel
                         noteId={id}
-                        render={(backReferences) =>
-                            backReferences &&
-                            backReferences.length > 0 && (
-                                <AuxiliaryPanel
-                                    icon={<Icon.LinkSimple className="h-3.5 w-3.5" />}
-                                    title="Back References"
-                                >
-                                    <ul className="flex flex-col">
-                                        {backReferences.map((backLink) => (
-                                            <li key={backLink.id}>
-                                                <Link
-                                                    to={NOTE_ROUTE}
-                                                    params={{ id: backLink.id }}
-                                                    className="flex items-center gap-2 rounded-[10px] px-2.5 py-1.5 text-fg-secondary transition-colors hover:bg-hover-subtle hover:text-fg-default"
-                                                >
-                                                    <Icon.File className="h-3.5 w-3.5 shrink-0 text-fg-tertiary" />
-                                                    <Text
-                                                        as="span"
-                                                        variant="body"
-                                                        weight="medium"
-                                                        className="text-current"
-                                                    >
-                                                        {backLink.title}
-                                                    </Text>
-                                                </Link>
-                                            </li>
-                                        ))}
-                                    </ul>
-                                </AuxiliaryPanel>
-                            )
-                        }
+                        properties={note.properties}
+                        expectedUpdatedAt={serverUpdatedAtRef.current}
+                        editSessionId={editSessionIdRef.current}
+                        disabled={saveStatus !== 'saved'}
+                        onSaved={(updatedNote) => {
+                            appliedNoteVersionRef.current = updatedNote.updatedAt;
+                            setServerUpdatedAt(updatedNote.updatedAt);
+                            updateLastSavedAt(updatedNote.updatedAt);
+                            setShowSavedConfirmation(true);
+                            queryClient.setQueryData<NoteDetailCache>(queryKeys.notes.detail(id), (current) => {
+                                if (!current) {
+                                    return current;
+                                }
+
+                                return {
+                                    ...current,
+                                    updatedAt: updatedNote.updatedAt,
+                                    properties: updatedNote.properties,
+                                };
+                            });
+                            publishClientNoteUpdatedEvent({
+                                noteId: id,
+                                updatedAt: updatedNote.updatedAt,
+                                editSessionId: editSessionIdRef.current,
+                            });
+                        }}
                     />
-                </QueryBoundary>
+
+                    <Editor
+                        key={`${id}:${editorRevision}`}
+                        ref={editorRef}
+                        content={editorContentOverride ?? note.content}
+                        currentNoteId={id}
+                        onChange={handleChange}
+                    />
+
+                    <QueryBoundary
+                        fallback={<Skeleton height={107} />}
+                        errorTitle="Failed to load reminders"
+                        errorDescription="Retry loading reminder details for this note."
+                        renderError={({ error, retry }) => (
+                            <QueryErrorView
+                                title="Failed to load reminders"
+                                description="Retry loading reminder details for this note."
+                                error={error}
+                                onRetry={retry}
+                                showBackAction={false}
+                                showHomeAction={false}
+                            />
+                        )}
+                    >
+                        <ReminderPanel noteId={id} />
+                    </QueryBoundary>
+
+                    <QueryBoundary
+                        fallback={<Skeleton height={100} />}
+                        errorTitle="Failed to load back references"
+                        errorDescription="Retry loading notes that link back here."
+                        renderError={({ error, retry }) => (
+                            <QueryErrorView
+                                title="Failed to load back references"
+                                description="Retry loading notes that link back here."
+                                error={error}
+                                onRetry={retry}
+                                showBackAction={false}
+                                showHomeAction={false}
+                            />
+                        )}
+                    >
+                        <BackReferences
+                            noteId={id}
+                            render={(backReferences) =>
+                                backReferences &&
+                                backReferences.length > 0 && (
+                                    <AuxiliaryPanel
+                                        icon={<Icon.LinkSimple className="h-3.5 w-3.5" />}
+                                        title="Back References"
+                                    >
+                                        <ul className="flex flex-col">
+                                            {backReferences.map((backLink) => (
+                                                <li key={backLink.id}>
+                                                    <Link
+                                                        to={NOTE_ROUTE}
+                                                        params={{ id: backLink.id }}
+                                                        className="flex items-center gap-2 rounded-[10px] px-2.5 py-1.5 text-fg-secondary transition-colors hover:bg-hover-subtle hover:text-fg-default"
+                                                    >
+                                                        <Icon.File className="h-3.5 w-3.5 shrink-0 text-fg-tertiary" />
+                                                        <Text
+                                                            as="span"
+                                                            variant="body"
+                                                            weight="medium"
+                                                            className="text-current"
+                                                        >
+                                                            {backLink.title}
+                                                        </Text>
+                                                    </Link>
+                                                </li>
+                                            ))}
+                                        </ul>
+                                    </AuxiliaryPanel>
+                                )
+                            }
+                        />
+                    </QueryBoundary>
+                </div>
 
                 <LayoutModal
                     isOpen={isLayoutModalOpen}

--- a/packages/client/src/styles/blocknote-overrides.scss
+++ b/packages/client/src/styles/blocknote-overrides.scss
@@ -349,41 +349,113 @@ html.dark .bn-mantine .bn-menu-dropdown {
 
 /* BlockNote body typography hierarchy */
 .bn-default-styles {
-    h1 {
-        font-size: 1.125rem;
-        font-weight: 700;
-        line-height: 1.35;
-        letter-spacing: -0.01em;
-
-        @media (min-width: 640px) {
-            font-size: 1.25rem;
-        }
+    [data-content-type='heading'] {
+        --level: 1.375rem;
+        --ob-heading-color: var(--fg-default);
+        --ob-heading-letter-spacing: -0.01em;
+        --ob-heading-line-height: 1.35;
+        --ob-heading-weight: 700;
     }
 
-    h2 {
-        font-size: 1rem;
-        font-weight: 600;
-        line-height: 1.4;
-        letter-spacing: -0.005em;
-
-        @media (min-width: 640px) {
-            font-size: 1.125rem;
-        }
+    [data-content-type='heading'][data-level='2'] {
+        --level: 1.1875rem;
+        --ob-heading-letter-spacing: -0.005em;
+        --ob-heading-line-height: 1.4;
+        --ob-heading-weight: 650;
     }
 
-    h3 {
-        font-size: 1rem;
-        font-weight: 600;
-        line-height: 1.5;
+    [data-content-type='heading'][data-level='3'] {
+        --level: 1.0625rem;
+        --ob-heading-letter-spacing: 0;
+        --ob-heading-line-height: 1.45;
+        --ob-heading-weight: 620;
     }
 
-    h4,
-    h5,
-    h6 {
-        font-size: 1rem;
-        font-weight: 500;
-        line-height: 1.5;
+    [data-content-type='heading'][data-level='4'] {
+        --level: 1rem;
+        --ob-heading-letter-spacing: 0;
+        --ob-heading-line-height: 1.5;
+        --ob-heading-weight: 600;
     }
+
+    [data-content-type='heading'][data-level='5'] {
+        --level: 1rem;
+        --ob-heading-color: var(--fg-muted);
+        --ob-heading-letter-spacing: 0;
+        --ob-heading-line-height: 1.5;
+        --ob-heading-weight: 560;
+    }
+
+    [data-content-type='heading'][data-level='6'] {
+        --level: 1rem;
+        --ob-heading-color: var(--fg-secondary);
+        --ob-heading-letter-spacing: 0.01em;
+        --ob-heading-line-height: 1.5;
+        --ob-heading-weight: 520;
+    }
+
+    [data-prev-level='1'] {
+        --prev-level: 1.375rem;
+        --ob-prev-heading-letter-spacing: -0.01em;
+        --ob-prev-heading-line-height: 1.35;
+        --ob-prev-heading-weight: 700;
+    }
+
+    [data-prev-level='2'] {
+        --prev-level: 1.1875rem;
+        --ob-prev-heading-letter-spacing: -0.005em;
+        --ob-prev-heading-line-height: 1.4;
+        --ob-prev-heading-weight: 650;
+    }
+
+    [data-prev-level='3'] {
+        --prev-level: 1.0625rem;
+        --ob-prev-heading-letter-spacing: 0;
+        --ob-prev-heading-line-height: 1.45;
+        --ob-prev-heading-weight: 620;
+    }
+
+    [data-prev-level='4'] {
+        --prev-level: 1rem;
+        --ob-prev-heading-letter-spacing: 0;
+        --ob-prev-heading-line-height: 1.5;
+        --ob-prev-heading-weight: 600;
+    }
+
+    [data-prev-level='5'] {
+        --prev-level: 1rem;
+        --ob-prev-heading-letter-spacing: 0;
+        --ob-prev-heading-line-height: 1.5;
+        --ob-prev-heading-weight: 560;
+    }
+
+    [data-prev-level='6'] {
+        --prev-level: 1rem;
+        --ob-prev-heading-letter-spacing: 0.01em;
+        --ob-prev-heading-line-height: 1.5;
+        --ob-prev-heading-weight: 520;
+    }
+
+    .bn-block-outer:not([data-prev-type]) > .bn-block > .bn-block-content[data-content-type='heading'],
+    .bn-block-outer:not([data-prev-type])
+        > .bn-block
+        > div[data-type='modification']
+        > div[data-type='modification']
+        > .bn-block-content[data-content-type='heading'] {
+        color: var(--ob-heading-color, var(--fg-default));
+        font-size: var(--level);
+        font-weight: var(--ob-heading-weight, 600);
+        letter-spacing: var(--ob-heading-letter-spacing, 0);
+        line-height: var(--ob-heading-line-height, 1.5);
+    }
+
+    .bn-block-outer[data-prev-type='heading'] > .bn-block > .bn-block-content {
+        font-size: var(--prev-level);
+        font-weight: var(--ob-prev-heading-weight, 600);
+        letter-spacing: var(--ob-prev-heading-letter-spacing, 0);
+        line-height: var(--ob-prev-heading-line-height, 1.5);
+    }
+
 
     p {
         line-height: 1.7;
@@ -398,3 +470,22 @@ html.dark .bn-mantine .bn-menu-dropdown {
     content: var(--index) ".";
     white-space: nowrap;
 }
+/* Match BlockNote side menu hitbox to the chosen heading typography. */
+.bn-side-menu[data-block-type='heading'][data-level='1'] {
+    height: 36px;
+}
+
+.bn-side-menu[data-block-type='heading'][data-level='2'] {
+    height: 33px;
+}
+
+.bn-side-menu[data-block-type='heading'][data-level='3'] {
+    height: 31px;
+}
+
+.bn-side-menu[data-block-type='heading'][data-level='4'],
+.bn-side-menu[data-block-type='heading'][data-level='5'],
+.bn-side-menu[data-block-type='heading'][data-level='6'] {
+    height: 30px;
+}
+


### PR DESCRIPTION
## :dart: Goal
Fix BlockNote heading drag-and-drop alignment after the note typography override, while keeping the change scoped as a visual patch.

## :hammer_and_wrench: Core Changes
- Reworked BlockNote heading typography overrides so H1-H6 use the chosen smaller hierarchy without replacing the default heading schema/render implementation.
- Matched BlockNote side-menu heading hitbox heights to the custom heading typography to fix DnD/drop cursor alignment.
- Normalized note auxiliary panel spacing with a parent gap stack and updated note skeleton heights to reduce loading layout shift.

## :brain: Key Decisions
- Kept BlockNote's default heading implementation intact to preserve existing editor, Markdown, and MCP heading behavior.
- Removed the heading level badge idea because it added editor noise without solving the DnD issue.
- Treated the change as `release: patch` because it is a backward-compatible UI bug fix and polish pass.

## :test_tube: Verification Guide
- `pnpm --filter @ocean-brain/client lint` — passes.
- `pnpm --filter @ocean-brain/client type-check` — passes.
- `pnpm --filter @ocean-brain/client build` — passes.
- Manual check: hover and drag BlockNote heading blocks; side menu and drop cursor should align with the visible heading height.

## :white_check_mark: Checklist
- [x] PR title follows `<emoji> <subject>` and starts with an English verb.
- [x] Body section headings match the PR template exactly.
- [x] Verification commands are documented with expected pass results.
- [x] Exactly one release impact label is applied: `release: patch`.
