### PR TITLE
🚑 Fix mobile sidebar pointer events

### DIFF
--- a/packages/client/src/components/layout/SiteLayout/LayoutShell.spec.tsx
+++ b/packages/client/src/components/layout/SiteLayout/LayoutShell.spec.tsx
@@ -46,11 +46,15 @@ describe('<LayoutShell />', () => {
         });
 
         const toggleButton = screen.getByRole('button', { name: 'Toggle sidebar' });
+        const sidebar = screen.getByText('Sidebar').closest('aside');
 
         expect(toggleButton).toHaveAttribute('aria-expanded', 'false');
+        expect(sidebar).toHaveClass('pointer-events-none');
 
         fireEvent.click(toggleButton);
 
         expect(toggleButton).toHaveAttribute('aria-expanded', 'true');
+        expect(sidebar).toHaveClass('pointer-events-auto');
+        expect(sidebar).not.toHaveClass('pointer-events-none');
     });
 });

--- a/packages/client/src/components/layout/SiteLayout/LayoutShell.tsx
+++ b/packages/client/src/components/layout/SiteLayout/LayoutShell.tsx
@@ -41,8 +41,6 @@ const sidebarClassName = classNames(
     'border-border-subtle',
     'bg-[var(--page-bg)]',
     'pb-20',
-    'pointer-events-none',
-    '-translate-x-full',
     'md:static',
     'md:w-auto',
     'md:translate-x-0',
@@ -50,6 +48,7 @@ const sidebarClassName = classNames(
     'md:pb-0',
     'md:pointer-events-auto',
 );
+const sidebarClosedClassName = 'pointer-events-none -translate-x-full';
 const sidebarOpenClassName = 'pointer-events-auto translate-x-0';
 const centerClassName = classNames(
     'flex',
@@ -115,7 +114,10 @@ const LayoutShell = ({ sidebar, topNavigation, children }: LayoutShellProps) => 
                     <Icon.Menu className="h-6 w-6" />
                 </button>
             </div>
-            <aside id={sidebarId} className={classNames(sidebarClassName, isMenuOpen && sidebarOpenClassName)}>
+            <aside
+                id={sidebarId}
+                className={classNames(sidebarClassName, isMenuOpen ? sidebarOpenClassName : sidebarClosedClassName)}
+            >
                 {sidebar}
             </aside>
             <main className={centerClassName}>


### PR DESCRIPTION
## :dart: Goal
Fix the mobile sidebar regression where the sidebar is visible after opening but taps pass through to the page behind it.

## :hammer_and_wrench: Core Changes
- Split mobile sidebar open and closed pointer-event/transform classes into mutually exclusive state classes.
- Added a layout test that verifies the opened sidebar has `pointer-events-auto` and no lingering `pointer-events-none` class.

## :brain: Key Decisions
- Keep this PR scoped to the mobile navigation hotfix only.
- Treat this as a patch release fix because it restores broken existing behavior without adding a new capability.

## :test_tube: Verification Guide
- `pnpm --filter @ocean-brain/client test LayoutShell.spec.tsx --run` — passes.
- `pnpm lint` — passes.
- `pnpm type-check` — passes.
- `pnpm build` — passes.
- Manual check: open the mobile sidebar and verify sidebar controls receive taps instead of the page behind it.

## :white_check_mark: Checklist
- [x] Title follows `<emoji> <subject>` and starts with an English verb.
- [x] Local validation for the changed scope is complete.
- [x] PR body follows the required template headings.
- [x] Release impact: `release: patch`.
