### PR TITLE
🐛 Fix mobile layout scroll boundary

### DIFF
--- a/packages/client/src/components/layout/SiteLayout/LayoutShell.spec.tsx
+++ b/packages/client/src/components/layout/SiteLayout/LayoutShell.spec.tsx
@@ -26,6 +26,12 @@ describe('<LayoutShell />', () => {
         expect(await screen.findByText('Sidebar')).toBeInTheDocument();
         expect(await screen.findByText('Top Navigation')).toBeInTheDocument();
         expect(await screen.findByText('Page Content')).toBeInTheDocument();
+
+        const root = screen.getByText('Page Content').closest('main')?.parentElement;
+        const main = screen.getByText('Page Content').closest('main');
+
+        expect(root).toHaveClass('h-dvh', 'overflow-hidden');
+        expect(main).toHaveClass('min-h-0', 'overflow-y-auto', 'overscroll-contain');
     });
 
     it('exposes the mobile sidebar toggle as an accessible stateful control', async () => {

--- a/packages/client/src/components/layout/SiteLayout/LayoutShell.tsx
+++ b/packages/client/src/components/layout/SiteLayout/LayoutShell.tsx
@@ -6,7 +6,7 @@ import { useEffect, useState } from 'react';
 import * as Icon from '~/components/icon';
 import { RestoreParentScroll } from '~/components/shared';
 
-const rootClassName = 'flex h-full w-full flex-row';
+const rootClassName = 'flex h-dvh min-h-0 w-full flex-row overflow-hidden';
 const menuButtonClassName = classNames(
     'fixed',
     'bottom-4',
@@ -53,11 +53,13 @@ const sidebarOpenClassName = 'pointer-events-auto translate-x-0';
 const centerClassName = classNames(
     'flex',
     'h-full',
+    'min-h-0',
     'min-w-0',
     'flex-1',
     'flex-col',
     'overflow-x-hidden',
     'overflow-y-auto',
+    'overscroll-contain',
     '[scrollbar-gutter:stable]',
 );
 const topClassName = classNames(
@@ -83,7 +85,17 @@ const topContentClassName = classNames(
     '[scrollbar-width:none]',
     '[&::-webkit-scrollbar]:hidden',
 );
-const contentClassName = 'min-w-0 max-w-full flex-1 overflow-x-clip p-4 max-md:pb-20';
+const contentClassName = classNames(
+    'min-h-0',
+    'min-w-0',
+    'max-w-full',
+    'flex-1',
+    'overflow-x-clip',
+    'px-4',
+    'pt-4',
+    'pb-4',
+    'max-md:pb-[calc(6rem+env(safe-area-inset-bottom))]',
+);
 
 interface LayoutShellProps {
     sidebar: ReactNode;


### PR DESCRIPTION
## :dart: Goal
Fix the mobile layout scroll boundary so the page shell keeps its top navigation stable and preserves bottom breathing room near the floating mobile menu.

## :hammer_and_wrench: Core Changes
- Constrain the site layout root with dynamic viewport height and hidden outer overflow.
- Keep the main content as the internal scroll container with `min-h-0` and overscroll containment.
- Replace shorthand content padding with directional padding so the mobile safe-area bottom padding is not hidden by generic padding rules.
- Extend the layout shell test to cover the scroll-container classes.

## :brain: Key Decisions
- Keep the fix inside the Tailwind-based layout instead of reintroducing CSS modules.
- Treat this as a patch fix because it restores expected mobile layout behavior without adding a new user-visible capability.

## :test_tube: Verification Guide
- `pnpm --filter @ocean-brain/client test LayoutShell.spec.tsx --run` — passes.
- `pnpm --filter @ocean-brain/client lint` — passes.
- `pnpm --filter @ocean-brain/client type-check` — passes.
- Manual check: on mobile width, scroll to the bottom of long pages and confirm the top navigation remains stable and bottom content is not hidden behind the floating menu.

## :white_check_mark: Checklist
- [x] Title follows `<emoji> <subject>` and starts with an English verb.
- [x] Local validation for the changed scope is complete.
- [x] PR body follows the required template headings.
- [x] Release impact: `release: patch`.
