### PR TITLE
🐛 Fix MCP note links with bracketed titles

### DIFF
--- a/packages/server/src/modules/blocknote.ts
+++ b/packages/server/src/modules/blocknote.ts
@@ -367,7 +367,7 @@ function replaceExplicitReferenceTokens(
     text: string,
     placeholderToReference: Map<string, { id: string; title: string; token: string }>,
 ) {
-    return text.replace(/\[\[([^\]\n]+)\]\]\(note:([^)\s]+)\)/g, (token, title: string, id: string) => {
+    return text.replace(/\[\[([^\n]+?)\]\]\(note:([^)\s]+)\)/g, (token, title: string, id: string) => {
         const placeholder = createReferencePlaceholder(placeholderToReference.size);
         placeholderToReference.set(placeholder, { id, title, token });
         return placeholder;

--- a/packages/server/test/blocknote.test.ts
+++ b/packages/server/test/blocknote.test.ts
@@ -348,6 +348,49 @@ test('markdownToBlocksJson restores note-id references with current note title',
     ]);
 });
 
+test('markdownToBlocksJson restores note-id references whose title contains square brackets', async () => {
+    const cases = [
+        { markdown: 'See [[[P] Project brief]](note:123)', currentTitle: '[P] Project brief' },
+        { markdown: 'See [[Project [P] brief]](note:123)', currentTitle: 'Project [P] brief' },
+        { markdown: 'See [[Project brief[P]]](note:123)', currentTitle: 'Project brief[P]' },
+    ];
+
+    for (const { markdown, currentTitle } of cases) {
+        const contentJson = await markdownToBlocksJson(markdown, {
+            ensureTag: async () => {
+                throw new Error('should not ensure tags');
+            },
+            findNotesByTitle: async () => {
+                throw new Error('should not look up title-based references');
+            },
+            findNoteById: async (id) =>
+                id === '123'
+                    ? {
+                          id: '123',
+                          title: currentTitle,
+                      }
+                    : null,
+        });
+
+        const blocks = JSON.parse(contentJson);
+
+        assert.deepEqual(blocks[0].content, [
+            {
+                type: 'text',
+                text: 'See ',
+                styles: {},
+            },
+            {
+                type: 'reference',
+                props: {
+                    id: '123',
+                    title: currentTitle,
+                },
+            },
+        ]);
+    }
+});
+
 test('markdownToBlocksJson leaves missing note-id references as text', async () => {
     const contentJson = await markdownToBlocksJson('See [[Missing Title]](note:404)', {
         ensureTag: async () => {


### PR DESCRIPTION
## :dart: Goal
Fix MCP Markdown imports so ID-backed note links remain structured references when the displayed title contains square brackets.

## :hammer_and_wrench: Core Changes
- Relax explicit `[[title]](note:id)` reference matching so title text may include single square brackets.
- Add coverage for bracketed title text at the start, middle, and end of the note link title.

## :brain: Key Decisions
- Continue treating `note:id` as the source of truth for structured references.
- Do not add a new Markdown syntax; this only fixes an existing ID-backed link form.

## :test_tube: Verification Guide
- `pnpm exec tsx --tsconfig packages/server/tsconfig.json --test packages/server/test/blocknote.test.ts` — passes.
- `pnpm --filter @ocean-brain/server lint` — passes.
- `pnpm --filter @ocean-brain/server type-check` — passes.

## :white_check_mark: Checklist
- [x] Title follows `<emoji> <subject>` and starts with an English verb.
- [x] Local validation for the changed scope is complete.
- [x] PR body follows the required template headings.
- [x] Release impact: `release: patch`.
