### PR TITLE
🐛 Fix MCP delete orphan tag force

### DIFF
--- a/packages/server/src/features/note/http/mcp-delete.test.ts
+++ b/packages/server/src/features/note/http/mcp-delete.test.ts
@@ -62,8 +62,8 @@ test('mcp delete note handler returns the deleted note payload', async () => {
         reminderCount: 0,
         backReferences: [],
         orphanedTagNames: ['temp'],
-        requiresForce: true,
-        forceReasons: ['orphan_tags'],
+        requiresForce: false,
+        forceReasons: [],
     }));
     const response = createResponse();
 
@@ -81,8 +81,8 @@ test('mcp delete note handler returns the deleted note payload', async () => {
             reminderCount: 0,
             backReferences: [],
             orphanedTagNames: ['temp'],
-            requiresForce: true,
-            forceReasons: ['orphan_tags'],
+            requiresForce: false,
+            forceReasons: [],
         },
     });
 });
@@ -99,8 +99,8 @@ test('mcp delete note handler emits a deleted server event', async () => {
             reminderCount: 0,
             backReferences: [],
             orphanedTagNames: ['temp'],
-            requiresForce: true,
-            forceReasons: ['orphan_tags'],
+            requiresForce: false,
+            forceReasons: [],
         }),
         (event) => {
             emittedEvents.push(event);

--- a/packages/server/src/features/note/services/cleanup.test.ts
+++ b/packages/server/src/features/note/services/cleanup.test.ts
@@ -100,7 +100,7 @@ test('note cleanup preview exposes reminders, backlinks, and orphaned tags', asy
         ],
         orphanedTagNames: ['temp'],
         requiresForce: true,
-        forceReasons: ['note_is_pinned', 'has_reminders', 'has_back_references', 'orphan_tags'],
+        forceReasons: ['note_is_pinned', 'has_reminders', 'has_back_references'],
     });
 });
 
@@ -149,7 +149,7 @@ test('note cleanup delete removes the note and prunes orphan tags', async () => 
         reminderCount: 0,
         backReferences: [],
         orphanedTagNames: ['temp'],
-        requiresForce: true,
-        forceReasons: ['orphan_tags'],
+        requiresForce: false,
+        forceReasons: [],
     });
 });

--- a/packages/server/src/features/note/services/cleanup.ts
+++ b/packages/server/src/features/note/services/cleanup.ts
@@ -178,8 +178,8 @@ export const createNoteCleanupService = (deps: {
             })),
             orphanedTagNames: orphanedTags.map((tag) => tag.name),
             orphanedTagIds: orphanedTags.map((tag) => tag.id),
-            requiresForce: candidate.requiresForce || orphanedTags.length > 0,
-            forceReasons: [...candidate.forceReasons, ...(orphanedTags.length > 0 ? ['orphan_tags'] : [])],
+            requiresForce: candidate.requiresForce,
+            forceReasons: candidate.forceReasons,
         };
     };
 


### PR DESCRIPTION
## :dart: Goal
Fix MCP note delete previews so orphaned tag cleanup is reported as preview information without requiring an unnecessary force confirmation by itself.

## :hammer_and_wrench: Core Changes
- Keep orphaned tag names and ids in cleanup preview output.
- Stop treating orphaned tags as a force reason when there are no other high-risk delete conditions.
- Update MCP delete and cleanup service tests for the adjusted force behavior.

## :brain: Key Decisions
- Orphaned tags are still shown in the preview because they are useful cleanup context.
- Force remains reserved for riskier cases like pinned notes, reminders, and back references.
- Treat this as a minor release impact because it changes MCP delete confirmation behavior within the broader MCP safety cleanup scope.

## :test_tube: Verification Guide
- `pnpm exec tsx --tsconfig packages/server/tsconfig.json --test packages/server/src/features/note/services/cleanup.test.ts packages/server/src/features/note/http/mcp-delete.test.ts` — passes.
- `pnpm --filter @ocean-brain/server lint` — passes.
- `pnpm --filter @ocean-brain/server type-check` — passes.

## :white_check_mark: Checklist
- [x] Title follows `<emoji> <subject>` and starts with an English verb.
- [x] Local validation for the changed scope is complete.
- [x] PR body follows the required template headings.
- [x] Release impact: `release: minor`.