### PR TITLE
🐛 Fix view table chip sizing

### DIFF
--- a/packages/client/src/components/view/ViewChip.tsx
+++ b/packages/client/src/components/view/ViewChip.tsx
@@ -1,0 +1,42 @@
+import classNames from 'classnames';
+import type { HTMLAttributes, ReactNode } from 'react';
+
+type ViewChipSize = 'compact' | 'regular';
+
+interface ViewChipProps extends HTMLAttributes<HTMLSpanElement> {
+    children: ReactNode;
+    contentClassName?: string;
+    size?: ViewChipSize;
+    truncateContent?: boolean;
+}
+
+const sizeClassNames: Record<ViewChipSize, string> = {
+    compact: 'h-[22px] px-2',
+    regular: 'h-7 px-2.5',
+};
+
+export default function ViewChip({
+    children,
+    className,
+    contentClassName,
+    size = 'regular',
+    truncateContent = true,
+    ...props
+}: ViewChipProps) {
+    return (
+        <span
+            className={classNames(
+                'inline-flex min-w-0 items-center overflow-hidden whitespace-nowrap rounded-full border text-xs font-medium leading-none',
+                sizeClassNames[size],
+                className,
+            )}
+            {...props}
+        >
+            {truncateContent ? (
+                <span className={classNames('min-w-0 truncate', contentClassName)}>{children}</span>
+            ) : (
+                children
+            )}
+        </span>
+    );
+}

--- a/packages/client/src/components/view/ViewSectionCard.tsx
+++ b/packages/client/src/components/view/ViewSectionCard.tsx
@@ -14,6 +14,7 @@ import {
     getViewDisplayTypeLabel,
     getViewTagMatchToken,
 } from '~/modules/view-dashboard';
+import ViewChip from './ViewChip';
 import ViewSectionRenderer from './ViewSectionRenderer';
 
 interface ViewSectionCardProps {
@@ -106,33 +107,33 @@ export default function ViewSectionCard({ section, onEdit, onDelete, dragHandle 
                         </div>
                     </div>
                     <div className="mt-3 flex flex-wrap gap-1.5">
-                        <span className="inline-flex items-center rounded-full border border-border-subtle/80 bg-elevated px-2.5 py-1 text-xs font-medium text-fg-secondary">
+                        <ViewChip className="max-w-full border-border-subtle/80 bg-elevated text-fg-secondary">
                             {getViewDisplayTypeLabel(section.displayType)}
-                        </span>
+                        </ViewChip>
                         {section.tagNames.map((tagName, index) => (
-                            <div key={tagName} className="flex items-center gap-1.5">
+                            <div key={tagName} className="flex min-w-0 items-center gap-1.5">
                                 {index > 0 && (
                                     <span className="px-0.5 text-[10px] font-semibold tracking-[0.08em] text-fg-tertiary/85">
                                         {tagMatchToken}
                                     </span>
                                 )}
-                                <span className="inline-flex items-center rounded-full border border-border-subtle/80 bg-transparent px-2.5 py-1 text-xs font-medium text-fg-secondary">
+                                <ViewChip className="max-w-full border-border-subtle/80 bg-transparent text-fg-secondary">
                                     {tagName}
-                                </span>
+                                </ViewChip>
                             </div>
                         ))}
                         {section.propertyFilters.map((filter) => (
-                            <span
+                            <ViewChip
                                 key={`${filter.key}-${filter.operator}-${filter.value ?? ''}`}
-                                className="inline-flex items-center rounded-full border border-border-subtle/80 bg-subtle px-2.5 py-1 text-xs font-medium text-fg-secondary"
+                                className="max-w-full border-border-subtle/80 bg-subtle text-fg-secondary"
                             >
                                 {formatViewPropertyFilter(filter)}
-                            </span>
+                            </ViewChip>
                         ))}
                         {!hasFilters && (
-                            <span className="inline-flex items-center rounded-full border border-border-subtle/80 bg-transparent px-2.5 py-1 text-xs font-medium text-fg-tertiary">
+                            <ViewChip className="max-w-full border-border-subtle/80 bg-transparent text-fg-tertiary">
                                 All notes
-                            </span>
+                            </ViewChip>
                         )}
                     </div>
                 </div>

--- a/packages/client/src/components/view/ViewSectionTableRenderer.tsx
+++ b/packages/client/src/components/view/ViewSectionTableRenderer.tsx
@@ -6,6 +6,7 @@ import type { ViewSection, ViewSortBy, ViewTableColumn } from '~/models/view.mod
 import { timeSince } from '~/modules/time';
 import { NOTE_ROUTE } from '~/modules/url';
 import { getViewTableColumnLabel, normalizeViewTableColumns } from '~/modules/view-dashboard';
+import ViewChip from './ViewChip';
 
 interface ViewSectionTableRendererProps {
     section: ViewSection;
@@ -42,6 +43,8 @@ const SORTABLE_TABLE_COLUMNS: Partial<Record<ViewTableColumn, ViewSortBy>> = {
     createdAt: 'createdAt',
     updatedAt: 'updatedAt',
 };
+const summaryListClassName = 'flex h-[22px] min-w-0 max-w-full items-center gap-1.5 overflow-hidden whitespace-nowrap';
+const emptySummaryClassName = 'text-xs leading-5 text-fg-tertiary';
 
 const getTableMinWidth = (columns: ViewTableColumn[]) => {
     const width = columns.reduce((totalWidth, column) => totalWidth + TABLE_COLUMN_WIDTHS[column], 0);
@@ -55,26 +58,27 @@ const renderTagSummary = (note: Note, options: { hideEmpty?: boolean } = {}) => 
             return null;
         }
 
-        return <span className="text-fg-tertiary">—</span>;
+        return <span className={emptySummaryClassName}>—</span>;
     }
 
     const visibleTags = note.tags.slice(0, 3);
     const hiddenCount = note.tags.length - visibleTags.length;
 
     return (
-        <div className="flex min-w-0 max-w-full gap-1.5 overflow-hidden">
+        <div className={summaryListClassName}>
             {visibleTags.map((tag) => (
-                <span
+                <ViewChip
                     key={tag.id}
-                    className="inline-flex max-w-[132px] shrink-0 items-center rounded-full border border-border-subtle bg-transparent px-2 py-0.5 text-xs font-medium text-fg-secondary"
+                    size="compact"
+                    className="max-w-[132px] shrink-0 border-border-subtle bg-transparent text-fg-secondary"
                 >
-                    <span className="truncate">{tag.name}</span>
-                </span>
+                    {tag.name}
+                </ViewChip>
             ))}
             {hiddenCount > 0 && (
-                <span className="inline-flex items-center rounded-full border border-border-subtle bg-subtle px-2 py-0.5 text-xs font-medium text-fg-tertiary">
+                <ViewChip size="compact" className="shrink-0 border-border-subtle bg-subtle text-fg-tertiary">
                     +{hiddenCount}
-                </span>
+                </ViewChip>
             )}
         </div>
     );
@@ -88,26 +92,28 @@ const renderPropertySummary = (note: Note, options: { hideEmpty?: boolean } = {}
             return null;
         }
 
-        return <span className="text-fg-tertiary">—</span>;
+        return <span className={emptySummaryClassName}>—</span>;
     }
 
     const hiddenCount = (note.properties?.length ?? 0) - visibleProperties.length;
 
     return (
-        <div className="flex min-w-0 max-w-full gap-1.5 overflow-hidden">
+        <div className={summaryListClassName}>
             {visibleProperties.map((property) => (
-                <span
+                <ViewChip
                     key={property.key}
-                    className="inline-flex max-w-[190px] shrink-0 items-center gap-1 rounded-full border border-border-subtle bg-subtle px-2 py-0.5 text-xs font-medium text-fg-secondary"
+                    size="compact"
+                    truncateContent={false}
+                    className="max-w-[190px] shrink-0 gap-1 border-border-subtle bg-subtle text-fg-secondary"
                 >
-                    <span className="max-w-[76px] shrink-0 truncate text-fg-tertiary">{property.name}</span>
+                    <span className="min-w-0 max-w-[76px] shrink truncate text-fg-tertiary">{property.name}</span>
                     <span className="min-w-0 truncate">{formatPropertyValue(property) || '—'}</span>
-                </span>
+                </ViewChip>
             ))}
             {hiddenCount > 0 && (
-                <span className="inline-flex items-center rounded-full border border-border-subtle bg-subtle px-2 py-0.5 text-xs font-medium text-fg-tertiary">
+                <ViewChip size="compact" className="shrink-0 border-border-subtle bg-subtle text-fg-tertiary">
                     +{hiddenCount}
-                </span>
+                </ViewChip>
             )}
         </div>
     );
@@ -167,13 +173,13 @@ export default function ViewSectionTableRenderer({
         switch (column) {
             case 'tags':
                 return (
-                    <td key={column} className="px-3 py-2.5 align-middle">
+                    <td key={column} className="overflow-hidden px-3 py-2.5 align-middle">
                         {renderTagSummary(note)}
                     </td>
                 );
             case 'properties':
                 return (
-                    <td key={column} className="px-3 py-2.5 align-middle">
+                    <td key={column} className="overflow-hidden px-3 py-2.5 align-middle">
                         {renderPropertySummary(note)}
                     </td>
                 );

--- a/packages/client/src/components/view/index.ts
+++ b/packages/client/src/components/view/index.ts
@@ -1,3 +1,4 @@
+export { default as ViewChip } from './ViewChip';
 export { default as ViewSectionCard } from './ViewSectionCard';
 export type { ViewSectionDialogDraft } from './ViewSectionDialog';
 export { default as ViewSectionDialog } from './ViewSectionDialog';

--- a/packages/client/src/pages/ViewNotes.tsx
+++ b/packages/client/src/pages/ViewNotes.tsx
@@ -7,7 +7,7 @@ import { QueryBoundary } from '~/components/app';
 import { NoteListCard } from '~/components/note';
 import { Empty, FallbackRender, PageLayout, Pagination, Skeleton } from '~/components/shared';
 import { Text, useToast } from '~/components/ui';
-import { ViewSectionTableRenderer } from '~/components/view';
+import { ViewChip, ViewSectionTableRenderer } from '~/components/view';
 import useNoteMutate from '~/hooks/resource/useNoteMutate';
 import type { ViewSortBy, ViewSortOrder } from '~/models/view.model';
 import { queryKeys } from '~/modules/query-key-factory';
@@ -142,25 +142,25 @@ function ViewNotesContent() {
                     </Text>
                     <div className="flex flex-wrap gap-1.5">
                         {tagNames.map((tagName) => (
-                            <span
+                            <ViewChip
                                 key={tagName}
-                                className="inline-flex items-center rounded-full border border-border-subtle bg-hover-subtle px-2.5 py-1 text-xs font-medium text-fg-secondary"
+                                className="max-w-full border-border-subtle bg-hover-subtle text-fg-secondary"
                             >
                                 {tagName}
-                            </span>
+                            </ViewChip>
                         ))}
                         {propertyFilters.map((filter) => (
-                            <span
+                            <ViewChip
                                 key={`${filter.key}-${filter.operator}-${filter.value ?? ''}`}
-                                className="inline-flex items-center rounded-full border border-border-subtle bg-hover-subtle px-2.5 py-1 text-xs font-medium text-fg-secondary"
+                                className="max-w-full border-border-subtle bg-hover-subtle text-fg-secondary"
                             >
                                 {formatViewPropertyFilter(filter)}
-                            </span>
+                            </ViewChip>
                         ))}
                         {tagNames.length === 0 && propertyFilters.length === 0 && (
-                            <span className="inline-flex items-center rounded-full border border-border-subtle bg-hover-subtle px-2.5 py-1 text-xs font-medium text-fg-secondary">
+                            <ViewChip className="max-w-full border-border-subtle bg-hover-subtle text-fg-secondary">
                                 All notes
-                            </span>
+                            </ViewChip>
                         )}
                     </div>
                 </div>


### PR DESCRIPTION
## :dart: Goal
- Prevent tag and property chips in view tables from becoming taller when long labels or inherited wrapping rules apply.
- Keep table rows and view filter summaries visually stable across dashboard and result pages.

## :hammer_and_wrench: Core Changes
- Added a shared `ViewChip` component for view-specific chip sizing, nowrap overflow handling, and truncation.
- Reused `ViewChip` in table tag/property cells, view section filter summaries, and view result page filter summaries.
- Kept table chips compact while preserving the larger filter chip sizing used in section headers.

## :brain: Key Decisions
- Kept the component under `components/view` because the fixed chip sizing is tied to view table/filter layouts rather than a global badge pattern.
- Left global word wrapping untouched, since the inherited wrapping behavior is still useful for editor and content surfaces.

## :test_tube: Verification Guide
### How to verify
1. Run `pnpm --filter @ocean-brain/client lint`.
2. Run `pnpm --filter @ocean-brain/client type-check`.
3. Run `pnpm --filter @ocean-brain/client test -- ViewSectionTableRenderer.spec.tsx`.
4. Open `/views` and confirm table tag/property chips and filter chips stay single-line with stable heights.

### Expected result
- Lint, type-check, and tests pass.
- View table chips remain compact instead of wrapping into taller pills.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)