### PR TITLE
🛠 Remove Docker image build caches

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM node:22-alpine
 
 ARG VERSION=latest
-RUN npm i -g ocean-brain@${VERSION}
+RUN npm i -g --omit=dev --no-audit --no-fund ocean-brain@${VERSION} \
+    && npm cache clean --force \
+    && rm -rf /root/.npm /root/.cache /tmp/*
 
 RUN mkdir -p /data /assets/images
 ENV OCEAN_BRAIN_DATA_DIR=/data


### PR DESCRIPTION
## :dart: Goal
- Reduce the published Docker image size by removing package-manager and build-time caches from the final image layer.
- Keep the container runtime behavior unchanged while lowering pull and local storage cost.

## :hammer_and_wrench: Core Changes
- Install the published `ocean-brain` package with npm audit/funding output disabled for Docker builds.
- Clean npm, root cache, and temporary files in the same layer as the global package install.
- Observed local Docker image size changed from about `1.15GB` to `625MB` for `VERSION=0.7.3` on arm64.

## :brain: Key Decisions
- Kept the existing npm-package-based Docker release flow instead of switching to a larger multi-stage rebuild in this patch.
- Removed only build/download caches under `/root` and `/tmp`; installed runtime files under `/usr/local/lib/node_modules/ocean-brain` remain intact.
- Release impact: `release: patch`.
- Expected release version: `0.7.4`.
- Tag plan: `v0.7.4` after merge and release approval.

## :test_tube: Verification Guide
### How to verify
1. `docker build --no-cache --build-arg VERSION=0.7.3 -t ocean-brain:local-verify .`
2. `docker run --rm ocean-brain:local-verify ocean-brain --version`
3. `docker run --rm ocean-brain:local-verify sh -lc 'cd /usr/local/lib/node_modules/ocean-brain && node -e "require(\"sqlite3\"); console.log(require.resolve(\"prisma/build/index.js\")); console.log(require.resolve(\"@prisma/client\")); console.log(require.resolve(\".prisma/client\"))"'`
4. Run the container with mounted `/data` and `/assets`, request `/`, create/query a note through GraphQL, then restart with the same `/data` volume and query it again.
5. CLI SMOKE workflow dispatch on this branch: https://github.com/baealex/ocean-brain/actions/runs/28027874502

### Expected result
- Docker build completes successfully.
- Image size is about `625MB` locally on arm64.
- CLI prints version `0.7.3` for the verification build.
- `sqlite3`, Prisma CLI, `@prisma/client`, and generated `.prisma/client` resolve successfully.
- Server starts, Prisma migrations apply, HTTP `/` returns the client HTML, GraphQL create/query works, and data persists after restart.
- CLI SMOKE passes on ubuntu, macOS, and Windows.

## :white_check_mark: Checklist
- [x] Lint completed (not applicable; Dockerfile-only change)
- [x] Type-check completed (not applicable; Dockerfile-only change)
- [x] Tests completed (local Docker smoke plus CLI SMOKE workflow pass)
- [x] Documentation updated (not needed)
