### PR TITLE
🐛 Wire select accessible labels

### DIFF
--- a/packages/client/src/components/calendar/CalendarHeader.tsx
+++ b/packages/client/src/components/calendar/CalendarHeader.tsx
@@ -63,11 +63,12 @@ export const CalendarHeader = ({ month, year, type, onPrevMonth, onNextMonth, on
                 <div className="surface-base inline-flex flex-wrap items-center gap-3 rounded-[16px] px-3.5 py-2.5">
                     <div className="flex items-center gap-2">
                         <Icon.Calendar className="h-4 w-4 shrink-0 text-fg-tertiary" />
-                        <Text as="span" variant="label" weight="medium" tone="tertiary">
+                        <Text id="calendar-note-date-label" as="span" variant="label" weight="medium" tone="tertiary">
                             Note date
                         </Text>
                         <Select
                             value={type}
+                            aria-labelledby="calendar-note-date-label"
                             onValueChange={(value) => onTypeChange(value as CalendarDisplayType)}
                             variant="ghost"
                             size="sm"

--- a/packages/client/src/components/shared/NoteFilters.tsx
+++ b/packages/client/src/components/shared/NoteFilters.tsx
@@ -31,11 +31,12 @@ export default function NoteFilters({
             <div className="surface-base inline-flex flex-wrap items-center gap-3 rounded-[16px] px-3.5 py-2.5">
                 <div className="flex items-center gap-2">
                     <Icon.Grid className="h-4 w-4 shrink-0 text-fg-tertiary" />
-                    <Text as="span" variant="label" weight="medium" tone="tertiary">
+                    <Text id="note-filters-items-label" as="span" variant="label" weight="medium" tone="tertiary">
                         Items
                     </Text>
                     <Select
                         value={String(itemsPerPage)}
+                        aria-labelledby="note-filters-items-label"
                         onValueChange={(value) => {
                             const nextItemsPerPage = Number(value);
 
@@ -63,6 +64,7 @@ export default function NoteFilters({
                     </Text>
                     <Select
                         value={sortBy}
+                        ariaLabel="Sort field"
                         onValueChange={(value) => onSortByChange(value as SortBy)}
                         variant="ghost"
                         size="sm"
@@ -72,6 +74,7 @@ export default function NoteFilters({
                     </Select>
                     <Select
                         value={sortOrder}
+                        ariaLabel="Sort order"
                         onValueChange={(value) => onSortOrderChange(value as SortOrder)}
                         variant="ghost"
                         size="sm"

--- a/packages/client/src/components/ui/Select/Select.spec.tsx
+++ b/packages/client/src/components/ui/Select/Select.spec.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react';
+
+import { Select } from './Select';
+
+describe('<Select />', () => {
+    it('passes label and description props to the select trigger', () => {
+        render(
+            <>
+                <span id="sort-label">Sort by</span>
+                <span id="sort-description">Choose how notes are ordered</span>
+                <Select
+                    id="sort-select"
+                    aria-labelledby="sort-label"
+                    aria-describedby="sort-description"
+                    placeholder="Sort by"
+                />
+            </>,
+        );
+
+        const trigger = screen.getByRole('combobox', { name: 'Sort by' });
+
+        expect(trigger).toHaveAttribute('id', 'sort-select');
+        expect(trigger).toHaveAccessibleDescription('Choose how notes are ordered');
+    });
+});

--- a/packages/client/src/components/ui/Select/Select.tsx
+++ b/packages/client/src/components/ui/Select/Select.tsx
@@ -44,22 +44,28 @@ const selectTriggerVariants = cva(
 );
 
 export interface SelectProps extends VariantProps<typeof selectTriggerVariants> {
+    id?: string;
     value?: string;
     defaultValue?: string;
     onValueChange?: (value: string) => void;
     placeholder?: string;
     ariaLabel?: string;
+    'aria-labelledby'?: string;
+    'aria-describedby'?: string;
     className?: string;
     children: React.ReactNode;
     disabled?: boolean;
 }
 
 const Select = ({
+    id,
     value,
     defaultValue,
     onValueChange,
     placeholder,
     ariaLabel,
+    'aria-labelledby': ariaLabelledBy,
+    'aria-describedby': ariaDescribedBy,
     variant,
     size,
     className,
@@ -74,7 +80,10 @@ const Select = ({
             disabled={disabled}
         >
             <SelectPrimitive.Trigger
+                id={id}
                 aria-label={ariaLabel}
+                aria-labelledby={ariaLabelledBy}
+                aria-describedby={ariaDescribedBy}
                 className={selectTriggerVariants({
                     variant,
                     size,

--- a/packages/client/src/components/view/ViewSectionDialog.spec.tsx
+++ b/packages/client/src/components/view/ViewSectionDialog.spec.tsx
@@ -145,6 +145,24 @@ describe('<ViewSectionDialog />', () => {
         expect(screen.getByRole('radio', { name: 'Show as list' })).toHaveAttribute('aria-checked', 'true');
     });
 
+    it('labels sort and limit selects through their visible labels', () => {
+        render(
+            <ViewSectionDialog
+                open
+                mode="edit"
+                initialSection={createSection()}
+                availableTags={[]}
+                availableProperties={[]}
+                onClose={vi.fn()}
+                onSubmit={vi.fn()}
+            />,
+        );
+
+        expect(screen.getByRole('combobox', { name: 'Sort by' })).toBeInTheDocument();
+        expect(screen.getByRole('combobox', { name: 'Order' })).toBeInTheDocument();
+        expect(screen.getByRole('combobox', { name: 'Max notes' })).toBeInTheDocument();
+    });
+
     it('submits partial URL text for contains filters', async () => {
         const user = userEvent.setup();
         const handleSubmit = vi.fn();

--- a/packages/client/src/components/view/ViewSectionDialog.tsx
+++ b/packages/client/src/components/view/ViewSectionDialog.tsx
@@ -719,21 +719,28 @@ export default function ViewSectionDialog({
 
                         <div className="mt-4 grid gap-4 md:grid-cols-3">
                             <div className="flex flex-col gap-2">
-                                <Label htmlFor="view-section-sort-by" size="sm">
+                                <Label id="view-section-sort-by-label" htmlFor="view-section-sort-by" size="sm">
                                     Sort by
                                 </Label>
-                                <Select value={sortBy} onValueChange={(value) => setSortBy(value as ViewSortBy)}>
+                                <Select
+                                    id="view-section-sort-by"
+                                    value={sortBy}
+                                    aria-labelledby="view-section-sort-by-label"
+                                    onValueChange={(value) => setSortBy(value as ViewSortBy)}
+                                >
                                     <SelectItem value="updatedAt">Updated time</SelectItem>
                                     <SelectItem value="createdAt">Created time</SelectItem>
                                     <SelectItem value="title">Title</SelectItem>
                                 </Select>
                             </div>
                             <div className="flex flex-col gap-2">
-                                <Label htmlFor="view-section-sort-order" size="sm">
+                                <Label id="view-section-sort-order-label" htmlFor="view-section-sort-order" size="sm">
                                     Order
                                 </Label>
                                 <Select
+                                    id="view-section-sort-order"
                                     value={sortOrder}
+                                    aria-labelledby="view-section-sort-order-label"
                                     onValueChange={(value) => setSortOrder(value as ViewSortOrder)}
                                 >
                                     <SelectItem value="desc">Descending</SelectItem>
@@ -741,10 +748,15 @@ export default function ViewSectionDialog({
                                 </Select>
                             </div>
                             <div className="flex flex-col gap-2">
-                                <Label htmlFor="view-section-limit" size="sm">
+                                <Label id="view-section-limit-label" htmlFor="view-section-limit" size="sm">
                                     Max notes
                                 </Label>
-                                <Select value={limit} onValueChange={setLimit}>
+                                <Select
+                                    id="view-section-limit"
+                                    value={limit}
+                                    aria-labelledby="view-section-limit-label"
+                                    onValueChange={setLimit}
+                                >
                                     <SelectItem value="3">3 notes</SelectItem>
                                     <SelectItem value="5">5 notes</SelectItem>
                                     <SelectItem value="8">8 notes</SelectItem>

--- a/packages/client/src/pages/Note.tsx
+++ b/packages/client/src/pages/Note.tsx
@@ -442,6 +442,7 @@ const NotePropertiesPanel = ({
             ) : (
                 <div className="divide-y divide-border-subtle">
                     {rows.map((row) => {
+                        const propertyLabelId = `note-property-${row.id}-label`;
                         const safeExternalUrl = row.valueType === 'url' ? getSafeExternalUrl(row.value) : null;
 
                         return (
@@ -450,7 +451,13 @@ const NotePropertiesPanel = ({
                                 className="group grid gap-2 py-2 sm:grid-cols-[minmax(0,180px)_minmax(0,1fr)_auto] sm:items-center"
                             >
                                 <div className="flex min-w-0 items-center gap-2 px-1">
-                                    <Text as="span" variant="label" tone="secondary" className="truncate">
+                                    <Text
+                                        id={propertyLabelId}
+                                        as="span"
+                                        variant="label"
+                                        tone="secondary"
+                                        className="truncate"
+                                    >
                                         {row.name}
                                     </Text>
                                     <Text
@@ -468,6 +475,7 @@ const NotePropertiesPanel = ({
                                         variant="ghost"
                                         value={row.value || 'false'}
                                         disabled={disabled}
+                                        aria-labelledby={propertyLabelId}
                                         onValueChange={(value) => updateRow(row.id, { value })}
                                     >
                                         <SelectItem value="false">False</SelectItem>
@@ -480,6 +488,7 @@ const NotePropertiesPanel = ({
                                         value={row.value}
                                         placeholder="Select option"
                                         disabled={disabled}
+                                        aria-labelledby={propertyLabelId}
                                         onValueChange={(value) => updateRow(row.id, { value })}
                                     >
                                         {(

--- a/packages/client/src/pages/setting/properties.tsx
+++ b/packages/client/src/pages/setting/properties.tsx
@@ -431,11 +431,12 @@ export default function PropertiesSettings() {
                             />
                         </label>
                         <label className="flex flex-col gap-1.5">
-                            <Text as="span" variant="label" weight="medium">
+                            <Text id="property-type-label" as="span" variant="label" weight="medium">
                                 Type
                             </Text>
                             <Select
                                 value={valueType}
+                                aria-labelledby="property-type-label"
                                 onValueChange={(value) => setValueType(value as NotePropertyValueType)}
                             >
                                 {PROPERTY_TYPE_OPTIONS.map((option) => (


### PR DESCRIPTION

## :dart: Goal
Make the shared Select component support programmatic label and description wiring, then connect the existing visible labels or explicit names at current Select use sites.

## :hammer_and_wrench: Core Changes
- Added `id`, `aria-labelledby`, and `aria-describedby` support to the shared Select trigger while preserving the existing `ariaLabel` prop.
- Wired visible labels to saved-view sort/limit Select controls and note/calendar/property Select controls.
- Added explicit names where compact toolbar controls share a visual label but need distinct accessible names.
- Kept regression coverage intentionally small: one shared Select contract test plus one representative saved-view form test.

## :brain: Key Decisions
- Avoided page-by-page accessible-name tests for every Select use site; those are better handled by static checks or review because broad UI tests would be high maintenance.
- Kept this PR scoped to Select labeling only; Graph fallback and broader cleanup remain separate PRs.
- Verified the implementation with a team-agent review before opening the PR; no blocking findings were reported.

## :test_tube: Verification Guide
- `pnpm --filter @ocean-brain/client exec vitest run --maxWorkers 1 src/components/ui/Select/Select.spec.tsx src/components/ui/PrimitiveControls.spec.tsx src/components/view/ViewSectionDialog.spec.tsx` -> 3 files / 10 tests passed
- `pnpm --filter @ocean-brain/client lint` -> passed
- `pnpm --filter @ocean-brain/client type-check` -> passed
- `pnpm check:encoding` -> passed
- `pnpm --filter @ocean-brain/client test:ci` -> 58 files / 180 tests passed
- `pnpm --filter @ocean-brain/client build` -> passed
- Team-agent review -> no blocking findings

## :white_check_mark: Checklist
- [x] Local validation for changed client scope is complete
- [x] Team-agent review completed before PR creation
- [x] PR title follows `<emoji> <subject>` and subject starts with an English verb
- [x] PR body follows the required template headings
- [x] Release impact label applied: `release: patch`
