### PR TITLE
✨ Add MCP version compatibility guard

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -38,6 +38,7 @@ program
 
             process.env.DATABASE_URL = process.env.DATABASE_URL || `file:${dbPath}`;
             process.env.OCEAN_BRAIN_PACKAGE_ROOT = serverRoot;
+            process.env.OCEAN_BRAIN_VERSION = pkg.version;
             process.env.OCEAN_BRAIN_DATA_DIR = dataDir;
             process.env.OCEAN_BRAIN_IMAGE_DIR = imageDir;
             process.env.PORT = process.env.PORT || opts.port;

--- a/packages/cli/src/mcp.ts
+++ b/packages/cli/src/mcp.ts
@@ -18,7 +18,15 @@ import { formatPropertyQueryResponse, type PropertyQueryResult } from './mcp-pro
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(
     fs.readFileSync(path.resolve(__dirname, '..', 'package.json'), 'utf-8')
-);
+) as { version: string };
+
+export const OCEAN_BRAIN_MCP_VERSION_HEADER = 'X-Ocean-Brain-MCP-Version';
+
+export const createMcpRequestHeaders = (token: string | undefined) => ({
+    'Content-Type': 'application/json',
+    [OCEAN_BRAIN_MCP_VERSION_HEADER]: pkg.version,
+    ...(token ? { Authorization: `Bearer ${token}` } : {})
+});
 
 export const OCEAN_BRAIN_MCP_TOOLS = {
     searchNotes: 'ocean_brain_search_notes',
@@ -113,15 +121,19 @@ async function graphql(
 ) {
     const response = await fetch(`${serverUrl}/graphql/mcp`, {
         method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-            ...(token ? { Authorization: `Bearer ${token}` } : {})
-        },
+        headers: createMcpRequestHeaders(token),
         body: JSON.stringify({ query, variables }),
     });
 
     if (!response.ok) {
-        throw new Error(`GraphQL request failed: ${response.status} ${response.statusText}`);
+        const errorBody = await response.json().catch(() => undefined) as
+            | { code?: string; message?: string }
+            | undefined;
+        throw new Error(
+            errorBody?.message
+                ? `GraphQL request failed: ${errorBody.code || response.status} ${errorBody.message}`
+                : `GraphQL request failed: ${response.status} ${response.statusText}`
+        );
     }
 
     const result = await response.json() as {
@@ -150,10 +162,7 @@ async function jsonRequest<TResponse extends Record<string, unknown>>(
 ) {
     const response = await fetch(`${serverUrl}${pathName}`, {
         method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-            ...(token ? { Authorization: `Bearer ${token}` } : {})
-        },
+        headers: createMcpRequestHeaders(token),
         body: JSON.stringify(body)
     });
 

--- a/packages/cli/test/mcp.test.ts
+++ b/packages/cli/test/mcp.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { fetchMcpNoteWriteBaseline } from '../src/mcp.js';
+import { createMcpRequestHeaders, fetchMcpNoteWriteBaseline, OCEAN_BRAIN_MCP_VERSION_HEADER } from '../src/mcp.js';
 
 test('fetchMcpNoteWriteBaseline requests the side-effect-free MCP HTTP baseline endpoint', async () => {
     const requests: Array<{
@@ -41,4 +41,12 @@ test('fetchMcpNoteWriteBaseline requests the side-effect-free MCP HTTP baseline 
             },
         },
     ]);
+});
+
+test('createMcpRequestHeaders includes the MCP package version contract header', () => {
+    const headers = createMcpRequestHeaders('token-a');
+
+    assert.equal(headers['Content-Type'], 'application/json');
+    assert.equal(headers.Authorization, 'Bearer token-a');
+    assert.match(headers[OCEAN_BRAIN_MCP_VERSION_HEADER], /^\d+\.\d+\.\d+/);
 });

--- a/packages/client/src/apis/mcp-admin.types.ts
+++ b/packages/client/src/apis/mcp-admin.types.ts
@@ -6,4 +6,9 @@ export interface McpAdminStatus {
         createdAt: string;
         lastUsedAt: string | null;
     };
+    server: {
+        version: string;
+        releaseUrl: string;
+        mcpVersionRequirement: string;
+    };
 }

--- a/packages/client/src/components/ui/Toast/ToastProvider.tsx
+++ b/packages/client/src/components/ui/Toast/ToastProvider.tsx
@@ -13,7 +13,7 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
                 toastOptions={{
                     duration: 3000,
                     classNames: {
-                        toast: 'surface-floating whitespace-nowrap px-5 py-3 text-sm font-medium text-fg-secondary shadow-sm',
+                        toast: 'surface-floating max-w-[min(420px,calc(100vw-32px))] whitespace-normal break-words px-5 py-3 text-sm font-medium text-fg-secondary shadow-sm',
                         title: 'text-sm font-medium text-fg-secondary',
                     },
                 }}

--- a/packages/client/src/modules/app-version.ts
+++ b/packages/client/src/modules/app-version.ts
@@ -1,0 +1,11 @@
+export const OCEAN_BRAIN_RELEASES_URL = 'https://github.com/baealex/ocean-brain/releases';
+export const OCEAN_BRAIN_VERSION = __OCEAN_BRAIN_VERSION__;
+
+export const formatVersionLabel = (version: string) => {
+    return /^\d+\.\d+\.\d+/.test(version) ? `v${version}` : version;
+};
+
+export const formatMcpVersionRequirement = (version: string) => {
+    const match = version.match(/^(\d+)\.(\d+)(?:\.\d+)?(?:[-+].*)?$/);
+    return match ? `${match[1]}.${match[2]}.x` : 'unknown';
+};

--- a/packages/client/src/modules/local-demo/client.ts
+++ b/packages/client/src/modules/local-demo/client.ts
@@ -26,6 +26,15 @@ const graphHandlers = localDemoPlugins.reduce<Record<string, LocalGraphHandler>>
     return { ...handlers, ...(plugin.graphHandlers ?? {}) };
 }, {});
 
+const withLocalDemoMcpServerInfo = (mcp: Omit<McpAdminStatus, 'server'>): McpAdminStatus => ({
+    ...mcp,
+    server: {
+        version: 'local-demo',
+        releaseUrl: 'https://github.com/baealex/ocean-brain/releases',
+        mcpVersionRequirement: 'local-demo',
+    },
+});
+
 const resolveOperationName = (request: GraphQueryRequest<object>) => {
     return request.operationName ?? request.query.match(/\b(?:query|mutation)\s+(\w+)/)?.[1] ?? '';
 };
@@ -71,14 +80,16 @@ export const uploadLocalDemoImage = async ({ base64, externalSrc }: { base64?: s
 };
 
 export const fetchLocalDemoMcpAdminStatus = async (): Promise<McpAdminStatus> => {
-    return localDemoStore.read().mcp;
+    return withLocalDemoMcpServerInfo(localDemoStore.read().mcp);
 };
 
 export const setLocalDemoMcpEnabled = async (enabled: boolean): Promise<McpAdminStatus> => {
-    return localDemoStore.update((state) => {
+    const mcp = localDemoStore.update((state) => {
         state.mcp.enabled = enabled;
         return state.mcp;
     });
+
+    return withLocalDemoMcpServerInfo(mcp);
 };
 
 export const rotateLocalDemoMcpToken = async () => {
@@ -98,11 +109,13 @@ export const rotateLocalDemoMcpToken = async () => {
 };
 
 export const revokeLocalDemoMcpToken = async (): Promise<McpAdminStatus> => {
-    return localDemoStore.update((state) => {
+    const mcp = localDemoStore.update((state) => {
         state.mcp.hasActiveToken = false;
         state.mcp.token = null;
         return state.mcp;
     });
+
+    return withLocalDemoMcpServerInfo(mcp);
 };
 
 export const localDemoOperationNames = Object.freeze(Object.keys(graphHandlers).sort());

--- a/packages/client/src/modules/local-demo/client.ts
+++ b/packages/client/src/modules/local-demo/client.ts
@@ -1,4 +1,5 @@
 import type { McpAdminStatus } from '~/apis/mcp-admin.api';
+import { formatMcpVersionRequirement, OCEAN_BRAIN_RELEASES_URL, OCEAN_BRAIN_VERSION } from '~/modules/app-version';
 import type { GraphQueryRequest, GraphQueryResponse } from '../graph-query-types';
 import { cacheLocalPlugin } from './plugins/cache';
 import { imagesLocalPlugin } from './plugins/images';
@@ -29,9 +30,9 @@ const graphHandlers = localDemoPlugins.reduce<Record<string, LocalGraphHandler>>
 const withLocalDemoMcpServerInfo = (mcp: Omit<McpAdminStatus, 'server'>): McpAdminStatus => ({
     ...mcp,
     server: {
-        version: 'local-demo',
-        releaseUrl: 'https://github.com/baealex/ocean-brain/releases',
-        mcpVersionRequirement: 'local-demo',
+        version: OCEAN_BRAIN_VERSION,
+        releaseUrl: OCEAN_BRAIN_RELEASES_URL,
+        mcpVersionRequirement: formatMcpVersionRequirement(OCEAN_BRAIN_VERSION),
     },
 });
 

--- a/packages/client/src/modules/local-demo/mcp-status.spec.ts
+++ b/packages/client/src/modules/local-demo/mcp-status.spec.ts
@@ -1,0 +1,11 @@
+import { fetchLocalDemoMcpAdminStatus } from './client';
+
+describe('fetchLocalDemoMcpAdminStatus', () => {
+    it('returns build version metadata for local-only demo builds', async () => {
+        const status = await fetchLocalDemoMcpAdminStatus();
+
+        expect(status.server.version).toMatch(/^\d+\.\d+\.\d+/);
+        expect(status.server.mcpVersionRequirement).toMatch(/^\d+\.\d+\.x$/);
+        expect(status.server.releaseUrl).toBe('https://github.com/baealex/ocean-brain/releases');
+    });
+});

--- a/packages/client/src/pages/setting/index.spec.tsx
+++ b/packages/client/src/pages/setting/index.spec.tsx
@@ -1,0 +1,57 @@
+import { QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import type { McpAdminStatus } from '~/apis/mcp-admin.api';
+import * as mcpAdminApi from '~/apis/mcp-admin.api';
+import { createTestQueryClient } from '~/test/test-utils';
+import Setting from './index';
+
+vi.mock('@tanstack/react-router', () => ({
+    Link: ({ children, className, to }: { children: ReactNode; className?: string; to: string }) => (
+        <a href={to} className={className}>
+            {children}
+        </a>
+    ),
+}));
+
+vi.mock('~/apis/mcp-admin.api', () => ({
+    fetchMcpAdminStatus: vi.fn(),
+}));
+
+const createMcpStatus = (overrides: Partial<McpAdminStatus> = {}): McpAdminStatus => ({
+    enabled: true,
+    hasActiveToken: true,
+    token: {
+        id: '1',
+        createdAt: '2026-06-23T00:00:00.000Z',
+        lastUsedAt: null,
+    },
+    server: {
+        version: '0.7.3',
+        releaseUrl: 'https://github.com/baealex/ocean-brain/releases',
+        mcpVersionRequirement: '0.7.x',
+    },
+    ...overrides,
+});
+
+const renderPage = () => {
+    render(
+        <QueryClientProvider client={createTestQueryClient()}>
+            <Setting />
+        </QueryClientProvider>,
+    );
+};
+
+describe('<Setting />', () => {
+    it('shows the current server version and update link on the root settings page', async () => {
+        vi.mocked(mcpAdminApi.fetchMcpAdminStatus).mockResolvedValue(createMcpStatus());
+
+        renderPage();
+
+        expect(await screen.findByText('Current version: v0.7.3 / Required MCP version: 0.7.x')).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: /ocean brain/i })).toHaveAttribute(
+            'href',
+            'https://github.com/baealex/ocean-brain/releases',
+        );
+    });
+});

--- a/packages/client/src/pages/setting/index.spec.tsx
+++ b/packages/client/src/pages/setting/index.spec.tsx
@@ -43,13 +43,13 @@ const renderPage = () => {
 };
 
 describe('<Setting />', () => {
-    it('shows the current server version and update link on the root settings page', async () => {
+    it('shows the current server version as secondary footer metadata', async () => {
         vi.mocked(mcpAdminApi.fetchMcpAdminStatus).mockResolvedValue(createMcpStatus());
 
         renderPage();
 
-        expect(await screen.findByText('Current version: v0.7.3 / Required MCP version: 0.7.x')).toBeInTheDocument();
-        expect(screen.getByRole('link', { name: /ocean brain/i })).toHaveAttribute(
+        expect(await screen.findByText(/Ocean Brain v0\.7\.3/)).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: 'Releases' })).toHaveAttribute(
             'href',
             'https://github.com/baealex/ocean-brain/releases',
         );

--- a/packages/client/src/pages/setting/index.tsx
+++ b/packages/client/src/pages/setting/index.tsx
@@ -1,7 +1,15 @@
+import { useQuery } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
+import { fetchMcpAdminStatus } from '~/apis/mcp-admin.api';
 import * as Icon from '~/components/icon';
 import { PageLayout } from '~/components/shared';
 import { Text } from '~/components/ui';
+import {
+    formatMcpVersionRequirement,
+    formatVersionLabel,
+    OCEAN_BRAIN_RELEASES_URL,
+    OCEAN_BRAIN_VERSION,
+} from '~/modules/app-version';
 import {
     SETTINGS_MANAGE_IMAGE_ROUTE,
     SETTINGS_MCP_ROUTE,
@@ -11,8 +19,19 @@ import {
 } from '~/modules/url';
 import { useTheme } from '~/store/theme';
 
+const mcpAdminStatusQueryKey = ['mcp-admin', 'status'] as const;
+
 const Setting = () => {
     const { theme, toggleTheme } = useTheme((state) => state);
+    const { data: status } = useQuery({
+        queryKey: mcpAdminStatusQueryKey,
+        queryFn: fetchMcpAdminStatus,
+    });
+    const versionInfo = status?.server ?? {
+        version: OCEAN_BRAIN_VERSION,
+        releaseUrl: OCEAN_BRAIN_RELEASES_URL,
+        mcpVersionRequirement: formatMcpVersionRequirement(OCEAN_BRAIN_VERSION),
+    };
     const itemClassName =
         'focus-ring-soft surface-base group flex items-start justify-between gap-3.5 px-4 py-3.5 text-left text-fg-default outline-none transition-colors hover:bg-hover-subtle';
     const leadingClassName =
@@ -20,10 +39,39 @@ const Setting = () => {
     const iconClassName = 'h-6 w-6';
     const sectionLabelClassName = 'text-fg-tertiary';
     const contentClassName = 'min-w-0 flex flex-col gap-0.5 pt-0.5';
+    const versionLabel = formatVersionLabel(versionInfo.version);
 
     return (
         <PageLayout title="Settings" description="Manage appearance, integrations, and workspace tools">
             <div className="flex flex-col gap-6">
+                <section className="flex flex-col gap-3">
+                    <Text as="p" variant="label" weight="medium" className={sectionLabelClassName}>
+                        Version
+                    </Text>
+                    <a href={versionInfo.releaseUrl} target="_blank" rel="noreferrer" className={itemClassName}>
+                        <div className="flex min-w-0 items-start gap-3">
+                            <span className={leadingClassName}>
+                                <Icon.Info className={iconClassName} />
+                            </span>
+                            <div className={contentClassName}>
+                                <Text as="div" variant="body" weight="medium">
+                                    Ocean Brain
+                                </Text>
+                                <Text as="div" variant="meta" tone="secondary">
+                                    Current version: {versionLabel} / Required MCP version:{' '}
+                                    {versionInfo.mcpVersionRequirement}
+                                </Text>
+                            </div>
+                        </div>
+                        <div className="mt-0.5 flex shrink-0 items-center gap-2 text-fg-tertiary">
+                            <Text as="span" variant="meta" weight="medium" tone="secondary">
+                                Check latest
+                            </Text>
+                            <Icon.Refresh className="h-4 w-4" />
+                        </div>
+                    </a>
+                </section>
+
                 <section className="flex flex-col gap-3">
                     <Text as="p" variant="label" weight="medium" className={sectionLabelClassName}>
                         Appearance

--- a/packages/client/src/pages/setting/index.tsx
+++ b/packages/client/src/pages/setting/index.tsx
@@ -77,28 +77,6 @@ const Setting = () => {
 
                 <section className="flex flex-col gap-3">
                     <Text as="p" variant="label" weight="medium" className={sectionLabelClassName}>
-                        Integrations
-                    </Text>
-                    <Link to={SETTINGS_MCP_ROUTE} className={itemClassName}>
-                        <div className="flex min-w-0 items-start gap-3">
-                            <span className={leadingClassName}>
-                                <Icon.LinkIcon className={iconClassName} />
-                            </span>
-                            <div className={contentClassName}>
-                                <Text as="div" variant="body" weight="medium">
-                                    MCP
-                                </Text>
-                                <Text as="div" variant="meta" tone="secondary">
-                                    Manage AI integration access.
-                                </Text>
-                            </div>
-                        </div>
-                        <Icon.ChevronRight className="mt-0.5 h-4 w-4 shrink-0 text-fg-tertiary transition-transform group-hover:translate-x-0.5 group-hover:text-fg-secondary" />
-                    </Link>
-                </section>
-
-                <section className="flex flex-col gap-3">
-                    <Text as="p" variant="label" weight="medium" className={sectionLabelClassName}>
                         Workspace
                     </Text>
                     <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
@@ -161,6 +139,30 @@ const Setting = () => {
                                     </Text>
                                     <Text as="div" variant="meta" tone="secondary">
                                         Manage template variables.
+                                    </Text>
+                                </div>
+                            </div>
+                            <Icon.ChevronRight className="mt-0.5 h-4 w-4 shrink-0 text-fg-tertiary transition-transform group-hover:translate-x-0.5 group-hover:text-fg-secondary" />
+                        </Link>
+                    </div>
+                </section>
+
+                <section className="flex flex-col gap-3">
+                    <Text as="p" variant="label" weight="medium" className={sectionLabelClassName}>
+                        Advanced
+                    </Text>
+                    <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+                        <Link to={SETTINGS_MCP_ROUTE} className={itemClassName}>
+                            <div className="flex min-w-0 items-start gap-3">
+                                <span className={leadingClassName}>
+                                    <Icon.LinkIcon className={iconClassName} />
+                                </span>
+                                <div className={contentClassName}>
+                                    <Text as="div" variant="body" weight="medium">
+                                        MCP
+                                    </Text>
+                                    <Text as="div" variant="meta" tone="secondary">
+                                        Connect external AI clients.
                                     </Text>
                                 </div>
                             </div>

--- a/packages/client/src/pages/setting/index.tsx
+++ b/packages/client/src/pages/setting/index.tsx
@@ -46,34 +46,6 @@ const Setting = () => {
             <div className="flex flex-col gap-6">
                 <section className="flex flex-col gap-3">
                     <Text as="p" variant="label" weight="medium" className={sectionLabelClassName}>
-                        Version
-                    </Text>
-                    <a href={versionInfo.releaseUrl} target="_blank" rel="noreferrer" className={itemClassName}>
-                        <div className="flex min-w-0 items-start gap-3">
-                            <span className={leadingClassName}>
-                                <Icon.Info className={iconClassName} />
-                            </span>
-                            <div className={contentClassName}>
-                                <Text as="div" variant="body" weight="medium">
-                                    Ocean Brain
-                                </Text>
-                                <Text as="div" variant="meta" tone="secondary">
-                                    Current version: {versionLabel} / Required MCP version:{' '}
-                                    {versionInfo.mcpVersionRequirement}
-                                </Text>
-                            </div>
-                        </div>
-                        <div className="mt-0.5 flex shrink-0 items-center gap-2 text-fg-tertiary">
-                            <Text as="span" variant="meta" weight="medium" tone="secondary">
-                                Check latest
-                            </Text>
-                            <Icon.Refresh className="h-4 w-4" />
-                        </div>
-                    </a>
-                </section>
-
-                <section className="flex flex-col gap-3">
-                    <Text as="p" variant="label" weight="medium" className={sectionLabelClassName}>
                         Appearance
                     </Text>
                     <button type="button" className={itemClassName} onClick={toggleTheme}>
@@ -196,6 +168,18 @@ const Setting = () => {
                         </Link>
                     </div>
                 </section>
+
+                <Text as="p" variant="meta" tone="tertiary" className="border-t border-border-subtle pt-4">
+                    Ocean Brain {versionLabel} ·{' '}
+                    <a
+                        href={versionInfo.releaseUrl}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="font-medium text-fg-secondary underline-offset-4 hover:underline"
+                    >
+                        Releases
+                    </a>
+                </Text>
             </div>
         </PageLayout>
     );

--- a/packages/client/src/pages/setting/index.tsx
+++ b/packages/client/src/pages/setting/index.tsx
@@ -42,7 +42,7 @@ const Setting = () => {
     const versionLabel = formatVersionLabel(versionInfo.version);
 
     return (
-        <PageLayout title="Settings" description="Manage appearance, integrations, and workspace tools">
+        <PageLayout title="Settings" description="Manage display, workspace tools, and advanced connections">
             <div className="flex flex-col gap-6">
                 <section className="flex flex-col gap-3">
                     <Text as="p" variant="label" weight="medium" className={sectionLabelClassName}>
@@ -80,38 +80,6 @@ const Setting = () => {
                         Workspace
                     </Text>
                     <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-                        <Link to={SETTINGS_TRASH_ROUTE} search={{ page: 1 }} className={itemClassName}>
-                            <div className="flex min-w-0 items-start gap-3">
-                                <span className={leadingClassName}>
-                                    <Icon.TrashCan className={iconClassName} />
-                                </span>
-                                <div className={contentClassName}>
-                                    <Text as="div" variant="body" weight="medium">
-                                        Trash
-                                    </Text>
-                                    <Text as="div" variant="meta" tone="secondary">
-                                        Restore deleted notes.
-                                    </Text>
-                                </div>
-                            </div>
-                            <Icon.ChevronRight className="mt-0.5 h-4 w-4 shrink-0 text-fg-tertiary transition-transform group-hover:translate-x-0.5 group-hover:text-fg-secondary" />
-                        </Link>
-                        <Link to={SETTINGS_MANAGE_IMAGE_ROUTE} search={{ page: 1 }} className={itemClassName}>
-                            <div className="flex min-w-0 items-start gap-3">
-                                <span className={leadingClassName}>
-                                    <Icon.Image className={iconClassName} />
-                                </span>
-                                <div className={contentClassName}>
-                                    <Text as="div" variant="body" weight="medium">
-                                        Images
-                                    </Text>
-                                    <Text as="div" variant="meta" tone="secondary">
-                                        Upload and organize images.
-                                    </Text>
-                                </div>
-                            </div>
-                            <Icon.ChevronRight className="mt-0.5 h-4 w-4 shrink-0 text-fg-tertiary transition-transform group-hover:translate-x-0.5 group-hover:text-fg-secondary" />
-                        </Link>
                         <Link to={SETTINGS_PROPERTIES_ROUTE} search={{ page: 1 }} className={itemClassName}>
                             <div className="flex min-w-0 items-start gap-3">
                                 <span className={leadingClassName}>
@@ -122,7 +90,7 @@ const Setting = () => {
                                         Properties
                                     </Text>
                                     <Text as="div" variant="meta" tone="secondary">
-                                        Define shared fields for notes and future views.
+                                        Manage fields used across notes.
                                     </Text>
                                 </div>
                             </div>
@@ -138,7 +106,39 @@ const Setting = () => {
                                         Placeholders
                                     </Text>
                                     <Text as="div" variant="meta" tone="secondary">
-                                        Manage template variables.
+                                        Manage reusable template variables.
+                                    </Text>
+                                </div>
+                            </div>
+                            <Icon.ChevronRight className="mt-0.5 h-4 w-4 shrink-0 text-fg-tertiary transition-transform group-hover:translate-x-0.5 group-hover:text-fg-secondary" />
+                        </Link>
+                        <Link to={SETTINGS_MANAGE_IMAGE_ROUTE} search={{ page: 1 }} className={itemClassName}>
+                            <div className="flex min-w-0 items-start gap-3">
+                                <span className={leadingClassName}>
+                                    <Icon.Image className={iconClassName} />
+                                </span>
+                                <div className={contentClassName}>
+                                    <Text as="div" variant="body" weight="medium">
+                                        Images
+                                    </Text>
+                                    <Text as="div" variant="meta" tone="secondary">
+                                        Review uploaded note images.
+                                    </Text>
+                                </div>
+                            </div>
+                            <Icon.ChevronRight className="mt-0.5 h-4 w-4 shrink-0 text-fg-tertiary transition-transform group-hover:translate-x-0.5 group-hover:text-fg-secondary" />
+                        </Link>
+                        <Link to={SETTINGS_TRASH_ROUTE} search={{ page: 1 }} className={itemClassName}>
+                            <div className="flex min-w-0 items-start gap-3">
+                                <span className={leadingClassName}>
+                                    <Icon.TrashCan className={iconClassName} />
+                                </span>
+                                <div className={contentClassName}>
+                                    <Text as="div" variant="body" weight="medium">
+                                        Trash
+                                    </Text>
+                                    <Text as="div" variant="meta" tone="secondary">
+                                        Restore or permanently delete notes.
                                     </Text>
                                 </div>
                             </div>
@@ -162,7 +162,7 @@ const Setting = () => {
                                         MCP
                                     </Text>
                                     <Text as="div" variant="meta" tone="secondary">
-                                        Connect external AI clients.
+                                        Connect Codex, Claude, or another MCP client.
                                     </Text>
                                 </div>
                             </div>

--- a/packages/client/src/pages/setting/mcp.spec.tsx
+++ b/packages/client/src/pages/setting/mcp.spec.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { McpAdminStatus } from '~/apis/mcp-admin.api';
 import * as mcpAdminApi from '~/apis/mcp-admin.api';
-import { ToastProvider } from '~/components/ui';
+import { ConfirmProvider, ToastProvider } from '~/components/ui';
 import { createTestQueryClient } from '~/test/test-utils';
 import McpSetting from './mcp';
 
@@ -31,9 +31,11 @@ const renderPage = () => {
 
     render(
         <QueryClientProvider client={queryClient}>
-            <ToastProvider>
-                <McpSetting />
-            </ToastProvider>
+            <ConfirmProvider>
+                <ToastProvider>
+                    <McpSetting />
+                </ToastProvider>
+            </ConfirmProvider>
         </QueryClientProvider>,
     );
 };
@@ -43,22 +45,12 @@ describe('<McpSetting />', () => {
         vi.clearAllMocks();
     });
 
-    it('shows origin-based MCP server URL and renders mcp.json snippet', async () => {
+    it('shows origin-based Ocean Brain URL', async () => {
         vi.mocked(mcpAdminApi.fetchMcpAdminStatus).mockResolvedValue(createMcpStatus());
 
         renderPage();
 
-        expect(await screen.findByText('v0.7.3')).toBeInTheDocument();
-        expect(screen.getByText('0.7.x')).toBeInTheDocument();
-        expect(screen.getByRole('link', { name: /check latest version/i })).toHaveAttribute(
-            'href',
-            'https://github.com/baealex/ocean-brain/releases',
-        );
-        expect(await screen.findByLabelText(/server url/i)).toHaveValue(window.location.origin);
-        expect(screen.getAllByText(/"mcpServers"/).length).toBeGreaterThan(0);
-        expect(screen.getAllByText(/--token-file/).length).toBeGreaterThan(0);
-        expect(screen.getAllByText(/--token/).length).toBeGreaterThan(0);
-        expect(screen.getAllByText(new RegExp(window.location.origin)).length).toBeGreaterThan(0);
+        expect(await screen.findByLabelText(/ocean brain url/i)).toHaveValue(window.location.origin);
     });
 
     it('submits enabled toggle and refreshes status', async () => {
@@ -67,7 +59,7 @@ describe('<McpSetting />', () => {
 
         renderPage();
 
-        const toggle = await screen.findByRole('switch', { name: /allow mcp access/i });
+        const toggle = await screen.findByRole('switch', { name: /mcp access/i });
         await userEvent.click(toggle);
         expect(toggle).toHaveAttribute('aria-checked', 'true');
     });

--- a/packages/client/src/pages/setting/mcp.spec.tsx
+++ b/packages/client/src/pages/setting/mcp.spec.tsx
@@ -1,6 +1,7 @@
 import { QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { McpAdminStatus } from '~/apis/mcp-admin.api';
 import * as mcpAdminApi from '~/apis/mcp-admin.api';
 import { ToastProvider } from '~/components/ui';
 import { createTestQueryClient } from '~/test/test-utils';
@@ -12,6 +13,18 @@ vi.mock('~/apis/mcp-admin.api', () => ({
     rotateMcpToken: vi.fn(),
     revokeMcpToken: vi.fn(),
 }));
+
+const createMcpStatus = (overrides: Partial<McpAdminStatus> = {}): McpAdminStatus => ({
+    enabled: false,
+    hasActiveToken: false,
+    token: null,
+    server: {
+        version: '0.7.3',
+        releaseUrl: 'https://github.com/baealex/ocean-brain/releases',
+        mcpVersionRequirement: '0.7.x',
+    },
+    ...overrides,
+});
 
 const renderPage = () => {
     const queryClient = createTestQueryClient();
@@ -31,14 +44,16 @@ describe('<McpSetting />', () => {
     });
 
     it('shows origin-based MCP server URL and renders mcp.json snippet', async () => {
-        vi.mocked(mcpAdminApi.fetchMcpAdminStatus).mockResolvedValue({
-            enabled: false,
-            hasActiveToken: false,
-            token: null,
-        });
+        vi.mocked(mcpAdminApi.fetchMcpAdminStatus).mockResolvedValue(createMcpStatus());
 
         renderPage();
 
+        expect(await screen.findByText('v0.7.3')).toBeInTheDocument();
+        expect(screen.getByText('0.7.x')).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: /check latest version/i })).toHaveAttribute(
+            'href',
+            'https://github.com/baealex/ocean-brain/releases',
+        );
         expect(await screen.findByLabelText(/server url/i)).toHaveValue(window.location.origin);
         expect(screen.getAllByText(/"mcpServers"/).length).toBeGreaterThan(0);
         expect(screen.getAllByText(/--token-file/).length).toBeGreaterThan(0);
@@ -47,16 +62,8 @@ describe('<McpSetting />', () => {
     });
 
     it('submits enabled toggle and refreshes status', async () => {
-        vi.mocked(mcpAdminApi.fetchMcpAdminStatus).mockResolvedValue({
-            enabled: false,
-            hasActiveToken: false,
-            token: null,
-        });
-        vi.mocked(mcpAdminApi.setMcpEnabled).mockResolvedValue({
-            enabled: true,
-            hasActiveToken: false,
-            token: null,
-        });
+        vi.mocked(mcpAdminApi.fetchMcpAdminStatus).mockResolvedValue(createMcpStatus());
+        vi.mocked(mcpAdminApi.setMcpEnabled).mockResolvedValue(createMcpStatus({ enabled: true }));
 
         renderPage();
 

--- a/packages/client/src/pages/setting/mcp.tsx
+++ b/packages/client/src/pages/setting/mcp.tsx
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
 import { fetchMcpAdminStatus, revokeMcpToken, rotateMcpToken, setMcpEnabled } from '~/apis/mcp-admin.api';
+import * as Icon from '~/components/icon';
 import { Button, PageLayout, SurfaceCard } from '~/components/shared';
 import { Input, Label, Switch, Text, Textarea, ToggleGroup, ToggleGroupItem, useToast } from '~/components/ui';
 
@@ -78,6 +79,14 @@ const McpSetting = () => {
     const enabled = status?.enabled ?? false;
     const hasActiveToken = status?.hasActiveToken ?? false;
     const canToggle = !isLoading && !setEnabledMutation.isPending;
+    const serverVersion = status?.server.version;
+    const releaseUrl = status?.server.releaseUrl ?? 'https://github.com/baealex/ocean-brain/releases';
+    const mcpVersionRequirement = status?.server.mcpVersionRequirement;
+    const serverVersionLabel = serverVersion
+        ? /^\d+\.\d+\.\d+/.test(serverVersion)
+            ? `v${serverVersion}`
+            : serverVersion
+        : 'Loading...';
     const headerTextClassName = 'space-y-1';
     const cardBodyClassName = 'space-y-4.5';
     const statusToggleClassName =
@@ -108,6 +117,43 @@ const McpSetting = () => {
     return (
         <PageLayout title="MCP" variant="default" description="Manage MCP access, tokens, and connection details">
             <div className="grid grid-cols-1 gap-4">
+                <SurfaceCard tone="elevated">
+                    <div className="flex flex-wrap items-start justify-between gap-4">
+                        <div className={headerTextClassName}>
+                            <Text as="h2" {...cardTitleProps}>
+                                Version
+                            </Text>
+                            <Text as="p" variant="meta" tone="secondary">
+                                Current server version and MCP compatibility target.
+                            </Text>
+                        </div>
+                        <Button asChild variant="subtle" size="sm">
+                            <a href={releaseUrl} target="_blank" rel="noreferrer">
+                                <Icon.Refresh className="h-4 w-4" />
+                                Check latest version
+                            </a>
+                        </Button>
+                    </div>
+                    <div className="mt-4 grid grid-cols-1 gap-3 md:grid-cols-2">
+                        <div className="rounded-[14px] border border-border-subtle bg-muted px-3 py-2.5">
+                            <Text as="div" variant="meta" weight="medium" tone="secondary">
+                                Current version
+                            </Text>
+                            <Text as="div" variant="body" weight="semibold" className="mt-1">
+                                {serverVersionLabel}
+                            </Text>
+                        </div>
+                        <div className="rounded-[14px] border border-border-subtle bg-muted px-3 py-2.5">
+                            <Text as="div" variant="meta" weight="medium" tone="secondary">
+                                Required MCP version
+                            </Text>
+                            <Text as="div" variant="body" weight="semibold" className="mt-1">
+                                {mcpVersionRequirement ?? 'Loading...'}
+                            </Text>
+                        </div>
+                    </div>
+                </SurfaceCard>
+
                 <SurfaceCard tone="elevated">
                     <div className="flex flex-wrap items-start justify-between gap-4">
                         <div className={headerTextClassName}>

--- a/packages/client/src/pages/setting/mcp.tsx
+++ b/packages/client/src/pages/setting/mcp.tsx
@@ -2,19 +2,62 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
 import { fetchMcpAdminStatus, revokeMcpToken, rotateMcpToken, setMcpEnabled } from '~/apis/mcp-admin.api';
 import * as Icon from '~/components/icon';
-import { Button, PageLayout, SurfaceCard } from '~/components/shared';
-import { Input, Label, Switch, Text, Textarea, ToggleGroup, ToggleGroupItem, useToast } from '~/components/ui';
-import { formatVersionLabel, OCEAN_BRAIN_RELEASES_URL } from '~/modules/app-version';
+import { Button, PageLayout } from '~/components/shared';
+import {
+    Input,
+    Label,
+    Switch,
+    Text,
+    Textarea,
+    ToggleGroup,
+    ToggleGroupItem,
+    useConfirm,
+    useToast,
+} from '~/components/ui';
 
 const mcpAdminStatusQueryKey = ['mcp-admin', 'status'] as const;
 
-const createTokenFileMcpJsonSnippet = (serverUrl: string) => {
+type ClientGuide = 'codex' | 'claude' | 'json';
+
+const shellQuote = (value: string) => {
+    if (/^[A-Za-z0-9_./:@$-]+$/.test(value)) {
+        return value;
+    }
+
+    return `'${value.replace(/'/g, "'\\''")}'`;
+};
+
+const defaultTokenFilePath = '$HOME/.config/ocean-brain/mcp-token';
+
+const createTokenFileCommand = (tokenFilePath: string, token: string) => {
+    const quotedPath = shellQuote(tokenFilePath);
+
+    return [
+        `mkdir -p "$(dirname ${quotedPath})"`,
+        `printf '%s' ${shellQuote(token)} > ${quotedPath}`,
+        `chmod 600 ${quotedPath}`,
+    ].join('\n');
+};
+
+const buildOceanBrainMcpArgs = (serverUrl: string, tokenFilePath: string) => {
+    return `npx -y ocean-brain mcp --server ${shellQuote(serverUrl)} --token-file ${shellQuote(tokenFilePath)}`;
+};
+
+const createCodexCommand = (serverUrl: string, tokenFilePath: string) => {
+    return `codex mcp add ocean-brain -- ${buildOceanBrainMcpArgs(serverUrl, tokenFilePath)}`;
+};
+
+const createClaudeCommand = (serverUrl: string, tokenFilePath: string) => {
+    return `claude mcp add --transport stdio ocean-brain -- ${buildOceanBrainMcpArgs(serverUrl, tokenFilePath)}`;
+};
+
+const createMcpJsonSnippet = (serverUrl: string, tokenFilePath: string) => {
     return JSON.stringify(
         {
             mcpServers: {
                 'ocean-brain': {
                     command: 'npx',
-                    args: ['-y', 'ocean-brain', 'mcp', '--server', serverUrl, '--token-file', '/path/to/token.txt'],
+                    args: ['-y', 'ocean-brain', 'mcp', '--server', serverUrl, '--token-file', tokenFilePath],
                 },
             },
         },
@@ -23,28 +66,58 @@ const createTokenFileMcpJsonSnippet = (serverUrl: string) => {
     );
 };
 
-const createInlineTokenMcpJsonSnippet = (serverUrl: string) => {
-    return JSON.stringify(
-        {
-            mcpServers: {
-                'ocean-brain': {
-                    command: 'npx',
-                    args: ['-y', 'ocean-brain', 'mcp', '--server', serverUrl, '--token', 'your-token-here'],
-                },
-            },
-        },
-        null,
-        2,
-    );
+const createConnectionOutput = (clientGuide: ClientGuide, serverUrl: string, tokenFilePath: string, token: string) => {
+    const connectCommand =
+        clientGuide === 'codex'
+            ? createCodexCommand(serverUrl, tokenFilePath)
+            : clientGuide === 'claude'
+              ? createClaudeCommand(serverUrl, tokenFilePath)
+              : createMcpJsonSnippet(serverUrl, tokenFilePath);
+
+    if (clientGuide === 'json') {
+        return [
+            `# 1. Create the token file`,
+            createTokenFileCommand(tokenFilePath, token),
+            '',
+            '# 2. Add this MCP JSON',
+            connectCommand,
+        ].join('\n');
+    }
+
+    return [
+        `# 1. Create the token file`,
+        createTokenFileCommand(tokenFilePath, token),
+        '',
+        `# 2. Add Ocean Brain to ${clientGuide}`,
+        connectCommand,
+    ].join('\n');
+};
+
+const getMcpCliRequirement = (version?: string) => {
+    if (!version) {
+        return 'Ocean Brain CLI';
+    }
+
+    const [major, minor] = version.split('.');
+
+    return major && minor ? `Ocean Brain CLI v${major}.${minor}.x` : 'Ocean Brain CLI';
+};
+
+const clientGuideLabel: Record<ClientGuide, string> = {
+    codex: 'Codex',
+    claude: 'Claude',
+    json: 'JSON',
 };
 
 const McpSetting = () => {
+    const confirm = useConfirm();
     const toast = useToast();
     const queryClient = useQueryClient();
 
     const [serverUrl, setServerUrl] = useState(() => window.location.origin);
     const [issuedToken, setIssuedToken] = useState('');
-    const [guideMode, setGuideMode] = useState<'token-file' | 'inline-token'>('token-file');
+    const [tokenFilePath, setTokenFilePath] = useState(defaultTokenFilePath);
+    const [clientGuide, setClientGuide] = useState<ClientGuide>('codex');
 
     const { data: status, isLoading } = useQuery({
         queryKey: mcpAdminStatusQueryKey,
@@ -63,7 +136,7 @@ const McpSetting = () => {
         mutationFn: rotateMcpToken,
         onSuccess: async ({ token }) => {
             setIssuedToken(token);
-            toast('A new MCP token has been issued.');
+            toast('New MCP token issued. Previous token is no longer valid.');
             await queryClient.invalidateQueries({ queryKey: mcpAdminStatusQueryKey });
         },
     });
@@ -73,208 +146,257 @@ const McpSetting = () => {
         onSuccess: (nextStatus) => {
             setIssuedToken('');
             queryClient.setQueryData(mcpAdminStatusQueryKey, nextStatus);
-            toast('The active MCP token has been revoked.');
+            toast('MCP token revoked. Existing client configs will stop working.');
         },
     });
 
     const enabled = status?.enabled ?? false;
     const hasActiveToken = status?.hasActiveToken ?? false;
     const canToggle = !isLoading && !setEnabledMutation.isPending;
-    const serverVersion = status?.server.version;
-    const releaseUrl = status?.server.releaseUrl ?? OCEAN_BRAIN_RELEASES_URL;
-    const mcpVersionRequirement = status?.server.mcpVersionRequirement;
-    const serverVersionLabel = serverVersion ? formatVersionLabel(serverVersion) : 'Loading...';
-    const headerTextClassName = 'space-y-1';
-    const cardBodyClassName = 'space-y-4.5';
-    const statusToggleClassName =
-        'inline-flex items-center gap-3 rounded-[14px] border border-border-subtle bg-muted px-3 py-2';
-    const activeTokenBadgeClassName = 'rounded-full border border-border-subtle bg-hover-subtle px-2.5 py-1';
-    const guidePanelClassName = 'space-y-3 rounded-[16px] border border-border-subtle bg-surface px-4 py-3';
-    const guideSnippetClassName =
-        'overflow-x-auto rounded-[14px] border border-border-subtle bg-surface px-4 py-3 text-xs text-fg-secondary';
-    const cardTitleProps = {
-        variant: 'subheading' as const,
-        weight: 'medium' as const,
-        tracking: 'tight' as const,
-    };
+    const normalizedTokenFilePath = tokenFilePath.trim() || defaultTokenFilePath;
+    const mcpCliRequirement = getMcpCliRequirement(status?.server.version);
+    const tokenStatusText = hasActiveToken ? '1 active token' : 'No active token';
+    const outputLabel = clientGuide === 'json' ? 'Token file and MCP JSON' : `${clientGuideLabel[clientGuide]} setup`;
+    const tokenValue = issuedToken || 'PASTE_TOKEN_HERE';
+    const connectionOutput = createConnectionOutput(clientGuide, serverUrl, normalizedTokenFilePath, tokenValue);
+    const copyLabel = 'Copy setup';
+
+    const sectionHeadingClassName = 'text-fg-tertiary';
     const fieldLabelClassName = 'font-medium text-fg-tertiary';
-    const activeGuide =
-        guideMode === 'token-file'
-            ? {
-                  title: 'Token file',
-                  description: 'Recommended. Keeps the token out of config.',
-                  snippet: createTokenFileMcpJsonSnippet(serverUrl),
-              }
-            : {
-                  title: 'Inline token',
-                  description: 'Useful for quick local testing.',
-                  snippet: createInlineTokenMcpJsonSnippet(serverUrl),
-              };
+    const rowClassName = 'surface-base px-4 py-3.5';
+    const fieldGroupClassName = 'space-y-2';
+    const outputTextAreaClassName =
+        'max-w-full overflow-x-auto whitespace-pre font-mono text-xs leading-5 text-fg-secondary';
+
+    const handleCopyToken = async () => {
+        try {
+            await navigator.clipboard.writeText(issuedToken);
+            toast('Copied token.');
+        } catch {
+            toast('Failed to copy token.');
+        }
+    };
+
+    const handleCopyConnection = async () => {
+        try {
+            await navigator.clipboard.writeText(connectionOutput);
+            toast(clientGuide === 'json' ? 'Copied MCP JSON.' : 'Copied MCP command.');
+        } catch {
+            toast(`Could not copy. Select the ${clientGuide === 'json' ? 'JSON' : 'command'} and copy it manually.`);
+        }
+    };
+
+    const handleRotateToken = async () => {
+        if (
+            hasActiveToken &&
+            !(await confirm(
+                'Rotate the MCP token? Existing MCP clients will stop working until they use the new token.',
+            ))
+        ) {
+            return;
+        }
+
+        rotateTokenMutation.mutate(undefined);
+    };
+
+    const handleRevokeToken = async () => {
+        if (!(await confirm('Revoke the MCP token? Existing MCP clients will stop working immediately.'))) {
+            return;
+        }
+
+        revokeTokenMutation.mutate();
+    };
 
     return (
-        <PageLayout title="MCP" variant="default" description="Manage MCP access, tokens, and connection details">
-            <div className="grid grid-cols-1 gap-4">
-                <SurfaceCard tone="elevated">
-                    <div className="flex flex-wrap items-start justify-between gap-4">
-                        <div className={headerTextClassName}>
-                            <Text as="h2" {...cardTitleProps}>
-                                Version
-                            </Text>
-                            <Text as="p" variant="meta" tone="secondary">
-                                Current server version and MCP compatibility target.
-                            </Text>
-                        </div>
-                        <Button asChild variant="subtle" size="sm">
-                            <a href={releaseUrl} target="_blank" rel="noreferrer">
-                                <Icon.Refresh className="h-4 w-4" />
-                                Check latest version
-                            </a>
-                        </Button>
-                    </div>
-                    <div className="mt-4 grid grid-cols-1 gap-3 md:grid-cols-2">
-                        <div className="rounded-[14px] border border-border-subtle bg-muted px-3 py-2.5">
-                            <Text as="div" variant="meta" weight="medium" tone="secondary">
-                                Current version
-                            </Text>
-                            <Text as="div" variant="body" weight="semibold" className="mt-1">
-                                {serverVersionLabel}
-                            </Text>
-                        </div>
-                        <div className="rounded-[14px] border border-border-subtle bg-muted px-3 py-2.5">
-                            <Text as="div" variant="meta" weight="medium" tone="secondary">
-                                Required MCP version
-                            </Text>
-                            <Text as="div" variant="body" weight="semibold" className="mt-1">
-                                {mcpVersionRequirement ?? 'Loading...'}
-                            </Text>
-                        </div>
-                    </div>
-                </SurfaceCard>
-
-                <SurfaceCard tone="elevated">
-                    <div className="flex flex-wrap items-start justify-between gap-4">
-                        <div className={headerTextClassName}>
-                            <Text as="h2" {...cardTitleProps}>
-                                MCP Access
-                            </Text>
-                            <Text as="p" variant="meta" tone="secondary">
-                                Allow or block MCP requests at the server level.
-                            </Text>
-                        </div>
-                        <div className={statusToggleClassName}>
-                            <Text as="span" variant="meta" weight="medium" tone="secondary">
-                                {enabled ? 'Enabled' : 'Disabled'}
-                            </Text>
-                            <Switch
-                                aria-label="Allow MCP access"
-                                checked={enabled}
-                                disabled={!canToggle}
-                                onCheckedChange={() => {
-                                    setEnabledMutation.mutate(!enabled);
-                                }}
-                            />
-                        </div>
-                    </div>
-                </SurfaceCard>
-
-                <SurfaceCard tone="elevated">
-                    <div className={cardBodyClassName}>
-                        <div className="flex flex-wrap items-start justify-between gap-3">
-                            <div className={headerTextClassName}>
-                                <Text as="h2" {...cardTitleProps}>
-                                    Token Management
-                                </Text>
-                                <Text as="p" variant="meta" tone="secondary" className="max-w-[64ch]">
-                                    Ocean Brain supports one active MCP token at a time. Rotating immediately
-                                    invalidates the previous one.
-                                </Text>
-                            </div>
+        <PageLayout
+            title="MCP"
+            variant="default"
+            description="Connect this Ocean Brain instance to MCP clients."
+            headerRight={
+                <div className="inline-flex items-center gap-3 rounded-[14px] border border-border-subtle bg-muted px-3 py-2">
+                    <Text as="span" variant="meta" weight="medium" tone="secondary">
+                        MCP access {enabled ? 'on' : 'off'}
+                    </Text>
+                    <Switch
+                        aria-label="MCP access"
+                        checked={enabled}
+                        disabled={!canToggle}
+                        onCheckedChange={() => {
+                            setEnabledMutation.mutate(!enabled);
+                        }}
+                    />
+                </div>
+            }
+        >
+            <div className="flex flex-col gap-4">
+                <section className="flex flex-col gap-3" aria-labelledby="mcp-connect-heading">
+                    <div className="flex flex-wrap items-start justify-between gap-3">
+                        <div className="space-y-1">
                             <Text
-                                as="span"
-                                variant="meta"
+                                id="mcp-connect-heading"
+                                as="h2"
+                                variant="label"
                                 weight="medium"
-                                tone={hasActiveToken ? 'secondary' : 'tertiary'}
-                                className={activeTokenBadgeClassName}
+                                className={sectionHeadingClassName}
                             >
-                                {hasActiveToken ? '1 active token' : 'No active token'}
+                                Connect a client
+                            </Text>
+                            <Text as="p" variant="meta" tone="secondary">
+                                Save your token in a local file, then copy the command for your client.
                             </Text>
                         </div>
-                        <div className="flex flex-wrap gap-2.5">
+                        <Text
+                            as="span"
+                            variant="meta"
+                            weight="medium"
+                            tone="tertiary"
+                            className="rounded-full border border-border-subtle bg-hover-subtle px-2.5 py-1"
+                        >
+                            {mcpCliRequirement}
+                        </Text>
+                    </div>
+
+                    <div className={`${rowClassName} flex flex-col gap-3`}>
+                        <div className="flex flex-wrap items-center gap-3">
+                            <ToggleGroup
+                                type="single"
+                                variant="quiet"
+                                size="sm"
+                                value={clientGuide}
+                                onValueChange={(value) => {
+                                    if (value === 'codex' || value === 'claude' || value === 'json') {
+                                        setClientGuide(value);
+                                    }
+                                }}
+                            >
+                                <ToggleGroupItem value="codex">Codex</ToggleGroupItem>
+                                <ToggleGroupItem value="claude">Claude</ToggleGroupItem>
+                                <ToggleGroupItem value="json">JSON</ToggleGroupItem>
+                            </ToggleGroup>
+                        </div>
+
+                        <div className="min-w-0 space-y-2">
+                            <div className="flex flex-wrap items-center justify-between gap-3">
+                                <Label htmlFor="mcp-connection-output" className={fieldLabelClassName}>
+                                    {outputLabel}
+                                </Label>
+                                <Button type="button" variant="subtle" size="sm" onClick={handleCopyConnection}>
+                                    <Icon.Copy className="h-4 w-4" />
+                                    {copyLabel}
+                                </Button>
+                            </div>
+                            <Textarea
+                                id="mcp-connection-output"
+                                readOnly
+                                rows={clientGuide === 'json' ? 13 : 9}
+                                wrap="off"
+                                value={connectionOutput}
+                                className={outputTextAreaClassName}
+                            />
+                            <Text as="p" variant="meta" tone="tertiary">
+                                {issuedToken
+                                    ? 'The new token is already included in the token file step.'
+                                    : 'Replace PASTE_TOKEN_HERE before running. The MCP client reads the token from that file.'}
+                            </Text>
+                        </div>
+
+                        <details className="group rounded-[12px] border border-border-subtle bg-muted">
+                            <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-3 py-2.5 marker:hidden">
+                                <Text as="span" variant="meta" weight="medium" tone="secondary">
+                                    Connection options
+                                </Text>
+                                <Icon.ChevronDown
+                                    className="h-4 w-4 shrink-0 text-fg-tertiary transition-transform group-open:rotate-180"
+                                    aria-hidden="true"
+                                />
+                            </summary>
+                            <div className="space-y-3 border-t border-border-subtle px-3 py-3">
+                                <div className={fieldGroupClassName}>
+                                    <Label htmlFor="mcp-server-url" className={fieldLabelClassName}>
+                                        Ocean Brain URL
+                                    </Label>
+                                    <Input
+                                        id="mcp-server-url"
+                                        value={serverUrl}
+                                        onChange={(event) => setServerUrl(event.target.value)}
+                                    />
+                                </div>
+
+                                <div className={fieldGroupClassName}>
+                                    <Label htmlFor="mcp-token-file-path" className={fieldLabelClassName}>
+                                        Token file path
+                                    </Label>
+                                    <Input
+                                        id="mcp-token-file-path"
+                                        placeholder="/absolute/path/to/ocean-brain-mcp-token.txt"
+                                        value={tokenFilePath}
+                                        onChange={(event) => setTokenFilePath(event.target.value)}
+                                    />
+                                </div>
+                            </div>
+                        </details>
+                    </div>
+                </section>
+
+                <section className="flex flex-col gap-3" aria-labelledby="mcp-token-heading">
+                    <div className={`${rowClassName} flex flex-wrap items-center justify-between gap-3`}>
+                        <div className="min-w-0 space-y-1">
+                            <Text
+                                id="mcp-token-heading"
+                                as="h2"
+                                variant="label"
+                                weight="medium"
+                                className={sectionHeadingClassName}
+                            >
+                                Token
+                            </Text>
+                            <Text as="p" variant="meta" tone="tertiary">
+                                {tokenStatusText}. New tokens are shown once.
+                            </Text>
+                        </div>
+                        <div className="flex flex-wrap gap-2">
                             <Button
-                                onClick={() => rotateTokenMutation.mutate(undefined)}
+                                type="button"
+                                size="sm"
+                                variant={hasActiveToken ? 'subtle' : 'primary'}
+                                onClick={handleRotateToken}
                                 isLoading={rotateTokenMutation.isPending}
                             >
-                                Rotate token
+                                {hasActiveToken ? 'Rotate token' : 'Issue token'}
                             </Button>
                             <Button
+                                type="button"
+                                size="sm"
                                 variant="soft-danger"
-                                onClick={() => revokeTokenMutation.mutate()}
+                                onClick={handleRevokeToken}
                                 isLoading={revokeTokenMutation.isPending}
                                 disabled={!hasActiveToken}
                             >
                                 Revoke token
                             </Button>
                         </div>
-                        {issuedToken && (
-                            <div className="space-y-2.5">
-                                <Label htmlFor="issued-mcp-token" className={fieldLabelClassName}>
-                                    Issued token
-                                </Label>
-                                <Textarea id="issued-mcp-token" rows={3} readOnly value={issuedToken} />
-                            </div>
-                        )}
                     </div>
-                </SurfaceCard>
 
-                <SurfaceCard tone="elevated">
-                    <div className={cardBodyClassName}>
-                        <div className={headerTextClassName}>
-                            <Text as="h2" {...cardTitleProps}>
-                                Connection Guide
-                            </Text>
-                            <Text as="p" variant="meta" tone="secondary">
-                                Connect your MCP client with either a token file or an inline token.
-                            </Text>
-                        </div>
-                        <div className="space-y-2">
-                            <Label htmlFor="mcp-server-url" className={fieldLabelClassName}>
-                                Server URL
-                            </Label>
-                            <Input
-                                id="mcp-server-url"
-                                value={serverUrl}
-                                onChange={(event) => setServerUrl(event.target.value)}
-                            />
-                        </div>
-                        <div className="space-y-3">
-                            <ToggleGroup
-                                type="single"
-                                variant="pills"
-                                size="sm"
-                                value={guideMode}
-                                onValueChange={(value) => {
-                                    if (value === 'token-file' || value === 'inline-token') {
-                                        setGuideMode(value);
-                                    }
-                                }}
-                            >
-                                <ToggleGroupItem value="token-file">Token file</ToggleGroupItem>
-                                <ToggleGroupItem value="inline-token">Inline token</ToggleGroupItem>
-                            </ToggleGroup>
-                            <div className={guidePanelClassName}>
-                                <div className={headerTextClassName}>
-                                    <Text as="p" variant="meta" weight="semibold">
-                                        {activeGuide.title}
-                                    </Text>
+                    {issuedToken && (
+                        <div className={`${rowClassName} border-dashed`}>
+                            <div className="mb-3 flex flex-wrap items-start justify-between gap-3">
+                                <div className="space-y-1">
+                                    <Label htmlFor="issued-mcp-token" className={fieldLabelClassName}>
+                                        New token
+                                    </Label>
                                     <Text as="p" variant="meta" tone="secondary">
-                                        {activeGuide.description}
+                                        Copy this token now and save it in your token file.
                                     </Text>
                                 </div>
-                                <pre className={guideSnippetClassName}>{activeGuide.snippet}</pre>
+                                <Button type="button" variant="subtle" size="sm" onClick={handleCopyToken}>
+                                    <Icon.Copy className="h-4 w-4" />
+                                    Copy token
+                                </Button>
                             </div>
+                            <Textarea id="issued-mcp-token" rows={3} readOnly value={issuedToken} />
                         </div>
-                    </div>
-                </SurfaceCard>
+                    )}
+                </section>
             </div>
         </PageLayout>
     );

--- a/packages/client/src/pages/setting/mcp.tsx
+++ b/packages/client/src/pages/setting/mcp.tsx
@@ -4,6 +4,7 @@ import { fetchMcpAdminStatus, revokeMcpToken, rotateMcpToken, setMcpEnabled } fr
 import * as Icon from '~/components/icon';
 import { Button, PageLayout, SurfaceCard } from '~/components/shared';
 import { Input, Label, Switch, Text, Textarea, ToggleGroup, ToggleGroupItem, useToast } from '~/components/ui';
+import { formatVersionLabel, OCEAN_BRAIN_RELEASES_URL } from '~/modules/app-version';
 
 const mcpAdminStatusQueryKey = ['mcp-admin', 'status'] as const;
 
@@ -80,13 +81,9 @@ const McpSetting = () => {
     const hasActiveToken = status?.hasActiveToken ?? false;
     const canToggle = !isLoading && !setEnabledMutation.isPending;
     const serverVersion = status?.server.version;
-    const releaseUrl = status?.server.releaseUrl ?? 'https://github.com/baealex/ocean-brain/releases';
+    const releaseUrl = status?.server.releaseUrl ?? OCEAN_BRAIN_RELEASES_URL;
     const mcpVersionRequirement = status?.server.mcpVersionRequirement;
-    const serverVersionLabel = serverVersion
-        ? /^\d+\.\d+\.\d+/.test(serverVersion)
-            ? `v${serverVersion}`
-            : serverVersion
-        : 'Loading...';
+    const serverVersionLabel = serverVersion ? formatVersionLabel(serverVersion) : 'Loading...';
     const headerTextClassName = 'space-y-1';
     const cardBodyClassName = 'space-y-4.5';
     const statusToggleClassName =

--- a/packages/client/src/vite-env.d.ts
+++ b/packages/client/src/vite-env.d.ts
@@ -7,3 +7,5 @@ interface ImportMetaEnv {
 interface ImportMeta {
     readonly env: ImportMetaEnv;
 }
+
+declare const __OCEAN_BRAIN_VERSION__: string;

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -1,5 +1,6 @@
 import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
+import { readFileSync } from 'fs';
 import path from 'path';
 import svgr from 'vite-plugin-svgr';
 import { defineConfig } from 'vitest/config';
@@ -17,6 +18,9 @@ const mcpAdminAdapterPath = isLocalOnlyDemoBuild
 const imageUploadAdapterPath = isLocalOnlyDemoBuild
     ? './src/apis/image-upload-adapter.local.ts'
     : './src/apis/image-upload-adapter.ts';
+const cliPackageJson = JSON.parse(readFileSync(path.resolve(__dirname, '../cli/package.json'), 'utf-8')) as {
+    version: string;
+};
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -47,6 +51,9 @@ export default defineConfig({
             },
             { find: '~', replacement: path.resolve(__dirname, './src') },
         ],
+    },
+    define: {
+        __OCEAN_BRAIN_VERSION__: JSON.stringify(cliPackageJson.version),
     },
     build: {
         sourcemap: false,

--- a/packages/server/src/features/mcp-admin/http/handlers.test.ts
+++ b/packages/server/src/features/mcp-admin/http/handlers.test.ts
@@ -176,6 +176,7 @@ test('POST /api/mcp-admin/enabled toggles enabled state for authenticated sessio
 
     assert.equal(enabled.status, 200);
     assert.equal(enabled.body.enabled, true);
+    assert.equal(typeof (enabled.body.server as { version?: unknown }).version, 'string');
 });
 
 test('POST /api/mcp-admin/token/revoke revokes active token for authenticated session', async (t) => {

--- a/packages/server/src/features/mcp-admin/http/handlers.ts
+++ b/packages/server/src/features/mcp-admin/http/handlers.ts
@@ -1,3 +1,4 @@
+import { getOceanBrainVersionInfo } from '~/modules/app-version.js';
 import { createAppError } from '~/modules/error-handler.js';
 import type { Controller } from '~/types/index.js';
 import { createMcpAdminService, type McpAdminService } from '../service.js';
@@ -7,11 +8,20 @@ type McpAdminControllerService = Pick<
     'getStatus' | 'setEnabled' | 'rotateToken' | 'revokeActiveToken'
 >;
 
+const createMcpAdminStatusResponse = async (service: McpAdminControllerService) => {
+    const status = await service.getStatus();
+
+    return {
+        ...status,
+        server: getOceanBrainVersionInfo(),
+    };
+};
+
 export const createMcpAdminStatusHandler = (
     service: McpAdminControllerService = createMcpAdminService(),
 ): Controller => {
     return async (_req, res) => {
-        const status = await service.getStatus();
+        const status = await createMcpAdminStatusResponse(service);
         res.status(200).json(status).end();
     };
 };
@@ -26,7 +36,7 @@ export const createMcpAdminSetEnabledHandler = (
         }
 
         await service.setEnabled(enabled);
-        const status = await service.getStatus();
+        const status = await createMcpAdminStatusResponse(service);
         res.status(200).json(status).end();
     };
 };
@@ -50,7 +60,7 @@ export const createMcpAdminRevokeTokenHandler = (
 ): Controller => {
     return async (_req, res) => {
         await service.revokeActiveToken();
-        const status = await service.getStatus();
+        const status = await createMcpAdminStatusResponse(service);
         res.status(200).json(status).end();
     };
 };

--- a/packages/server/src/modules/app-version.ts
+++ b/packages/server/src/modules/app-version.ts
@@ -1,0 +1,76 @@
+import fs from 'fs';
+import path from 'path';
+
+import { paths } from '~/paths.js';
+
+export const OCEAN_BRAIN_RELEASES_URL = 'https://github.com/baealex/ocean-brain/releases';
+
+interface MajorMinorVersion {
+    major: number;
+    minor: number;
+}
+
+const normalizeVersion = (version: string) => version.trim().replace(/^v/i, '');
+
+export const parseMajorMinorVersion = (version: string): MajorMinorVersion | null => {
+    const match = normalizeVersion(version).match(/^(\d+)\.(\d+)(?:\.\d+)?(?:[-+].*)?$/);
+
+    if (!match) {
+        return null;
+    }
+
+    return {
+        major: Number(match[1]),
+        minor: Number(match[2]),
+    };
+};
+
+export const formatMcpVersionRequirement = (serverVersion: string) => {
+    const parsed = parseMajorMinorVersion(serverVersion);
+    return parsed ? `${parsed.major}.${parsed.minor}.x` : 'unknown';
+};
+
+const readPackageVersion = (packageJsonPath: string) => {
+    try {
+        const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8')) as { version?: unknown };
+        return typeof packageJson.version === 'string' ? packageJson.version : undefined;
+    } catch {
+        return undefined;
+    }
+};
+
+const getVersionCandidatePaths = () => {
+    return Array.from(
+        new Set([
+            path.resolve(paths.packageRoot, '..', 'package.json'),
+            path.resolve(paths.packageRoot, '..', 'cli', 'package.json'),
+            path.resolve(process.cwd(), 'packages', 'cli', 'package.json'),
+            path.resolve(process.cwd(), '..', 'cli', 'package.json'),
+        ]),
+    );
+};
+
+export const resolveOceanBrainVersion = () => {
+    if (process.env.OCEAN_BRAIN_VERSION) {
+        return normalizeVersion(process.env.OCEAN_BRAIN_VERSION);
+    }
+
+    for (const candidatePath of getVersionCandidatePaths()) {
+        const version = readPackageVersion(candidatePath);
+        if (version) {
+            return normalizeVersion(version);
+        }
+    }
+
+    return '0.0.0';
+};
+
+export const getOceanBrainVersionInfo = () => {
+    const version = resolveOceanBrainVersion();
+
+    return {
+        version,
+        releaseUrl: OCEAN_BRAIN_RELEASES_URL,
+        mcpVersionRequirement: formatMcpVersionRequirement(version),
+    };
+};

--- a/packages/server/src/modules/mcp-auth.ts
+++ b/packages/server/src/modules/mcp-auth.ts
@@ -2,6 +2,7 @@ import type { NextFunction, Request, RequestHandler, Response } from 'express';
 import type { ValidationRule } from 'graphql';
 import { GraphQLError } from 'graphql';
 
+import { getOceanBrainVersionInfo, parseMajorMinorVersion } from './app-version.js';
 import type { AuthConfig } from './auth-mode.js';
 
 export interface McpTokenValidationResult {
@@ -15,6 +16,32 @@ export interface McpAdminAuthPort {
 }
 
 const JSON_HEADERS = { 'Content-Type': 'application/json' };
+export const OCEAN_BRAIN_MCP_VERSION_HEADER = 'X-Ocean-Brain-MCP-Version';
+
+const readMcpVersion = (req: Request) => {
+    const value = req.headers[OCEAN_BRAIN_MCP_VERSION_HEADER.toLowerCase()];
+    return Array.isArray(value) ? value[0] : value;
+};
+
+export const isMcpVersionCompatible = (serverVersion: string, mcpVersion: string) => {
+    const server = parseMajorMinorVersion(serverVersion);
+    const mcp = parseMajorMinorVersion(mcpVersion);
+
+    return Boolean(server && mcp && server.major === mcp.major && server.minor === mcp.minor);
+};
+
+const createMcpVersionCompatibilityMessage = (serverVersion: string, mcpVersion: string | undefined) => {
+    const mcpVersionText = mcpVersion ? `v${mcpVersion}` : 'not provided';
+
+    return [
+        'Ocean Brain MCP and server versions are incompatible.',
+        `Server: v${serverVersion}`,
+        `MCP: ${mcpVersionText}`,
+        '',
+        'Please update Ocean Brain MCP to match the server minor version.',
+        getOceanBrainVersionInfo().releaseUrl,
+    ].join('\n');
+};
 
 const readBearerToken = (authorizationHeader?: string) => {
     if (!authorizationHeader?.startsWith('Bearer ')) {
@@ -71,6 +98,24 @@ export const createMcpAuthMiddleware = (_authConfig: AuthConfig, mcpAdminAuth: M
                     .json({
                         code: 'FORBIDDEN',
                         message: 'Invalid MCP bearer token.',
+                    })
+                    .end();
+                return;
+            }
+
+            const versionInfo = getOceanBrainVersionInfo();
+            const mcpVersion = readMcpVersion(req);
+
+            if (!mcpVersion || !isMcpVersionCompatible(versionInfo.version, mcpVersion)) {
+                res.status(426)
+                    .set(JSON_HEADERS)
+                    .json({
+                        code: 'MCP_VERSION_INCOMPATIBLE',
+                        message: createMcpVersionCompatibilityMessage(versionInfo.version, mcpVersion),
+                        serverVersion: versionInfo.version,
+                        mcpVersion: mcpVersion ?? null,
+                        requiredMcpVersion: versionInfo.mcpVersionRequirement,
+                        releaseUrl: versionInfo.releaseUrl,
                     })
                     .end();
                 return;

--- a/packages/server/src/paths.ts
+++ b/packages/server/src/paths.ts
@@ -11,6 +11,7 @@ const IMAGE_DIR =
     process.env.OCEAN_BRAIN_IMAGE_DIR || path.resolve(process.env.OCEAN_BRAIN_DATA_DIR || '.', 'assets/images');
 
 export const paths = {
+    packageRoot: path.resolve(PACKAGE_ROOT),
     clientDist: path.resolve(PACKAGE_ROOT, 'client/dist'),
     clientIndex: path.resolve(PACKAGE_ROOT, 'client/dist/index.html'),
     imageDir: path.resolve(IMAGE_DIR),

--- a/packages/server/test/mcp-auth.test.ts
+++ b/packages/server/test/mcp-auth.test.ts
@@ -3,7 +3,33 @@ import type { AddressInfo } from 'node:net';
 import test, { type TestContext } from 'node:test';
 import { createAppWithMcpAuth } from '../src/app.js';
 import type { McpAdminService } from '../src/features/mcp-admin/service.js';
+import { parseMajorMinorVersion, resolveOceanBrainVersion } from '../src/modules/app-version.js';
 import { AUTH_SESSION_COOKIE_NAME, type AuthConfig } from '../src/modules/auth-mode.js';
+import { OCEAN_BRAIN_MCP_VERSION_HEADER } from '../src/modules/mcp-auth.js';
+
+const createCompatibleMcpVersion = (patch = 999) => {
+    const version = parseMajorMinorVersion(resolveOceanBrainVersion());
+    assert.ok(version);
+
+    return `${version.major}.${version.minor}.${patch}`;
+};
+
+const createIncompatibleMcpVersion = () => {
+    const version = parseMajorMinorVersion(resolveOceanBrainVersion());
+    assert.ok(version);
+
+    return `${version.major}.${version.minor + 1}.0`;
+};
+
+const createMcpHeaders = (bearerToken?: string, options: { mcpVersion?: string | null } = {}) => {
+    const mcpVersion = Object.hasOwn(options, 'mcpVersion') ? options.mcpVersion : createCompatibleMcpVersion();
+
+    return {
+        'Content-Type': 'application/json',
+        ...(mcpVersion ? { [OCEAN_BRAIN_MCP_VERSION_HEADER]: mcpVersion } : {}),
+        ...(bearerToken ? { Authorization: `Bearer ${bearerToken}` } : {}),
+    };
+};
 
 const createPasswordAuthConfig = (): AuthConfig => ({
     mode: 'password',
@@ -40,10 +66,7 @@ const startServer = async (t: TestContext, authConfig: AuthConfig, mcpAdminAuth:
 const graphRequest = async (baseUrl: string, path: string, query: string, bearerToken?: string) => {
     const response = await fetch(`${baseUrl}${path}`, {
         method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-            ...(bearerToken ? { Authorization: `Bearer ${bearerToken}` } : {}),
-        },
+        headers: createMcpHeaders(bearerToken),
         body: JSON.stringify({ query }),
     });
 
@@ -56,10 +79,7 @@ const graphRequest = async (baseUrl: string, path: string, query: string, bearer
 const deleteNoteRequest = async (baseUrl: string, noteId: string, bearerToken?: string) => {
     const response = await fetch(`${baseUrl}/api/mcp/notes/delete`, {
         method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-            ...(bearerToken ? { Authorization: `Bearer ${bearerToken}` } : {}),
-        },
+        headers: createMcpHeaders(bearerToken),
         body: JSON.stringify({ id: noteId }),
     });
 
@@ -72,10 +92,7 @@ const deleteNoteRequest = async (baseUrl: string, noteId: string, bearerToken?: 
 const createTagRequest = async (baseUrl: string, name: string, bearerToken?: string) => {
     const response = await fetch(`${baseUrl}/api/mcp/tags/create`, {
         method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-            ...(bearerToken ? { Authorization: `Bearer ${bearerToken}` } : {}),
-        },
+        headers: createMcpHeaders(bearerToken),
         body: JSON.stringify({ name }),
     });
 
@@ -88,10 +105,7 @@ const createTagRequest = async (baseUrl: string, name: string, bearerToken?: str
 const createNoteRequest = async (baseUrl: string, body: Record<string, unknown>, bearerToken?: string) => {
     const response = await fetch(`${baseUrl}/api/mcp/notes/create`, {
         method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-            ...(bearerToken ? { Authorization: `Bearer ${bearerToken}` } : {}),
-        },
+        headers: createMcpHeaders(bearerToken),
         body: JSON.stringify(body),
     });
 
@@ -112,10 +126,7 @@ const connectServerEvents = async (baseUrl: string) => {
 const updateNoteRequest = async (baseUrl: string, body: Record<string, unknown>, bearerToken?: string) => {
     const response = await fetch(`${baseUrl}/api/mcp/notes/update`, {
         method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-            ...(bearerToken ? { Authorization: `Bearer ${bearerToken}` } : {}),
-        },
+        headers: createMcpHeaders(bearerToken),
         body: JSON.stringify(body),
     });
 
@@ -128,10 +139,7 @@ const updateNoteRequest = async (baseUrl: string, body: Record<string, unknown>,
 const noteWriteBaselineRequest = async (baseUrl: string, body: Record<string, unknown>, bearerToken?: string) => {
     const response = await fetch(`${baseUrl}/api/mcp/notes/baseline`, {
         method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-            ...(bearerToken ? { Authorization: `Bearer ${bearerToken}` } : {}),
-        },
+        headers: createMcpHeaders(bearerToken),
         body: JSON.stringify(body),
     });
 
@@ -256,6 +264,65 @@ test('mcp disabled state blocks MCP graphql access even with a valid token', asy
     const query = await graphRequest(baseUrl, '/graphql/mcp', 'query { __typename }', 'mcp-secret');
     assert.equal(query.status, 403);
     assert.equal(query.body.code, 'MCP_DISABLED');
+});
+
+test('mcp version guard allows patch version differences', async (t) => {
+    const { baseUrl } = await startServer(
+        t,
+        createOpenAuthConfig(),
+        createMcpAdminAuth({ enabled: true, expectedToken: 'mcp-secret' }),
+    );
+
+    const response = await fetch(`${baseUrl}/api/mcp/notes/create`, {
+        method: 'POST',
+        headers: createMcpHeaders('mcp-secret', { mcpVersion: createCompatibleMcpVersion(999) }),
+        body: JSON.stringify({}),
+    });
+    const body = (await response.json()) as Record<string, unknown>;
+
+    assert.equal(response.status, 400);
+    assert.equal(body.code, 'INVALID_NOTE_TITLE');
+});
+
+test('mcp version guard blocks minor version differences', async (t) => {
+    const { baseUrl } = await startServer(
+        t,
+        createOpenAuthConfig(),
+        createMcpAdminAuth({ enabled: true, expectedToken: 'mcp-secret' }),
+    );
+
+    const response = await fetch(`${baseUrl}/graphql/mcp`, {
+        method: 'POST',
+        headers: createMcpHeaders('mcp-secret', { mcpVersion: createIncompatibleMcpVersion() }),
+        body: JSON.stringify({ query: 'query { __typename }' }),
+    });
+    const body = (await response.json()) as Record<string, unknown>;
+
+    assert.equal(response.status, 426);
+    assert.equal(body.code, 'MCP_VERSION_INCOMPATIBLE');
+    assert.equal(body.mcpVersion, createIncompatibleMcpVersion());
+    assert.equal(body.serverVersion, resolveOceanBrainVersion());
+    assert.match(String(body.message), /Please update Ocean Brain MCP/);
+    assert.match(String(body.message), /https:\/\/github\.com\/baealex\/ocean-brain\/releases/);
+});
+
+test('mcp version guard blocks requests without an MCP version header after auth succeeds', async (t) => {
+    const { baseUrl } = await startServer(
+        t,
+        createOpenAuthConfig(),
+        createMcpAdminAuth({ enabled: true, expectedToken: 'mcp-secret' }),
+    );
+
+    const response = await fetch(`${baseUrl}/graphql/mcp`, {
+        method: 'POST',
+        headers: createMcpHeaders('mcp-secret', { mcpVersion: null }),
+        body: JSON.stringify({ query: 'query { __typename }' }),
+    });
+    const body = (await response.json()) as Record<string, unknown>;
+
+    assert.equal(response.status, 426);
+    assert.equal(body.code, 'MCP_VERSION_INCOMPATIBLE');
+    assert.equal(body.mcpVersion, null);
 });
 
 test('enabled state still requires a valid bearer token on the MCP note delete endpoint', async (t) => {


### PR DESCRIPTION
## :dart: Goal
- Make the currently installed Ocean Brain version visible from Settings, including MCP-specific settings.
- Ensure local-only demo builds also expose the build version instead of placeholder version text.
- Guide MCP clients into the expected `major.minor` compatibility range with clear update guidance when versions do not match.

## :hammer_and_wrench: Core Changes
- Added server version metadata to the MCP admin status response and surfaced it in both the root Settings page and MCP Settings page with the required MCP version range and GitHub Releases link.
- Injected the Ocean Brain package version into client builds so local-only demo mode can show the actual build version.
- Added `X-Ocean-Brain-MCP-Version` to CLI MCP GraphQL/HTTP requests.
- Added a shared MCP version compatibility guard that returns `426 MCP_VERSION_INCOMPATIBLE` with server/MCP versions and release guidance.
- Added tests for patch-version allowance, minor-version blocking, missing version headers, root/MCP settings UI visibility, local-demo version metadata, and CLI request headers.

## :brain: Key Decisions
- Compatibility is defined by matching `major.minor`; patch differences are allowed.
- Version checks run after MCP enabled/token validation, preserving existing auth error behavior for unauthenticated requests.
- The server version comes from `OCEAN_BRAIN_VERSION` when the CLI starts the server, with package-path fallback for dev and packaged runtime paths.
- Client/demo version display uses the CLI package version injected at build time, and server-backed Settings prefer the MCP admin status response when available.
- Release impact: `release: minor` because this ships a new user-visible version/status capability and MCP compatibility guidance. Expected release/tag plan: next minor release tag, for example `v0.8.0`, to be confirmed during release preparation.

## :test_tube: Verification Guide
### How to verify
1. Run `pnpm check:encoding`.
2. Run `pnpm lint`.
3. Run `pnpm type-check` and `pnpm --filter ocean-brain type-check`.
4. Run `pnpm test:ci`.
5. Run `pnpm build`, `pnpm --filter ocean-brain build`, and `VITE_DEMO_MODE=local-only pnpm --filter @ocean-brain/client build`.
6. Confirm the local-only client build output contains the current version text.
7. Start a local server with a temporary data directory, issue an MCP token, enable MCP, and call `/graphql/mcp` with compatible, incompatible, and missing `X-Ocean-Brain-MCP-Version` headers.

### Expected result
- Encoding, lint, type-check, test, and build commands pass.
- Root Settings and MCP Settings show the current Ocean Brain version, required MCP version range, and GitHub Releases link.
- Local-only demo builds show the injected Ocean Brain build version rather than `local-demo` placeholders.
- MCP requests with matching `major.minor` and different patch versions succeed.
- MCP requests with mismatched `major.minor` or no version header return `426 MCP_VERSION_INCOMPATIBLE` with server version, MCP version, required range, and GitHub Releases URL.
- MCP SDK tool calls surface the incompatibility as an `isError: true` result containing update guidance.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)