### PR TITLE
✨ Add accessible graph explorer

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -30,6 +30,7 @@
         "@radix-ui/react-slot": "^1.2.4",
         "@tanstack/react-query": "^5.90.21",
         "@tanstack/react-router": "^1.166.3",
+        "@tanstack/react-virtual": "^3.14.3",
         "axios": "^1.15.2",
         "class-variance-authority": "^0.7.1",
         "classnames": "^2.5.1",

--- a/packages/client/src/modules/route-search.spec.ts
+++ b/packages/client/src/modules/route-search.spec.ts
@@ -2,6 +2,7 @@ import dayjs from 'dayjs';
 
 import {
     validateCalendarSearch,
+    validateGraphSearch,
     validateHomeSearch,
     validatePaginationSearch,
     validateSearchPageSearch,
@@ -62,6 +63,12 @@ describe('route-search validators', () => {
             month: dayjs().month() + 1,
             type: 'create',
         });
+    });
+
+    it('normalizes graph selected note search values', () => {
+        expect(validateGraphSearch({ selected: 'note-17' })).toEqual({ selected: 'note-17' });
+        expect(validateGraphSearch({ selected: '  ' })).toEqual({});
+        expect(validateGraphSearch({ selected: 17 })).toEqual({});
     });
 
     it('normalizes view-notes search values', () => {

--- a/packages/client/src/modules/route-search.ts
+++ b/packages/client/src/modules/route-search.ts
@@ -88,6 +88,10 @@ export interface CalendarRouteSearch {
     type: 'create' | 'update';
 }
 
+export interface GraphRouteSearch {
+    selected?: string;
+}
+
 export interface ViewNotesRouteSearch extends PaginationRouteSearch {
     sectionId: string;
 }
@@ -120,6 +124,11 @@ export const validateCalendarSearch = (search: SearchRecord): CalendarRouteSearc
     }),
     type: parseEnum(search.type, CALENDAR_TYPES, 'create'),
 });
+
+export const validateGraphSearch = (search: SearchRecord): GraphRouteSearch => {
+    const selected = parseString(search.selected, '').trim();
+    return selected ? { selected } : {};
+};
 
 export const validateViewNotesSearch = (search: SearchRecord): ViewNotesRouteSearch => ({
     page: parsePositiveInt(search.page, 1),

--- a/packages/client/src/pages/Graph.spec.tsx
+++ b/packages/client/src/pages/Graph.spec.tsx
@@ -1,0 +1,101 @@
+import { QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { createTestQueryClient } from '~/test/test-utils';
+import Graph from './Graph';
+
+const routeState = vi.hoisted(() => ({
+    navigate: vi.fn(),
+}));
+
+const apiMocks = vi.hoisted(() => ({
+    fetchNoteGraph: vi.fn(),
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+    Link: ({
+        children,
+        params,
+        to,
+        ...props
+    }: {
+        children: React.ReactNode;
+        params?: { id?: string };
+        to?: string;
+    }) => (
+        <a href={params?.id ? `/${params.id}` : to} {...props}>
+            {children}
+        </a>
+    ),
+    useNavigate: () => routeState.navigate,
+}));
+
+vi.mock('~/apis/note.api', () => apiMocks);
+
+vi.mock('react-force-graph-2d', async () => {
+    const React = await vi.importActual<typeof import('react')>('react');
+
+    return {
+        default: React.forwardRef((_props, ref) => {
+            React.useImperativeHandle(ref, () => ({
+                enableZoomInteraction: vi.fn(),
+                zoomToFit: vi.fn(),
+            }));
+
+            return <div data-testid="force-graph" />;
+        }),
+    };
+});
+
+const renderGraph = () => {
+    const queryClient = createTestQueryClient();
+
+    render(
+        <QueryClientProvider client={queryClient}>
+            <Graph />
+        </QueryClientProvider>,
+    );
+};
+
+describe('<Graph />', () => {
+    beforeEach(() => {
+        apiMocks.fetchNoteGraph.mockResolvedValue({
+            type: 'success',
+            noteGraph: {
+                nodes: [
+                    { id: 'note-1', title: 'Alpha note', connections: 1 },
+                    { id: 'note-2', title: 'Beta note', connections: 1 },
+                    { id: 'note-3', title: 'Isolated note', connections: 0 },
+                ],
+                links: [{ source: 'note-1', target: 'note-2' }],
+            },
+        });
+    });
+
+    it('provides a keyboard-accessible graph node list with note links and selection status', async () => {
+        renderGraph();
+
+        expect(await screen.findByRole('region', { name: 'Graph nodes' })).toBeInTheDocument();
+        expect(screen.getByTestId('force-graph')).toBeInTheDocument();
+
+        const alphaLink = screen.getByRole('link', { name: /Alpha note/ });
+        expect(alphaLink).toHaveAttribute('href', '/note-1');
+        expect(screen.queryByRole('link', { name: /Isolated note/ })).not.toBeInTheDocument();
+
+        fireEvent.focus(alphaLink);
+
+        expect(screen.getByRole('status')).toHaveTextContent('Alpha note selected, 1 links');
+        expect(screen.getByRole('status')).toHaveTextContent('Linked to Beta note');
+    });
+
+    it('filters the accessible graph node list', async () => {
+        const user = userEvent.setup();
+        renderGraph();
+
+        await user.type(await screen.findByRole('textbox', { name: 'Search graph nodes' }), 'beta');
+
+        expect(screen.getByRole('link', { name: /Beta note/ })).toBeInTheDocument();
+        expect(screen.queryByRole('link', { name: /Alpha note/ })).not.toBeInTheDocument();
+    });
+});

--- a/packages/client/src/pages/Graph.spec.tsx
+++ b/packages/client/src/pages/Graph.spec.tsx
@@ -1,5 +1,5 @@
 import { QueryClientProvider } from '@tanstack/react-query';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { createTestQueryClient } from '~/test/test-utils';
@@ -7,13 +7,23 @@ import Graph from './Graph';
 
 const routeState = vi.hoisted(() => ({
     navigate: vi.fn(),
+    search: {} as { selected?: string },
 }));
 
 const apiMocks = vi.hoisted(() => ({
     fetchNoteGraph: vi.fn(),
 }));
 
+const virtualizerMocks = vi.hoisted(() => ({
+    measureElement: vi.fn(),
+    scrollToIndex: vi.fn(),
+}));
+
 vi.mock('@tanstack/react-router', () => ({
+    getRouteApi: () => ({
+        useNavigate: () => routeState.navigate,
+        useSearch: () => routeState.search,
+    }),
     Link: ({
         children,
         params,
@@ -28,7 +38,35 @@ vi.mock('@tanstack/react-router', () => ({
             {children}
         </a>
     ),
-    useNavigate: () => routeState.navigate,
+}));
+
+vi.mock('@tanstack/react-virtual', () => ({
+    useVirtualizer: ({
+        count,
+        estimateSize,
+        getItemKey,
+    }: {
+        count: number;
+        estimateSize: (index: number) => number;
+        getItemKey?: (index: number) => number | string | bigint;
+    }) => {
+        const itemSize = count > 0 ? estimateSize(0) : 0;
+
+        return {
+            getTotalSize: () => count * itemSize,
+            getVirtualItems: () =>
+                Array.from({ length: count }, (_, index) => ({
+                    end: (index + 1) * itemSize,
+                    index,
+                    key: getItemKey?.(index) ?? index,
+                    lane: 0,
+                    size: itemSize,
+                    start: index * itemSize,
+                })),
+            measureElement: virtualizerMocks.measureElement,
+            scrollToIndex: virtualizerMocks.scrollToIndex,
+        };
+    },
 }));
 
 vi.mock('~/apis/note.api', () => apiMocks);
@@ -60,6 +98,10 @@ const renderGraph = () => {
 
 describe('<Graph />', () => {
     beforeEach(() => {
+        routeState.navigate.mockReset();
+        routeState.search = {};
+        virtualizerMocks.measureElement.mockReset();
+        virtualizerMocks.scrollToIndex.mockReset();
         apiMocks.fetchNoteGraph.mockResolvedValue({
             type: 'success',
             noteGraph: {
@@ -87,9 +129,47 @@ describe('<Graph />', () => {
 
         await user.click(alphaButton);
 
-        expect(screen.getByRole('status')).toHaveTextContent('Alpha note selected, 1 links');
-        expect(screen.getByRole('status')).toHaveTextContent('Beta note');
-        expect(routeState.navigate).not.toHaveBeenCalled();
+        expect(routeState.navigate).toHaveBeenCalledWith({
+            search: expect.any(Function),
+            replace: true,
+        });
+        expect(routeState.navigate.mock.calls[0][0].search({})).toEqual({
+            selected: 'note-1',
+        });
+    });
+
+    it('restores selected graph node from the route search', async () => {
+        routeState.search = { selected: 'note-2' };
+        renderGraph();
+
+        expect(await screen.findByRole('status')).toHaveTextContent('Beta note selected, 1 links');
+        expect(screen.getByRole('status')).toHaveTextContent('Alpha note');
+
+        await waitFor(() => {
+            expect(virtualizerMocks.scrollToIndex).toHaveBeenCalledWith(1, {
+                align: 'auto',
+                behavior: 'smooth',
+            });
+        });
+
+        const listItems = screen.getAllByRole('listitem');
+        expect(listItems[1]).toHaveAttribute('aria-posinset', '2');
+        expect(listItems[1]).toHaveAttribute('aria-setsize', '2');
+    });
+
+    it('keeps graph note rows virtualized', async () => {
+        renderGraph();
+
+        expect(await screen.findByRole('list', { name: 'Graph notes' })).toBeInTheDocument();
+        expect(virtualizerMocks.measureElement).toHaveBeenCalled();
+
+        const listItems = screen.getAllByRole('listitem');
+        expect(listItems[0]).toHaveStyle({
+            transform: 'translateY(0px)',
+        });
+        expect(listItems[1]).toHaveStyle({
+            transform: 'translateY(57px)',
+        });
     });
 
     it('filters the accessible graph node list', async () => {

--- a/packages/client/src/pages/Graph.spec.tsx
+++ b/packages/client/src/pages/Graph.spec.tsx
@@ -160,19 +160,18 @@ describe('<Graph />', () => {
         expect(listItems[1]).toHaveAttribute('aria-setsize', '2');
     });
 
-    it('keeps graph note rows virtualized', async () => {
+    it('keeps graph note rows in an accessible virtualized list', async () => {
         renderGraph();
 
         expect(await screen.findByRole('list', { name: 'Graph notes' })).toBeInTheDocument();
         expect(virtualizerMocks.measureElement).toHaveBeenCalled();
 
         const listItems = screen.getAllByRole('listitem');
-        expect(listItems[0]).toHaveStyle({
-            transform: 'translateY(0px)',
-        });
-        expect(listItems[1]).toHaveStyle({
-            transform: 'translateY(57px)',
-        });
+        expect(listItems).toHaveLength(2);
+        expect(listItems[0]).toHaveAttribute('aria-posinset', '1');
+        expect(listItems[0]).toHaveAttribute('aria-setsize', '2');
+        expect(listItems[1]).toHaveAttribute('aria-posinset', '2');
+        expect(listItems[1]).toHaveAttribute('aria-setsize', '2');
     });
 
     it('provides a keyboard scroll target for virtualized graph notes', async () => {
@@ -204,7 +203,11 @@ describe('<Graph />', () => {
 
         await user.keyboard('{PageDown}');
 
-        expect(virtualizerMocks.scrollToOffset).toHaveBeenCalledWith(399, { behavior: 'auto' });
+        const [offset, options] = virtualizerMocks.scrollToOffset.mock.calls[0] ?? [];
+
+        expect(offset).toEqual(expect.any(Number));
+        expect(offset).toBeGreaterThan(0);
+        expect(options).toEqual({ behavior: 'auto' });
     });
 
     it('filters the accessible graph node list', async () => {

--- a/packages/client/src/pages/Graph.spec.tsx
+++ b/packages/client/src/pages/Graph.spec.tsx
@@ -16,6 +16,7 @@ const apiMocks = vi.hoisted(() => ({
 
 const virtualizerMocks = vi.hoisted(() => ({
     measureElement: vi.fn(),
+    scrollToOffset: vi.fn(),
     scrollToIndex: vi.fn(),
 }));
 
@@ -64,6 +65,7 @@ vi.mock('@tanstack/react-virtual', () => ({
                     start: index * itemSize,
                 })),
             measureElement: virtualizerMocks.measureElement,
+            scrollToOffset: virtualizerMocks.scrollToOffset,
             scrollToIndex: virtualizerMocks.scrollToIndex,
         };
     },
@@ -101,6 +103,7 @@ describe('<Graph />', () => {
         routeState.navigate.mockReset();
         routeState.search = {};
         virtualizerMocks.measureElement.mockReset();
+        virtualizerMocks.scrollToOffset.mockReset();
         virtualizerMocks.scrollToIndex.mockReset();
         apiMocks.fetchNoteGraph.mockResolvedValue({
             type: 'success',
@@ -172,13 +175,74 @@ describe('<Graph />', () => {
         });
     });
 
+    it('provides a keyboard scroll target for virtualized graph notes', async () => {
+        const user = userEvent.setup();
+        apiMocks.fetchNoteGraph.mockResolvedValue({
+            type: 'success',
+            noteGraph: {
+                nodes: Array.from({ length: 20 }, (_, index) => ({
+                    id: `note-${index + 1}`,
+                    title: `Note ${index + 1}`,
+                    connections: 1,
+                })),
+                links: Array.from({ length: 19 }, (_, index) => ({
+                    source: `note-${index + 1}`,
+                    target: `note-${index + 2}`,
+                })),
+            },
+        });
+        renderGraph();
+
+        const list = await screen.findByRole('list', { name: 'Graph notes' });
+        expect(list).toHaveAttribute('tabindex', '0');
+        expect(list).toHaveAccessibleDescription(
+            '20 shown Focus the graph notes list and use arrow, page, home, or end keys to browse more results.',
+        );
+
+        list.focus();
+        expect(list).toHaveFocus();
+
+        await user.keyboard('{PageDown}');
+
+        expect(virtualizerMocks.scrollToOffset).toHaveBeenCalledWith(399, { behavior: 'auto' });
+    });
+
     it('filters the accessible graph node list', async () => {
         const user = userEvent.setup();
         renderGraph();
 
-        await user.type(await screen.findByRole('textbox', { name: 'Search graph' }), 'beta');
+        const searchInput = await screen.findByRole('textbox', { name: 'Search graph' });
+        expect(searchInput).toHaveAccessibleDescription('2 shown');
+
+        await user.type(searchInput, 'beta');
 
         expect(screen.getByRole('button', { name: /Beta note/ })).toBeInTheDocument();
         expect(screen.queryByRole('button', { name: /Alpha note/ })).not.toBeInTheDocument();
+        expect(searchInput).toHaveAccessibleDescription('1 shown');
+        expect(virtualizerMocks.scrollToOffset).toHaveBeenCalledWith(0, { behavior: 'auto' });
+    });
+
+    it('does not let selected-node scrolling override search reset', async () => {
+        routeState.search = { selected: 'note-2' };
+        const user = userEvent.setup();
+        renderGraph();
+
+        expect(await screen.findByRole('status')).toHaveTextContent('Beta note selected, 1 links');
+        await waitFor(() => {
+            expect(virtualizerMocks.scrollToIndex).toHaveBeenCalledWith(1, {
+                align: 'auto',
+                behavior: 'smooth',
+            });
+        });
+
+        virtualizerMocks.scrollToIndex.mockClear();
+        virtualizerMocks.scrollToOffset.mockClear();
+
+        await user.type(screen.getByRole('textbox', { name: 'Search graph' }), 'note');
+
+        expect(screen.getByRole('button', { name: /Alpha note/ })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /Beta note/ })).toBeInTheDocument();
+        expect(virtualizerMocks.scrollToOffset).toHaveBeenCalledWith(0, { behavior: 'auto' });
+        expect(virtualizerMocks.scrollToIndex).not.toHaveBeenCalled();
     });
 });

--- a/packages/client/src/pages/Graph.spec.tsx
+++ b/packages/client/src/pages/Graph.spec.tsx
@@ -1,5 +1,5 @@
 import { QueryClientProvider } from '@tanstack/react-query';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { createTestQueryClient } from '~/test/test-utils';
@@ -73,29 +73,32 @@ describe('<Graph />', () => {
         });
     });
 
-    it('provides a keyboard-accessible graph node list with note links and selection status', async () => {
+    it('provides a keyboard-accessible graph node list with separate selection and open actions', async () => {
+        const user = userEvent.setup();
         renderGraph();
 
-        expect(await screen.findByRole('region', { name: 'Graph nodes' })).toBeInTheDocument();
+        expect(await screen.findByRole('region', { name: 'Graph Explorer' })).toBeInTheDocument();
         expect(screen.getByTestId('force-graph')).toBeInTheDocument();
 
-        const alphaLink = screen.getByRole('link', { name: /Alpha note/ });
-        expect(alphaLink).toHaveAttribute('href', '/note-1');
-        expect(screen.queryByRole('link', { name: /Isolated note/ })).not.toBeInTheDocument();
+        const alphaButton = screen.getByRole('button', { name: /Alpha note/ });
+        const alphaOpenLink = screen.getByRole('link', { name: 'Open Alpha note' });
+        expect(alphaOpenLink).toHaveAttribute('href', '/note-1');
+        expect(screen.queryByRole('button', { name: /Isolated note/ })).not.toBeInTheDocument();
 
-        fireEvent.focus(alphaLink);
+        await user.click(alphaButton);
 
         expect(screen.getByRole('status')).toHaveTextContent('Alpha note selected, 1 links');
-        expect(screen.getByRole('status')).toHaveTextContent('Linked to Beta note');
+        expect(screen.getByRole('status')).toHaveTextContent('Beta note');
+        expect(routeState.navigate).not.toHaveBeenCalled();
     });
 
     it('filters the accessible graph node list', async () => {
         const user = userEvent.setup();
         renderGraph();
 
-        await user.type(await screen.findByRole('textbox', { name: 'Search graph nodes' }), 'beta');
+        await user.type(await screen.findByRole('textbox', { name: 'Search graph' }), 'beta');
 
-        expect(screen.getByRole('link', { name: /Beta note/ })).toBeInTheDocument();
-        expect(screen.queryByRole('link', { name: /Alpha note/ })).not.toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /Beta note/ })).toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: /Alpha note/ })).not.toBeInTheDocument();
     });
 });

--- a/packages/client/src/pages/Graph.spec.tsx
+++ b/packages/client/src/pages/Graph.spec.tsx
@@ -195,7 +195,7 @@ describe('<Graph />', () => {
         const list = await screen.findByRole('list', { name: 'Graph notes' });
         expect(list).toHaveAttribute('tabindex', '0');
         expect(list).toHaveAccessibleDescription(
-            '20 shown Focus the graph notes list and use arrow, page, home, or end keys to browse more results.',
+            '20 graph notes shown Focus the graph notes list and use arrow, page, home, or end keys to browse more results.',
         );
 
         list.focus();
@@ -214,15 +214,21 @@ describe('<Graph />', () => {
         const user = userEvent.setup();
         renderGraph();
 
-        const searchInput = await screen.findByRole('textbox', { name: 'Search graph' });
-        expect(searchInput).toHaveAccessibleDescription('2 shown');
+        const searchInput = await screen.findByRole('textbox', { name: 'Search graph notes' });
+        expect(searchInput).toHaveAccessibleDescription('2 graph notes shown');
 
         await user.type(searchInput, 'beta');
 
         expect(screen.getByRole('button', { name: /Beta note/ })).toBeInTheDocument();
         expect(screen.queryByRole('button', { name: /Alpha note/ })).not.toBeInTheDocument();
-        expect(searchInput).toHaveAccessibleDescription('1 shown');
+        expect(searchInput).toHaveAccessibleDescription('1 graph notes shown');
         expect(virtualizerMocks.scrollToOffset).toHaveBeenCalledWith(0, { behavior: 'auto' });
+
+        await user.click(screen.getByRole('button', { name: 'Clear graph search' }));
+
+        expect(searchInput).toHaveValue('');
+        expect(screen.getByRole('button', { name: /Alpha note/ })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /Beta note/ })).toBeInTheDocument();
     });
 
     it('does not let selected-node scrolling override search reset', async () => {
@@ -241,7 +247,7 @@ describe('<Graph />', () => {
         virtualizerMocks.scrollToIndex.mockClear();
         virtualizerMocks.scrollToOffset.mockClear();
 
-        await user.type(screen.getByRole('textbox', { name: 'Search graph' }), 'note');
+        await user.type(screen.getByRole('textbox', { name: 'Search graph notes' }), 'note');
 
         expect(screen.getByRole('button', { name: /Alpha note/ })).toBeInTheDocument();
         expect(screen.getByRole('button', { name: /Beta note/ })).toBeInTheDocument();

--- a/packages/client/src/pages/Graph.tsx
+++ b/packages/client/src/pages/Graph.tsx
@@ -1,5 +1,5 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { useDeferredValue, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { fetchNoteGraph } from '~/apis/note.api';
 import { QueryBoundary, QueryErrorView } from '~/components/app';
@@ -27,7 +27,6 @@ const graphPageFallback = (
 
 function GraphContent() {
     const [nodeSearchQuery, setNodeSearchQuery] = useState('');
-    const deferredNodeSearchQuery = useDeferredValue(nodeSearchQuery);
     const { clearSelection, openNode, selectNode, selectedNodeId } = useGraphSelection();
 
     const { data } = useSuspenseQuery({
@@ -48,8 +47,8 @@ function GraphContent() {
     );
     const graphNodes = useMemo(() => (graphData ? sortGraphNodes(graphData.nodes) : []), [graphData]);
     const filteredGraphNodes = useMemo(
-        () => filterGraphNodes(graphNodes, deferredNodeSearchQuery),
-        [deferredNodeSearchQuery, graphNodes],
+        () => filterGraphNodes(graphNodes, nodeSearchQuery),
+        [graphNodes, nodeSearchQuery],
     );
     const selectedNode = useMemo(() => getSelectedGraphNode(graphNodes, selectedNodeId), [graphNodes, selectedNodeId]);
     const selectedConnectedNodes = useMemo(

--- a/packages/client/src/pages/Graph.tsx
+++ b/packages/client/src/pages/Graph.tsx
@@ -1,35 +1,21 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { Link, useNavigate } from '@tanstack/react-router';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import ForceGraph2D from 'react-force-graph-2d';
+import { useDeferredValue, useMemo, useState } from 'react';
 
-import { fetchNoteGraph, type GraphLink, type GraphNode } from '~/apis/note.api';
+import { fetchNoteGraph } from '~/apis/note.api';
 import { QueryBoundary, QueryErrorView } from '~/components/app';
-import * as Icon from '~/components/icon';
 import { Empty, PageLayout, Skeleton } from '~/components/shared';
-import { Input, Text } from '~/components/ui';
-import { getHash } from '~/modules/hash';
 import { queryKeys } from '~/modules/query-key-factory';
-import { NOTE_ROUTE } from '~/modules/url';
-import { useTheme } from '~/store/theme';
-import { getGraphLabelFont, getGraphLinkColor, getGraphNodeFill, getGraphTheme } from './graph-theme';
-
-interface GraphData {
-    nodes: GraphNode[];
-    links: GraphLink[];
-}
-
-interface ForceGraphInstance {
-    zoomToFit: (duration?: number, padding?: number) => void;
-    enableZoomInteraction: (enable: boolean) => void;
-}
-
-function getNodeSize(connections: number) {
-    if (connections <= 1) return 3.5;
-    if (connections <= 3) return 4.5;
-    if (connections <= 6) return 5.5;
-    return Math.min(7, 5.5 + Math.sqrt(connections) * 0.5);
-}
+import { GraphCanvas } from './GraphCanvas';
+import { GraphExplorerPanel } from './GraphExplorerPanel';
+import {
+    createAdjacencyMap,
+    createConnectedGraphData,
+    filterGraphNodes,
+    getConnectedGraphNodes,
+    getSelectedGraphNode,
+    sortGraphNodes,
+} from './graph-data';
+import { useGraphSelection } from './useGraphSelection';
 
 const graphPageFallback = (
     <PageLayout title="Knowledge Graph" description={<Skeleton width={184} height={16} className="rounded-full" />}>
@@ -40,20 +26,9 @@ const graphPageFallback = (
 );
 
 function GraphContent() {
-    const navigate = useNavigate();
-    const containerRef = useRef<HTMLDivElement>(null);
-    const graphRef = useRef<ForceGraphInstance | null>(null);
-    const [dimensions, setDimensions] = useState({
-        width: 800,
-        height: 600,
-    });
-    const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
     const [nodeSearchQuery, setNodeSearchQuery] = useState('');
-
-    const { theme } = useTheme((state) => state);
-    const graphTheme = getGraphTheme(theme);
-    const graphThemeRef = useRef(graphTheme);
-    graphThemeRef.current = graphTheme;
+    const deferredNodeSearchQuery = useDeferredValue(nodeSearchQuery);
+    const { clearSelection, openNode, selectNode, selectedNodeId } = useGraphSelection();
 
     const { data } = useSuspenseQuery({
         queryKey: queryKeys.notes.graph(),
@@ -66,249 +41,20 @@ function GraphContent() {
         },
     });
 
-    const graphData: GraphData | null = useMemo(() => {
-        if (data.nodes.length === 0) {
-            return null;
-        }
-
-        const connectedNodes = data.nodes.filter((node) => node.connections > 0);
-        if (connectedNodes.length === 0) {
-            return null;
-        }
-
-        const connectedIds = new Set(connectedNodes.map((node) => node.id));
-        return {
-            nodes: connectedNodes,
-            links: data.links.filter((link) => connectedIds.has(link.source) && connectedIds.has(link.target)),
-        };
-    }, [data]);
-
-    useEffect(() => {
-        if (!graphData) {
-            return;
-        }
-
-        const updateDimensions = () => {
-            if (!containerRef.current) {
-                return;
-            }
-
-            const rect = containerRef.current.getBoundingClientRect();
-            const isCompactLayout = rect.width < 768;
-            setDimensions({
-                width: rect.width,
-                height: isCompactLayout
-                    ? Math.max(420, Math.min(520, rect.width * 1.25))
-                    : Math.max(600, window.innerHeight - 150),
-            });
-        };
-
-        updateDimensions();
-        window.addEventListener('resize', updateDimensions);
-        return () => window.removeEventListener('resize', updateDimensions);
-    }, [graphData]);
-
-    useEffect(() => {
-        if (!graphData || !graphRef.current) {
-            return;
-        }
-
-        const timeoutId = window.setTimeout(() => {
-            graphRef.current?.zoomToFit(400, dimensions.width < 768 ? 80 : 50);
-        }, 500);
-
-        return () => window.clearTimeout(timeoutId);
-    }, [dimensions.width, graphData]);
-
-    const selectedNodeIdRef = useRef(selectedNodeId);
-    selectedNodeIdRef.current = selectedNodeId;
-
-    const handleNodeClick = useCallback(
-        (node: GraphNode) => {
-            if (selectedNodeIdRef.current === node.id) {
-                navigate({
-                    to: NOTE_ROUTE,
-                    params: { id: node.id },
-                });
-                return;
-            }
-
-            setSelectedNodeId(node.id);
-        },
-        [navigate],
+    const graphData = useMemo(() => createConnectedGraphData(data), [data]);
+    const adjacencyMap = useMemo(
+        () => (graphData ? createAdjacencyMap(graphData.links) : new Map<string, Set<string>>()),
+        [graphData],
     );
-
-    const handleBackgroundClick = useCallback(() => {
-        setSelectedNodeId(null);
-    }, []);
-
-    const handleNodeHover = useCallback((node: GraphNode | null) => {
-        if (containerRef.current) {
-            containerRef.current.style.cursor = node ? 'pointer' : 'default';
-        }
-    }, []);
-
-    const isDraggingRef = useRef(false);
-
-    const handleNodeDrag = useCallback(() => {
-        if (!isDraggingRef.current) {
-            isDraggingRef.current = true;
-            graphRef.current?.enableZoomInteraction(false);
-        }
-    }, []);
-
-    const handleNodeDragEnd = useCallback(() => {
-        isDraggingRef.current = false;
-        graphRef.current?.enableZoomInteraction(true);
-    }, []);
-
-    const adjacencyMapRef = useRef(new Map<string, Set<string>>());
-    const adjacencyMap = useMemo(() => {
-        const map = new Map<string, Set<string>>();
-        if (graphData) {
-            for (const link of graphData.links) {
-                if (!map.has(link.source)) map.set(link.source, new Set());
-                if (!map.has(link.target)) map.set(link.target, new Set());
-                map.get(link.source)?.add(link.target);
-                map.get(link.target)?.add(link.source);
-            }
-        }
-        return map;
-    }, [graphData]);
-    adjacencyMapRef.current = adjacencyMap;
-
-    const graphNodes = useMemo(() => {
-        if (!graphData) {
-            return [];
-        }
-
-        return [...graphData.nodes].sort((a, b) => b.connections - a.connections || a.title.localeCompare(b.title));
-    }, [graphData]);
-
-    const filteredGraphNodes = useMemo(() => {
-        const query = nodeSearchQuery.trim().toLowerCase();
-        if (!query) {
-            return graphNodes;
-        }
-
-        return graphNodes.filter((node) => node.title.toLowerCase().includes(query));
-    }, [graphNodes, nodeSearchQuery]);
-
-    const selectedNode = useMemo(() => {
-        if (!selectedNodeId) {
-            return null;
-        }
-
-        return graphNodes.find((node) => node.id === selectedNodeId) ?? null;
-    }, [graphNodes, selectedNodeId]);
-
-    const selectedConnectedNodes = useMemo(() => {
-        if (!selectedNodeId) {
-            return [];
-        }
-
-        const connectedIds = adjacencyMap.get(selectedNodeId);
-        if (!connectedIds) {
-            return [];
-        }
-
-        return graphNodes.filter((node) => connectedIds.has(node.id));
-    }, [adjacencyMap, graphNodes, selectedNodeId]);
-
-    const hubNodeCount = useMemo(() => graphNodes.filter((node) => node.connections >= 4).length, [graphNodes]);
-    const visibleSelectedConnections = selectedConnectedNodes.slice(0, 4);
-    const remainingSelectedConnectionCount = selectedConnectedNodes.length - visibleSelectedConnections.length;
-
-    const selectedNodeStatus = selectedNode
-        ? `${selectedNode.title || 'Untitled'} selected, ${selectedNode.connections} links`
-        : 'No graph node selected';
-
-    const nodeCanvasObject = useCallback(
-        (node: GraphNode & { x?: number; y?: number }, ctx: CanvasRenderingContext2D, globalScale: number) => {
-            const palette = graphThemeRef.current;
-            const selectedId = selectedNodeId;
-            const adjacency = adjacencyMapRef.current;
-            const nodeSize = getNodeSize(node.connections);
-            const nx = node.x || 0;
-            const ny = node.y || 0;
-
-            const isSelected = selectedId === node.id;
-            const isConnected = selectedId ? (adjacency.get(selectedId)?.has(node.id) ?? false) : false;
-            const isDimmed = selectedId !== null && !isSelected && !isConnected;
-            const colorIndex = getHash(node.id);
-
-            ctx.beginPath();
-            ctx.arc(nx, ny, nodeSize, 0, Math.PI * 2);
-
-            ctx.fillStyle = getGraphNodeFill(theme, {
-                connections: node.connections,
-                colorIndex,
-                selectedNodeId: selectedId,
-                nodeId: node.id,
-                isConnected,
-            });
-            ctx.fill();
-
-            if (isDimmed) {
-                return;
-            }
-
-            ctx.strokeStyle = palette.nodeStroke;
-            ctx.lineWidth = (isSelected ? 2 : 1) / globalScale;
-            ctx.stroke();
-
-            if (isSelected) {
-                ctx.beginPath();
-                ctx.arc(nx, ny, nodeSize + 2 / globalScale, 0, Math.PI * 2);
-                ctx.strokeStyle = palette.nodeSelectedStroke;
-                ctx.lineWidth = 1.5 / globalScale;
-                ctx.stroke();
-            }
-
-            const isHubConnected = isConnected && node.connections >= 4;
-            if (isSelected || isHubConnected || globalScale > 2.5) {
-                const label = node.title || 'Untitled';
-                const fontSize = Math.max(10 / globalScale, 2.5);
-                ctx.font = getGraphLabelFont(theme, {
-                    fontSize,
-                    emphasize: isSelected,
-                });
-                ctx.textAlign = 'center';
-                ctx.textBaseline = 'top';
-
-                const textWidth = ctx.measureText(label).width;
-                const padding = 2 / globalScale;
-                const labelY = ny + nodeSize + 3 / globalScale;
-
-                ctx.fillStyle = palette.labelBackground;
-                ctx.fillRect(nx - textWidth / 2 - padding, labelY, textWidth + padding * 2, fontSize + padding * 2);
-
-                ctx.fillStyle = palette.labelText;
-                ctx.fillText(label, nx, labelY + padding);
-            }
-        },
-        [selectedNodeId, theme],
+    const graphNodes = useMemo(() => (graphData ? sortGraphNodes(graphData.nodes) : []), [graphData]);
+    const filteredGraphNodes = useMemo(
+        () => filterGraphNodes(graphNodes, deferredNodeSearchQuery),
+        [deferredNodeSearchQuery, graphNodes],
     );
-
-    const linkCanvasObject = useCallback(
-        (link: GraphLink, ctx: CanvasRenderingContext2D, globalScale: number) => {
-            const selectedId = selectedNodeId;
-            const source = link.source as unknown as { x?: number; y?: number; id: string };
-            const target = link.target as unknown as { x?: number; y?: number; id: string };
-            const isConnected = selectedId ? source.id === selectedId || target.id === selectedId : false;
-
-            ctx.beginPath();
-            ctx.moveTo(source.x || 0, source.y || 0);
-            ctx.lineTo(target.x || 0, target.y || 0);
-
-            ctx.strokeStyle = getGraphLinkColor(theme, {
-                selectedNodeId: selectedId,
-                isConnected,
-            });
-            ctx.lineWidth = isConnected ? 2 / globalScale : 0.5 / globalScale;
-            ctx.stroke();
-        },
-        [selectedNodeId, theme],
+    const selectedNode = useMemo(() => getSelectedGraphNode(graphNodes, selectedNodeId), [graphNodes, selectedNodeId]);
+    const selectedConnectedNodes = useMemo(
+        () => getConnectedGraphNodes(graphNodes, adjacencyMap, selectedNodeId),
+        [adjacencyMap, graphNodes, selectedNodeId],
     );
 
     if (!graphData) {
@@ -328,310 +74,25 @@ function GraphContent() {
             description={`${graphData.nodes.length} linked notes, ${graphData.links.length} connections`}
         >
             <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_23rem]">
-                <div
-                    ref={containerRef}
-                    className="surface-base graph-canvas relative min-h-[420px] overflow-hidden md:min-h-[520px]"
-                    style={{ '--graph-bg': graphTheme.background } as React.CSSProperties}
-                >
-                    {selectedNode && (
-                        <div className="surface-floating absolute top-3 left-3 z-10 flex items-center gap-2 px-3 py-2">
-                            <Text as="span" variant="meta" weight="semibold" truncate className="max-w-48">
-                                {selectedNode.title}
-                            </Text>
-                            <Text as="span" variant="label" tone="tertiary">
-                                {selectedNode.connections} links
-                            </Text>
-                            <button
-                                type="button"
-                                onClick={() => setSelectedNodeId(null)}
-                                className="focus-ring-soft ml-1 flex h-6 w-6 cursor-pointer items-center justify-center rounded-[8px] text-fg-tertiary transition-colors hover:bg-hover-subtle hover:text-fg-default"
-                                aria-label="Deselect node"
-                            >
-                                <Icon.Close className="h-3.5 w-3.5" />
-                            </button>
-                        </div>
-                    )}
-                    <div className="surface-floating absolute top-3 right-3 z-10 flex flex-col gap-1.5 px-3 py-2.5">
-                        <div className="flex items-center gap-2">
-                            <span
-                                className="legend-dot h-2.5 w-2.5 shrink-0 rounded-full"
-                                style={{ '--legend-color': graphTheme.legendHub } as React.CSSProperties}
-                            />
-                            <Text as="span" variant="label" weight="medium" tone="secondary">
-                                Hub notes (4+ connections)
-                            </Text>
-                        </div>
-                        <div className="flex items-center gap-2">
-                            <span
-                                className="legend-dot h-2.5 w-2.5 shrink-0 rounded-full"
-                                style={{ '--legend-color': graphTheme.nodeConnected } as React.CSSProperties}
-                            />
-                            <Text as="span" variant="label" weight="medium" tone="secondary">
-                                Connected notes
-                            </Text>
-                        </div>
-                    </div>
-                    <div aria-hidden="true">
-                        <ForceGraph2D
-                            ref={graphRef as React.MutableRefObject<never>}
-                            graphData={graphData}
-                            width={dimensions.width}
-                            height={dimensions.height}
-                            nodeId="id"
-                            nodeLabel=""
-                            nodeCanvasObject={nodeCanvasObject}
-                            nodePointerAreaPaint={(node: GraphNode & { x?: number; y?: number }, color, ctx) => {
-                                ctx.beginPath();
-                                ctx.arc(
-                                    node.x || 0,
-                                    node.y || 0,
-                                    Math.max(getNodeSize(node.connections) + 4, 10),
-                                    0,
-                                    2 * Math.PI,
-                                );
-                                ctx.fillStyle = color;
-                                ctx.fill();
-                            }}
-                            linkCanvasObject={linkCanvasObject}
-                            linkCanvasObjectMode={() => 'replace'}
-                            linkDirectionalParticles={0}
-                            onNodeClick={handleNodeClick}
-                            onNodeHover={handleNodeHover}
-                            onBackgroundClick={handleBackgroundClick}
-                            onNodeDrag={handleNodeDrag}
-                            onNodeDragEnd={handleNodeDragEnd}
-                            warmupTicks={30}
-                            cooldownTicks={80}
-                            d3AlphaDecay={0.05}
-                            d3VelocityDecay={0.3}
-                            enableZoomInteraction={true}
-                            enablePanInteraction={true}
-                            minZoom={0.3}
-                            maxZoom={5}
-                        />
-                    </div>
-                </div>
-
-                <section
-                    className="surface-base flex max-h-none flex-col overflow-hidden xl:max-h-[min(44rem,calc(100vh-10rem))]"
-                    aria-labelledby="graph-explorer-heading"
-                >
-                    <div className="border-b border-border-subtle/80 px-4 py-3.5">
-                        <div className="flex items-start gap-3">
-                            <span className="mt-0.5 inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-[12px] border border-border-subtle bg-muted text-fg-secondary">
-                                <Icon.Graph className="h-4 w-4" aria-hidden="true" />
-                            </span>
-                            <div className="min-w-0">
-                                <Text id="graph-explorer-heading" as="h2" variant="body" weight="semibold">
-                                    Graph Explorer
-                                </Text>
-                                <Text as="p" variant="meta" tone="tertiary" className="mt-0.5">
-                                    Connection index
-                                </Text>
-                            </div>
-                        </div>
-
-                        <div className="mt-3 grid grid-cols-3 divide-x divide-border-subtle rounded-[12px] border border-border-subtle/80 bg-subtle/50">
-                            <div className="px-2.5 py-2">
-                                <Text as="p" variant="micro" tone="tertiary">
-                                    Notes
-                                </Text>
-                                <Text as="p" variant="label" weight="semibold">
-                                    {graphNodes.length}
-                                </Text>
-                            </div>
-                            <div className="px-2.5 py-2">
-                                <Text as="p" variant="micro" tone="tertiary">
-                                    Links
-                                </Text>
-                                <Text as="p" variant="label" weight="semibold">
-                                    {graphData.links.length}
-                                </Text>
-                            </div>
-                            <div className="px-2.5 py-2">
-                                <Text as="p" variant="micro" tone="tertiary">
-                                    Hubs
-                                </Text>
-                                <Text as="p" variant="label" weight="semibold">
-                                    {hubNodeCount}
-                                </Text>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div className="border-b border-border-subtle/80 px-4 py-3">
-                        <label htmlFor="graph-node-search">
-                            <Text as="span" variant="label" weight="medium" tone="secondary">
-                                Search graph
-                            </Text>
-                        </label>
-                        <div className="relative mt-1.5">
-                            <Icon.Search
-                                className="pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-fg-tertiary"
-                                aria-hidden="true"
-                            />
-                            <Input
-                                id="graph-node-search"
-                                size="sm"
-                                value={nodeSearchQuery}
-                                onChange={(event) => setNodeSearchQuery(event.target.value)}
-                                placeholder="Find a note"
-                                className="pl-9"
-                            />
-                        </div>
-                    </div>
-
-                    <Text id="graph-selection-status" as="p" role="status" aria-live="polite" className="sr-only">
-                        {selectedNode
-                            ? `${selectedNodeStatus}${
-                                  selectedConnectedNodes.length > 0
-                                      ? `. Linked to ${selectedConnectedNodes
-                                            .map((node) => node.title || 'Untitled')
-                                            .join(', ')}`
-                                      : ''
-                              }`
-                            : selectedNodeStatus}
-                    </Text>
-
-                    <div className="border-b border-border-subtle/80 px-4 py-3">
-                        {selectedNode ? (
-                            <div className="min-w-0">
-                                <Text as="p" variant="micro" tone="tertiary">
-                                    Selected note
-                                </Text>
-                                <div className="mt-1 flex items-start justify-between gap-3">
-                                    <div className="min-w-0">
-                                        <Text as="p" variant="body" weight="semibold" truncate>
-                                            {selectedNode.title || 'Untitled'}
-                                        </Text>
-                                        <Text as="p" variant="meta" tone="tertiary" className="mt-0.5">
-                                            {selectedNode.connections} links
-                                        </Text>
-                                    </div>
-                                    <Link
-                                        to={NOTE_ROUTE}
-                                        params={{ id: selectedNode.id }}
-                                        aria-label={`Open ${selectedNode.title || 'Untitled'}`}
-                                        className="focus-ring-soft inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-[10px] text-fg-secondary outline-none transition-colors hover:bg-hover-subtle hover:text-fg-default"
-                                    >
-                                        <Icon.ArrowRight className="h-4 w-4" aria-hidden="true" />
-                                    </Link>
-                                </div>
-                                {visibleSelectedConnections.length > 0 && (
-                                    <div className="mt-2 flex flex-wrap gap-1.5">
-                                        {visibleSelectedConnections.map((node) => (
-                                            <Link
-                                                key={node.id}
-                                                to={NOTE_ROUTE}
-                                                params={{ id: node.id }}
-                                                className="focus-ring-soft inline-flex max-w-full items-center gap-1 rounded-full border border-border-subtle bg-subtle px-2 py-0.5 text-xs font-medium text-fg-secondary outline-none transition-colors hover:border-border-secondary hover:bg-hover-subtle hover:text-fg-default"
-                                            >
-                                                <Icon.LinkIcon className="h-3 w-3 shrink-0" aria-hidden="true" />
-                                                <span className="truncate">{node.title || 'Untitled'}</span>
-                                            </Link>
-                                        ))}
-                                        {remainingSelectedConnectionCount > 0 && (
-                                            <span className="inline-flex items-center rounded-full border border-border-subtle px-2 py-0.5 text-xs font-medium text-fg-tertiary">
-                                                +{remainingSelectedConnectionCount}
-                                            </span>
-                                        )}
-                                    </div>
-                                )}
-                            </div>
-                        ) : (
-                            <div>
-                                <Text as="p" variant="micro" tone="tertiary">
-                                    Overview
-                                </Text>
-                                <Text as="p" variant="body" weight="semibold" className="mt-1">
-                                    No graph node selected
-                                </Text>
-                                <Text as="p" variant="meta" tone="tertiary" className="mt-0.5">
-                                    {graphNodes[0]?.title ? `Most linked: ${graphNodes[0].title}` : 'No linked notes'}
-                                </Text>
-                            </div>
-                        )}
-                    </div>
-
-                    <div className="flex min-h-0 flex-1 flex-col">
-                        <div className="flex items-center justify-between gap-3 px-4 py-2.5">
-                            <Text as="h3" variant="label" weight="semibold">
-                                Notes
-                            </Text>
-                            <Text as="span" variant="meta" tone="tertiary" className="shrink-0">
-                                {filteredGraphNodes.length} shown
-                            </Text>
-                        </div>
-                        {filteredGraphNodes.length > 0 ? (
-                            <ul className="min-h-0 flex-1 overflow-y-auto border-t border-border-subtle/60">
-                                {filteredGraphNodes.map((node) => {
-                                    const isSelected = selectedNodeId === node.id;
-                                    const nodeTitle = node.title || 'Untitled';
-
-                                    return (
-                                        <li key={node.id} className="border-b border-border-subtle/60 last:border-b-0">
-                                            <div
-                                                className={`grid grid-cols-[minmax(0,1fr)_auto] items-stretch transition-colors ${
-                                                    isSelected
-                                                        ? 'bg-elevated text-fg-default'
-                                                        : 'text-fg-secondary hover:bg-hover-subtle hover:text-fg-default'
-                                                }`}
-                                            >
-                                                <button
-                                                    type="button"
-                                                    aria-pressed={isSelected}
-                                                    aria-describedby={isSelected ? 'graph-selection-status' : undefined}
-                                                    onClick={() => setSelectedNodeId(node.id)}
-                                                    className="focus-ring-soft group grid min-w-0 grid-cols-[3px_minmax(0,1fr)_auto] items-center gap-3 px-4 py-3 text-left outline-none"
-                                                >
-                                                    <span
-                                                        className={`h-8 rounded-full transition-colors ${
-                                                            isSelected
-                                                                ? 'bg-fg-default'
-                                                                : 'bg-border-subtle group-hover:bg-border-secondary'
-                                                        }`}
-                                                        aria-hidden="true"
-                                                    />
-                                                    <span className="min-w-0">
-                                                        <Text as="span" variant="label" weight="medium" truncate>
-                                                            {nodeTitle}
-                                                        </Text>
-                                                    </span>
-                                                    <Text
-                                                        as="span"
-                                                        variant="meta"
-                                                        tone={isSelected ? 'secondary' : 'tertiary'}
-                                                        className="shrink-0"
-                                                    >
-                                                        <span aria-hidden="true">{node.connections}</span>
-                                                        <span className="sr-only">{node.connections} links</span>
-                                                    </Text>
-                                                </button>
-                                                <Link
-                                                    to={NOTE_ROUTE}
-                                                    params={{ id: node.id }}
-                                                    aria-label={`Open ${nodeTitle}`}
-                                                    className="focus-ring-soft m-2 inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-[10px] text-fg-secondary outline-none transition-colors hover:bg-hover-subtle hover:text-fg-default"
-                                                >
-                                                    <Icon.ArrowRight className="h-4 w-4" aria-hidden="true" />
-                                                </Link>
-                                            </div>
-                                        </li>
-                                    );
-                                })}
-                            </ul>
-                        ) : (
-                            <Text
-                                as="p"
-                                variant="meta"
-                                tone="tertiary"
-                                className="border-t border-border-subtle/60 px-4 py-5 text-center"
-                            >
-                                No matching graph nodes
-                            </Text>
-                        )}
-                    </div>
-                </section>
+                <GraphCanvas
+                    adjacencyMap={adjacencyMap}
+                    graphData={graphData}
+                    onClearSelection={clearSelection}
+                    onOpenNode={openNode}
+                    onSelectNode={selectNode}
+                    selectedNodeId={selectedNodeId}
+                />
+                <GraphExplorerPanel
+                    filteredGraphNodes={filteredGraphNodes}
+                    graphNodes={graphNodes}
+                    nodeSearchQuery={nodeSearchQuery}
+                    onClearSelection={clearSelection}
+                    onNodeSearchQueryChange={setNodeSearchQuery}
+                    onSelectNode={selectNode}
+                    selectedConnectedNodes={selectedConnectedNodes}
+                    selectedNode={selectedNode}
+                    selectedNodeId={selectedNodeId}
+                />
             </div>
         </PageLayout>
     );

--- a/packages/client/src/pages/Graph.tsx
+++ b/packages/client/src/pages/Graph.tsx
@@ -1,5 +1,5 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { useNavigate } from '@tanstack/react-router';
+import { Link, useNavigate } from '@tanstack/react-router';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import ForceGraph2D from 'react-force-graph-2d';
 
@@ -7,7 +7,7 @@ import { fetchNoteGraph, type GraphLink, type GraphNode } from '~/apis/note.api'
 import { QueryBoundary, QueryErrorView } from '~/components/app';
 import * as Icon from '~/components/icon';
 import { Empty, PageLayout, Skeleton } from '~/components/shared';
-import { Text } from '~/components/ui';
+import { Input, Text } from '~/components/ui';
 import { getHash } from '~/modules/hash';
 import { queryKeys } from '~/modules/query-key-factory';
 import { NOTE_ROUTE } from '~/modules/url';
@@ -48,6 +48,7 @@ function GraphContent() {
         height: 600,
     });
     const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+    const [nodeSearchQuery, setNodeSearchQuery] = useState('');
 
     const { theme } = useTheme((state) => state);
     const graphTheme = getGraphTheme(theme);
@@ -173,6 +174,48 @@ function GraphContent() {
     }, [graphData]);
     adjacencyMapRef.current = adjacencyMap;
 
+    const graphNodes = useMemo(() => {
+        if (!graphData) {
+            return [];
+        }
+
+        return [...graphData.nodes].sort((a, b) => b.connections - a.connections || a.title.localeCompare(b.title));
+    }, [graphData]);
+
+    const filteredGraphNodes = useMemo(() => {
+        const query = nodeSearchQuery.trim().toLowerCase();
+        if (!query) {
+            return graphNodes;
+        }
+
+        return graphNodes.filter((node) => node.title.toLowerCase().includes(query));
+    }, [graphNodes, nodeSearchQuery]);
+
+    const selectedNode = useMemo(() => {
+        if (!selectedNodeId) {
+            return null;
+        }
+
+        return graphNodes.find((node) => node.id === selectedNodeId) ?? null;
+    }, [graphNodes, selectedNodeId]);
+
+    const selectedConnectedNodes = useMemo(() => {
+        if (!selectedNodeId) {
+            return [];
+        }
+
+        const connectedIds = adjacencyMap.get(selectedNodeId);
+        if (!connectedIds) {
+            return [];
+        }
+
+        return graphNodes.filter((node) => connectedIds.has(node.id));
+    }, [adjacencyMap, graphNodes, selectedNodeId]);
+
+    const selectedNodeStatus = selectedNode
+        ? `${selectedNode.title || 'Untitled'} selected, ${selectedNode.connections} links`
+        : 'No graph node selected';
+
     const nodeCanvasObject = useCallback(
         (node: GraphNode & { x?: number; y?: number }, ctx: CanvasRenderingContext2D, globalScale: number) => {
             const palette = graphThemeRef.current;
@@ -277,94 +320,185 @@ function GraphContent() {
             title="Knowledge Graph"
             description={`${graphData.nodes.length} linked notes, ${graphData.links.length} connections`}
         >
-            <div
-                ref={containerRef}
-                className="surface-base graph-canvas relative overflow-hidden"
-                style={{ '--graph-bg': graphTheme.background } as React.CSSProperties}
-            >
-                {selectedNodeId &&
-                    (() => {
-                        const node = graphData.nodes.find((item) => item.id === selectedNodeId);
-                        if (!node) {
-                            return null;
-                        }
-
-                        return (
-                            <div className="surface-floating absolute top-3 left-3 z-10 flex items-center gap-2 px-3 py-2">
-                                <Text as="span" variant="meta" weight="semibold" truncate className="max-w-48">
-                                    {node.title}
-                                </Text>
-                                <Text as="span" variant="label" tone="tertiary">
-                                    {node.connections} links
-                                </Text>
-                                <button
-                                    type="button"
-                                    onClick={() => setSelectedNodeId(null)}
-                                    className="focus-ring-soft ml-1 flex h-6 w-6 cursor-pointer items-center justify-center rounded-[8px] text-fg-tertiary transition-colors hover:bg-hover-subtle hover:text-fg-default"
-                                    aria-label="Deselect node"
-                                >
-                                    <Icon.Close className="h-3.5 w-3.5" />
-                                </button>
-                            </div>
-                        );
-                    })()}
-                <div className="surface-floating absolute top-3 right-3 z-10 flex flex-col gap-1.5 px-3 py-2.5">
-                    <div className="flex items-center gap-2">
-                        <span
-                            className="legend-dot h-2.5 w-2.5 shrink-0 rounded-full"
-                            style={{ '--legend-color': graphTheme.legendHub } as React.CSSProperties}
-                        />
-                        <Text as="span" variant="label" weight="medium" tone="secondary">
-                            Hub notes (4+ connections)
-                        </Text>
+            <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_22rem]">
+                <div
+                    ref={containerRef}
+                    className="surface-base graph-canvas relative overflow-hidden"
+                    style={{ '--graph-bg': graphTheme.background } as React.CSSProperties}
+                >
+                    {selectedNode && (
+                        <div className="surface-floating absolute top-3 left-3 z-10 flex items-center gap-2 px-3 py-2">
+                            <Text as="span" variant="meta" weight="semibold" truncate className="max-w-48">
+                                {selectedNode.title}
+                            </Text>
+                            <Text as="span" variant="label" tone="tertiary">
+                                {selectedNode.connections} links
+                            </Text>
+                            <button
+                                type="button"
+                                onClick={() => setSelectedNodeId(null)}
+                                className="focus-ring-soft ml-1 flex h-6 w-6 cursor-pointer items-center justify-center rounded-[8px] text-fg-tertiary transition-colors hover:bg-hover-subtle hover:text-fg-default"
+                                aria-label="Deselect node"
+                            >
+                                <Icon.Close className="h-3.5 w-3.5" />
+                            </button>
+                        </div>
+                    )}
+                    <div className="surface-floating absolute top-3 right-3 z-10 flex flex-col gap-1.5 px-3 py-2.5">
+                        <div className="flex items-center gap-2">
+                            <span
+                                className="legend-dot h-2.5 w-2.5 shrink-0 rounded-full"
+                                style={{ '--legend-color': graphTheme.legendHub } as React.CSSProperties}
+                            />
+                            <Text as="span" variant="label" weight="medium" tone="secondary">
+                                Hub notes (4+ connections)
+                            </Text>
+                        </div>
+                        <div className="flex items-center gap-2">
+                            <span
+                                className="legend-dot h-2.5 w-2.5 shrink-0 rounded-full"
+                                style={{ '--legend-color': graphTheme.nodeConnected } as React.CSSProperties}
+                            />
+                            <Text as="span" variant="label" weight="medium" tone="secondary">
+                                Connected notes
+                            </Text>
+                        </div>
                     </div>
-                    <div className="flex items-center gap-2">
-                        <span
-                            className="legend-dot h-2.5 w-2.5 shrink-0 rounded-full"
-                            style={{ '--legend-color': graphTheme.nodeConnected } as React.CSSProperties}
+                    <div aria-hidden="true">
+                        <ForceGraph2D
+                            ref={graphRef as React.MutableRefObject<never>}
+                            graphData={graphData}
+                            width={dimensions.width}
+                            height={dimensions.height}
+                            nodeId="id"
+                            nodeLabel=""
+                            nodeCanvasObject={nodeCanvasObject}
+                            nodePointerAreaPaint={(node: GraphNode & { x?: number; y?: number }, color, ctx) => {
+                                ctx.beginPath();
+                                ctx.arc(
+                                    node.x || 0,
+                                    node.y || 0,
+                                    Math.max(getNodeSize(node.connections) + 4, 10),
+                                    0,
+                                    2 * Math.PI,
+                                );
+                                ctx.fillStyle = color;
+                                ctx.fill();
+                            }}
+                            linkCanvasObject={linkCanvasObject}
+                            linkCanvasObjectMode={() => 'replace'}
+                            linkDirectionalParticles={0}
+                            onNodeClick={handleNodeClick}
+                            onNodeHover={handleNodeHover}
+                            onBackgroundClick={handleBackgroundClick}
+                            onNodeDrag={handleNodeDrag}
+                            onNodeDragEnd={handleNodeDragEnd}
+                            warmupTicks={30}
+                            cooldownTicks={80}
+                            d3AlphaDecay={0.05}
+                            d3VelocityDecay={0.3}
+                            enableZoomInteraction={true}
+                            enablePanInteraction={true}
+                            minZoom={0.3}
+                            maxZoom={5}
                         />
-                        <Text as="span" variant="label" weight="medium" tone="secondary">
-                            Connected notes
-                        </Text>
                     </div>
                 </div>
-                <ForceGraph2D
-                    ref={graphRef as React.MutableRefObject<never>}
-                    graphData={graphData}
-                    width={dimensions.width}
-                    height={dimensions.height}
-                    nodeId="id"
-                    nodeLabel=""
-                    nodeCanvasObject={nodeCanvasObject}
-                    nodePointerAreaPaint={(node: GraphNode & { x?: number; y?: number }, color, ctx) => {
-                        ctx.beginPath();
-                        ctx.arc(
-                            node.x || 0,
-                            node.y || 0,
-                            Math.max(getNodeSize(node.connections) + 4, 10),
-                            0,
-                            2 * Math.PI,
-                        );
-                        ctx.fillStyle = color;
-                        ctx.fill();
-                    }}
-                    linkCanvasObject={linkCanvasObject}
-                    linkCanvasObjectMode={() => 'replace'}
-                    linkDirectionalParticles={0}
-                    onNodeClick={handleNodeClick}
-                    onNodeHover={handleNodeHover}
-                    onBackgroundClick={handleBackgroundClick}
-                    onNodeDrag={handleNodeDrag}
-                    onNodeDragEnd={handleNodeDragEnd}
-                    warmupTicks={30}
-                    cooldownTicks={80}
-                    d3AlphaDecay={0.05}
-                    d3VelocityDecay={0.3}
-                    enableZoomInteraction={true}
-                    enablePanInteraction={true}
-                    minZoom={0.3}
-                    maxZoom={5}
-                />
+
+                <section
+                    className="surface-base flex max-h-[min(42rem,calc(100vh-10rem))] flex-col overflow-hidden px-4 py-3"
+                    aria-labelledby="graph-node-list-heading"
+                >
+                    <div className="flex items-start justify-between gap-3">
+                        <div className="min-w-0">
+                            <Text id="graph-node-list-heading" as="h2" variant="body" weight="semibold">
+                                Graph nodes
+                            </Text>
+                            <Text as="p" variant="meta" tone="tertiary" className="mt-0.5">
+                                {filteredGraphNodes.length} of {graphNodes.length} notes
+                            </Text>
+                        </div>
+                        <Text as="span" variant="label" tone="secondary" className="shrink-0">
+                            {graphData.links.length} links
+                        </Text>
+                    </div>
+
+                    <label htmlFor="graph-node-search" className="sr-only">
+                        Search graph nodes
+                    </label>
+                    <Input
+                        id="graph-node-search"
+                        size="sm"
+                        value={nodeSearchQuery}
+                        onChange={(event) => setNodeSearchQuery(event.target.value)}
+                        placeholder="Search graph nodes"
+                        className="mt-3"
+                    />
+
+                    <div
+                        id="graph-selection-status"
+                        role="status"
+                        aria-live="polite"
+                        className="mt-3 rounded-[14px] border border-border-subtle bg-subtle px-3 py-2"
+                    >
+                        <Text as="p" variant="label" weight="medium">
+                            {selectedNodeStatus}
+                        </Text>
+                        {selectedConnectedNodes.length > 0 && (
+                            <Text as="p" variant="meta" tone="tertiary" truncate className="mt-0.5">
+                                Linked to {selectedConnectedNodes.map((node) => node.title || 'Untitled').join(', ')}
+                            </Text>
+                        )}
+                    </div>
+
+                    {filteredGraphNodes.length > 0 ? (
+                        <ul
+                            className="mt-3 flex min-h-0 flex-1 flex-col gap-1.5 overflow-y-auto"
+                            aria-label="Graph node list"
+                        >
+                            {filteredGraphNodes.map((node) => {
+                                const isSelected = selectedNodeId === node.id;
+
+                                return (
+                                    <li key={node.id}>
+                                        <Link
+                                            to={NOTE_ROUTE}
+                                            params={{ id: node.id }}
+                                            aria-describedby={isSelected ? 'graph-selection-status' : undefined}
+                                            onFocus={() => setSelectedNodeId(node.id)}
+                                            className={`focus-ring-soft flex items-center justify-between gap-3 rounded-[12px] border px-3 py-2 text-left outline-none transition-colors ${
+                                                isSelected
+                                                    ? 'border-border-secondary bg-elevated text-fg-default'
+                                                    : 'border-border-subtle bg-transparent text-fg-secondary hover:border-border-secondary hover:bg-elevated hover:text-fg-default'
+                                            }`}
+                                        >
+                                            <Text as="span" variant="label" weight="medium" truncate>
+                                                {node.title || 'Untitled'}
+                                            </Text>
+                                            <Text
+                                                as="span"
+                                                variant="meta"
+                                                tone={isSelected ? 'secondary' : 'tertiary'}
+                                                className="shrink-0"
+                                            >
+                                                {node.connections} links
+                                            </Text>
+                                        </Link>
+                                    </li>
+                                );
+                            })}
+                        </ul>
+                    ) : (
+                        <Text
+                            as="p"
+                            variant="meta"
+                            tone="tertiary"
+                            className="mt-3 rounded-[14px] border border-dashed border-border-subtle px-3 py-4 text-center"
+                        >
+                            No matching graph nodes
+                        </Text>
+                    )}
+                </section>
             </div>
         </PageLayout>
     );

--- a/packages/client/src/pages/Graph.tsx
+++ b/packages/client/src/pages/Graph.tsx
@@ -94,9 +94,12 @@ function GraphContent() {
             }
 
             const rect = containerRef.current.getBoundingClientRect();
+            const isCompactLayout = rect.width < 768;
             setDimensions({
                 width: rect.width,
-                height: Math.max(600, window.innerHeight - 150),
+                height: isCompactLayout
+                    ? Math.max(420, Math.min(520, rect.width * 1.25))
+                    : Math.max(600, window.innerHeight - 150),
             });
         };
 
@@ -111,11 +114,11 @@ function GraphContent() {
         }
 
         const timeoutId = window.setTimeout(() => {
-            graphRef.current?.zoomToFit(400, 50);
+            graphRef.current?.zoomToFit(400, dimensions.width < 768 ? 80 : 50);
         }, 500);
 
         return () => window.clearTimeout(timeoutId);
-    }, [graphData]);
+    }, [dimensions.width, graphData]);
 
     const selectedNodeIdRef = useRef(selectedNodeId);
     selectedNodeIdRef.current = selectedNodeId;
@@ -211,6 +214,10 @@ function GraphContent() {
 
         return graphNodes.filter((node) => connectedIds.has(node.id));
     }, [adjacencyMap, graphNodes, selectedNodeId]);
+
+    const hubNodeCount = useMemo(() => graphNodes.filter((node) => node.connections >= 4).length, [graphNodes]);
+    const visibleSelectedConnections = selectedConnectedNodes.slice(0, 4);
+    const remainingSelectedConnectionCount = selectedConnectedNodes.length - visibleSelectedConnections.length;
 
     const selectedNodeStatus = selectedNode
         ? `${selectedNode.title || 'Untitled'} selected, ${selectedNode.connections} links`
@@ -320,10 +327,10 @@ function GraphContent() {
             title="Knowledge Graph"
             description={`${graphData.nodes.length} linked notes, ${graphData.links.length} connections`}
         >
-            <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_22rem]">
+            <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_23rem]">
                 <div
                     ref={containerRef}
-                    className="surface-base graph-canvas relative overflow-hidden"
+                    className="surface-base graph-canvas relative min-h-[420px] overflow-hidden md:min-h-[520px]"
                     style={{ '--graph-bg': graphTheme.background } as React.CSSProperties}
                 >
                     {selectedNode && (
@@ -406,98 +413,224 @@ function GraphContent() {
                 </div>
 
                 <section
-                    className="surface-base flex max-h-[min(42rem,calc(100vh-10rem))] flex-col overflow-hidden px-4 py-3"
-                    aria-labelledby="graph-node-list-heading"
+                    className="surface-base flex max-h-none flex-col overflow-hidden xl:max-h-[min(44rem,calc(100vh-10rem))]"
+                    aria-labelledby="graph-explorer-heading"
                 >
-                    <div className="flex items-start justify-between gap-3">
-                        <div className="min-w-0">
-                            <Text id="graph-node-list-heading" as="h2" variant="body" weight="semibold">
-                                Graph nodes
-                            </Text>
-                            <Text as="p" variant="meta" tone="tertiary" className="mt-0.5">
-                                {filteredGraphNodes.length} of {graphNodes.length} notes
-                            </Text>
+                    <div className="border-b border-border-subtle/80 px-4 py-3.5">
+                        <div className="flex items-start gap-3">
+                            <span className="mt-0.5 inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-[12px] border border-border-subtle bg-muted text-fg-secondary">
+                                <Icon.Graph className="h-4 w-4" aria-hidden="true" />
+                            </span>
+                            <div className="min-w-0">
+                                <Text id="graph-explorer-heading" as="h2" variant="body" weight="semibold">
+                                    Graph Explorer
+                                </Text>
+                                <Text as="p" variant="meta" tone="tertiary" className="mt-0.5">
+                                    Connection index
+                                </Text>
+                            </div>
                         </div>
-                        <Text as="span" variant="label" tone="secondary" className="shrink-0">
-                            {graphData.links.length} links
-                        </Text>
+
+                        <div className="mt-3 grid grid-cols-3 divide-x divide-border-subtle rounded-[12px] border border-border-subtle/80 bg-subtle/50">
+                            <div className="px-2.5 py-2">
+                                <Text as="p" variant="micro" tone="tertiary">
+                                    Notes
+                                </Text>
+                                <Text as="p" variant="label" weight="semibold">
+                                    {graphNodes.length}
+                                </Text>
+                            </div>
+                            <div className="px-2.5 py-2">
+                                <Text as="p" variant="micro" tone="tertiary">
+                                    Links
+                                </Text>
+                                <Text as="p" variant="label" weight="semibold">
+                                    {graphData.links.length}
+                                </Text>
+                            </div>
+                            <div className="px-2.5 py-2">
+                                <Text as="p" variant="micro" tone="tertiary">
+                                    Hubs
+                                </Text>
+                                <Text as="p" variant="label" weight="semibold">
+                                    {hubNodeCount}
+                                </Text>
+                            </div>
+                        </div>
                     </div>
 
-                    <label htmlFor="graph-node-search" className="sr-only">
-                        Search graph nodes
-                    </label>
-                    <Input
-                        id="graph-node-search"
-                        size="sm"
-                        value={nodeSearchQuery}
-                        onChange={(event) => setNodeSearchQuery(event.target.value)}
-                        placeholder="Search graph nodes"
-                        className="mt-3"
-                    />
-
-                    <div
-                        id="graph-selection-status"
-                        role="status"
-                        aria-live="polite"
-                        className="mt-3 rounded-[14px] border border-border-subtle bg-subtle px-3 py-2"
-                    >
-                        <Text as="p" variant="label" weight="medium">
-                            {selectedNodeStatus}
-                        </Text>
-                        {selectedConnectedNodes.length > 0 && (
-                            <Text as="p" variant="meta" tone="tertiary" truncate className="mt-0.5">
-                                Linked to {selectedConnectedNodes.map((node) => node.title || 'Untitled').join(', ')}
+                    <div className="border-b border-border-subtle/80 px-4 py-3">
+                        <label htmlFor="graph-node-search">
+                            <Text as="span" variant="label" weight="medium" tone="secondary">
+                                Search graph
                             </Text>
+                        </label>
+                        <div className="relative mt-1.5">
+                            <Icon.Search
+                                className="pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-fg-tertiary"
+                                aria-hidden="true"
+                            />
+                            <Input
+                                id="graph-node-search"
+                                size="sm"
+                                value={nodeSearchQuery}
+                                onChange={(event) => setNodeSearchQuery(event.target.value)}
+                                placeholder="Find a note"
+                                className="pl-9"
+                            />
+                        </div>
+                    </div>
+
+                    <Text id="graph-selection-status" as="p" role="status" aria-live="polite" className="sr-only">
+                        {selectedNode
+                            ? `${selectedNodeStatus}${
+                                  selectedConnectedNodes.length > 0
+                                      ? `. Linked to ${selectedConnectedNodes
+                                            .map((node) => node.title || 'Untitled')
+                                            .join(', ')}`
+                                      : ''
+                              }`
+                            : selectedNodeStatus}
+                    </Text>
+
+                    <div className="border-b border-border-subtle/80 px-4 py-3">
+                        {selectedNode ? (
+                            <div className="min-w-0">
+                                <Text as="p" variant="micro" tone="tertiary">
+                                    Selected note
+                                </Text>
+                                <div className="mt-1 flex items-start justify-between gap-3">
+                                    <div className="min-w-0">
+                                        <Text as="p" variant="body" weight="semibold" truncate>
+                                            {selectedNode.title || 'Untitled'}
+                                        </Text>
+                                        <Text as="p" variant="meta" tone="tertiary" className="mt-0.5">
+                                            {selectedNode.connections} links
+                                        </Text>
+                                    </div>
+                                    <Link
+                                        to={NOTE_ROUTE}
+                                        params={{ id: selectedNode.id }}
+                                        aria-label={`Open ${selectedNode.title || 'Untitled'}`}
+                                        className="focus-ring-soft inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-[10px] text-fg-secondary outline-none transition-colors hover:bg-hover-subtle hover:text-fg-default"
+                                    >
+                                        <Icon.ArrowRight className="h-4 w-4" aria-hidden="true" />
+                                    </Link>
+                                </div>
+                                {visibleSelectedConnections.length > 0 && (
+                                    <div className="mt-2 flex flex-wrap gap-1.5">
+                                        {visibleSelectedConnections.map((node) => (
+                                            <Link
+                                                key={node.id}
+                                                to={NOTE_ROUTE}
+                                                params={{ id: node.id }}
+                                                className="focus-ring-soft inline-flex max-w-full items-center gap-1 rounded-full border border-border-subtle bg-subtle px-2 py-0.5 text-xs font-medium text-fg-secondary outline-none transition-colors hover:border-border-secondary hover:bg-hover-subtle hover:text-fg-default"
+                                            >
+                                                <Icon.LinkIcon className="h-3 w-3 shrink-0" aria-hidden="true" />
+                                                <span className="truncate">{node.title || 'Untitled'}</span>
+                                            </Link>
+                                        ))}
+                                        {remainingSelectedConnectionCount > 0 && (
+                                            <span className="inline-flex items-center rounded-full border border-border-subtle px-2 py-0.5 text-xs font-medium text-fg-tertiary">
+                                                +{remainingSelectedConnectionCount}
+                                            </span>
+                                        )}
+                                    </div>
+                                )}
+                            </div>
+                        ) : (
+                            <div>
+                                <Text as="p" variant="micro" tone="tertiary">
+                                    Overview
+                                </Text>
+                                <Text as="p" variant="body" weight="semibold" className="mt-1">
+                                    No graph node selected
+                                </Text>
+                                <Text as="p" variant="meta" tone="tertiary" className="mt-0.5">
+                                    {graphNodes[0]?.title ? `Most linked: ${graphNodes[0].title}` : 'No linked notes'}
+                                </Text>
+                            </div>
                         )}
                     </div>
 
-                    {filteredGraphNodes.length > 0 ? (
-                        <ul
-                            className="mt-3 flex min-h-0 flex-1 flex-col gap-1.5 overflow-y-auto"
-                            aria-label="Graph node list"
-                        >
-                            {filteredGraphNodes.map((node) => {
-                                const isSelected = selectedNodeId === node.id;
+                    <div className="flex min-h-0 flex-1 flex-col">
+                        <div className="flex items-center justify-between gap-3 px-4 py-2.5">
+                            <Text as="h3" variant="label" weight="semibold">
+                                Notes
+                            </Text>
+                            <Text as="span" variant="meta" tone="tertiary" className="shrink-0">
+                                {filteredGraphNodes.length} shown
+                            </Text>
+                        </div>
+                        {filteredGraphNodes.length > 0 ? (
+                            <ul className="min-h-0 flex-1 overflow-y-auto border-t border-border-subtle/60">
+                                {filteredGraphNodes.map((node) => {
+                                    const isSelected = selectedNodeId === node.id;
+                                    const nodeTitle = node.title || 'Untitled';
 
-                                return (
-                                    <li key={node.id}>
-                                        <Link
-                                            to={NOTE_ROUTE}
-                                            params={{ id: node.id }}
-                                            aria-describedby={isSelected ? 'graph-selection-status' : undefined}
-                                            onFocus={() => setSelectedNodeId(node.id)}
-                                            className={`focus-ring-soft flex items-center justify-between gap-3 rounded-[12px] border px-3 py-2 text-left outline-none transition-colors ${
-                                                isSelected
-                                                    ? 'border-border-secondary bg-elevated text-fg-default'
-                                                    : 'border-border-subtle bg-transparent text-fg-secondary hover:border-border-secondary hover:bg-elevated hover:text-fg-default'
-                                            }`}
-                                        >
-                                            <Text as="span" variant="label" weight="medium" truncate>
-                                                {node.title || 'Untitled'}
-                                            </Text>
-                                            <Text
-                                                as="span"
-                                                variant="meta"
-                                                tone={isSelected ? 'secondary' : 'tertiary'}
-                                                className="shrink-0"
+                                    return (
+                                        <li key={node.id} className="border-b border-border-subtle/60 last:border-b-0">
+                                            <div
+                                                className={`grid grid-cols-[minmax(0,1fr)_auto] items-stretch transition-colors ${
+                                                    isSelected
+                                                        ? 'bg-elevated text-fg-default'
+                                                        : 'text-fg-secondary hover:bg-hover-subtle hover:text-fg-default'
+                                                }`}
                                             >
-                                                {node.connections} links
-                                            </Text>
-                                        </Link>
-                                    </li>
-                                );
-                            })}
-                        </ul>
-                    ) : (
-                        <Text
-                            as="p"
-                            variant="meta"
-                            tone="tertiary"
-                            className="mt-3 rounded-[14px] border border-dashed border-border-subtle px-3 py-4 text-center"
-                        >
-                            No matching graph nodes
-                        </Text>
-                    )}
+                                                <button
+                                                    type="button"
+                                                    aria-pressed={isSelected}
+                                                    aria-describedby={isSelected ? 'graph-selection-status' : undefined}
+                                                    onClick={() => setSelectedNodeId(node.id)}
+                                                    className="focus-ring-soft group grid min-w-0 grid-cols-[3px_minmax(0,1fr)_auto] items-center gap-3 px-4 py-3 text-left outline-none"
+                                                >
+                                                    <span
+                                                        className={`h-8 rounded-full transition-colors ${
+                                                            isSelected
+                                                                ? 'bg-fg-default'
+                                                                : 'bg-border-subtle group-hover:bg-border-secondary'
+                                                        }`}
+                                                        aria-hidden="true"
+                                                    />
+                                                    <span className="min-w-0">
+                                                        <Text as="span" variant="label" weight="medium" truncate>
+                                                            {nodeTitle}
+                                                        </Text>
+                                                    </span>
+                                                    <Text
+                                                        as="span"
+                                                        variant="meta"
+                                                        tone={isSelected ? 'secondary' : 'tertiary'}
+                                                        className="shrink-0"
+                                                    >
+                                                        <span aria-hidden="true">{node.connections}</span>
+                                                        <span className="sr-only">{node.connections} links</span>
+                                                    </Text>
+                                                </button>
+                                                <Link
+                                                    to={NOTE_ROUTE}
+                                                    params={{ id: node.id }}
+                                                    aria-label={`Open ${nodeTitle}`}
+                                                    className="focus-ring-soft m-2 inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-[10px] text-fg-secondary outline-none transition-colors hover:bg-hover-subtle hover:text-fg-default"
+                                                >
+                                                    <Icon.ArrowRight className="h-4 w-4" aria-hidden="true" />
+                                                </Link>
+                                            </div>
+                                        </li>
+                                    );
+                                })}
+                            </ul>
+                        ) : (
+                            <Text
+                                as="p"
+                                variant="meta"
+                                tone="tertiary"
+                                className="border-t border-border-subtle/60 px-4 py-5 text-center"
+                            >
+                                No matching graph nodes
+                            </Text>
+                        )}
+                    </div>
                 </section>
             </div>
         </PageLayout>

--- a/packages/client/src/pages/GraphCanvas.tsx
+++ b/packages/client/src/pages/GraphCanvas.tsx
@@ -1,0 +1,265 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import ForceGraph2D from 'react-force-graph-2d';
+
+import type { GraphLink, GraphNode } from '~/apis/note.api';
+import { Text } from '~/components/ui';
+import { getHash } from '~/modules/hash';
+import { useTheme } from '~/store/theme';
+import { type GraphData, getNodeSize } from './graph-data';
+import { getGraphLabelFont, getGraphLinkColor, getGraphNodeFill, getGraphTheme } from './graph-theme';
+
+interface ForceGraphInstance {
+    zoomToFit: (duration?: number, padding?: number) => void;
+    enableZoomInteraction: (enable: boolean) => void;
+}
+
+interface GraphCanvasProps {
+    adjacencyMap: Map<string, Set<string>>;
+    graphData: GraphData;
+    onClearSelection: () => void;
+    onOpenNode: (nodeId: string) => void;
+    onSelectNode: (nodeId: string) => void;
+    selectedNodeId: string | null;
+}
+
+export function GraphCanvas({
+    adjacencyMap,
+    graphData,
+    onClearSelection,
+    onOpenNode,
+    onSelectNode,
+    selectedNodeId,
+}: GraphCanvasProps) {
+    const containerRef = useRef<HTMLDivElement>(null);
+    const graphRef = useRef<ForceGraphInstance | null>(null);
+    const [dimensions, setDimensions] = useState({
+        width: 800,
+        height: 600,
+    });
+
+    const { theme } = useTheme((state) => state);
+    const graphTheme = getGraphTheme(theme);
+    const graphThemeRef = useRef(graphTheme);
+    graphThemeRef.current = graphTheme;
+
+    const selectedNodeIdRef = useRef(selectedNodeId);
+    selectedNodeIdRef.current = selectedNodeId;
+
+    const adjacencyMapRef = useRef(adjacencyMap);
+    adjacencyMapRef.current = adjacencyMap;
+
+    useEffect(() => {
+        const updateDimensions = () => {
+            if (!containerRef.current) {
+                return;
+            }
+
+            const rect = containerRef.current.getBoundingClientRect();
+            const isCompactLayout = rect.width < 768;
+            setDimensions({
+                width: rect.width,
+                height: isCompactLayout ? Math.max(420, Math.min(520, rect.width * 1.25)) : Math.max(600, rect.height),
+            });
+        };
+
+        updateDimensions();
+        window.addEventListener('resize', updateDimensions);
+        return () => window.removeEventListener('resize', updateDimensions);
+    }, []);
+
+    useEffect(() => {
+        const timeoutId = window.setTimeout(() => {
+            graphRef.current?.zoomToFit(400, dimensions.width < 768 ? 80 : 50);
+        }, 500);
+
+        return () => window.clearTimeout(timeoutId);
+    }, [dimensions.width, graphData]);
+
+    const handleNodeClick = useCallback(
+        (node: GraphNode) => {
+            if (selectedNodeIdRef.current === node.id) {
+                onOpenNode(node.id);
+                return;
+            }
+
+            onSelectNode(node.id);
+        },
+        [onOpenNode, onSelectNode],
+    );
+
+    const handleNodeHover = useCallback((node: GraphNode | null) => {
+        if (containerRef.current) {
+            containerRef.current.style.cursor = node ? 'pointer' : 'default';
+        }
+    }, []);
+
+    const isDraggingRef = useRef(false);
+
+    const handleNodeDrag = useCallback(() => {
+        if (!isDraggingRef.current) {
+            isDraggingRef.current = true;
+            graphRef.current?.enableZoomInteraction(false);
+        }
+    }, []);
+
+    const handleNodeDragEnd = useCallback(() => {
+        isDraggingRef.current = false;
+        graphRef.current?.enableZoomInteraction(true);
+    }, []);
+
+    const nodeCanvasObject = useCallback(
+        (node: GraphNode & { x?: number; y?: number }, ctx: CanvasRenderingContext2D, globalScale: number) => {
+            const palette = graphThemeRef.current;
+            const selectedId = selectedNodeId;
+            const adjacency = adjacencyMapRef.current;
+            const nodeSize = getNodeSize(node.connections);
+            const nx = node.x || 0;
+            const ny = node.y || 0;
+
+            const isSelected = selectedId === node.id;
+            const isConnected = selectedId ? (adjacency.get(selectedId)?.has(node.id) ?? false) : false;
+            const isDimmed = selectedId !== null && !isSelected && !isConnected;
+            const colorIndex = getHash(node.id);
+
+            ctx.beginPath();
+            ctx.arc(nx, ny, nodeSize, 0, Math.PI * 2);
+
+            ctx.fillStyle = getGraphNodeFill(theme, {
+                connections: node.connections,
+                colorIndex,
+                selectedNodeId: selectedId,
+                nodeId: node.id,
+                isConnected,
+            });
+            ctx.fill();
+
+            if (isDimmed) {
+                return;
+            }
+
+            ctx.strokeStyle = palette.nodeStroke;
+            ctx.lineWidth = (isSelected ? 2 : 1) / globalScale;
+            ctx.stroke();
+
+            if (isSelected) {
+                ctx.beginPath();
+                ctx.arc(nx, ny, nodeSize + 2 / globalScale, 0, Math.PI * 2);
+                ctx.strokeStyle = palette.nodeSelectedStroke;
+                ctx.lineWidth = 1.5 / globalScale;
+                ctx.stroke();
+            }
+
+            const isHubConnected = isConnected && node.connections >= 4;
+            if (isSelected || isHubConnected || globalScale > 2.5) {
+                const label = node.title || 'Untitled';
+                const fontSize = Math.max(10 / globalScale, 2.5);
+                ctx.font = getGraphLabelFont(theme, {
+                    fontSize,
+                    emphasize: isSelected,
+                });
+                ctx.textAlign = 'center';
+                ctx.textBaseline = 'top';
+
+                const textWidth = ctx.measureText(label).width;
+                const padding = 2 / globalScale;
+                const labelY = ny + nodeSize + 3 / globalScale;
+
+                ctx.fillStyle = palette.labelBackground;
+                ctx.fillRect(nx - textWidth / 2 - padding, labelY, textWidth + padding * 2, fontSize + padding * 2);
+
+                ctx.fillStyle = palette.labelText;
+                ctx.fillText(label, nx, labelY + padding);
+            }
+        },
+        [selectedNodeId, theme],
+    );
+
+    const linkCanvasObject = useCallback(
+        (link: GraphLink, ctx: CanvasRenderingContext2D, globalScale: number) => {
+            const selectedId = selectedNodeId;
+            const source = link.source as unknown as { x?: number; y?: number; id: string };
+            const target = link.target as unknown as { x?: number; y?: number; id: string };
+            const isConnected = selectedId ? source.id === selectedId || target.id === selectedId : false;
+
+            ctx.beginPath();
+            ctx.moveTo(source.x || 0, source.y || 0);
+            ctx.lineTo(target.x || 0, target.y || 0);
+
+            ctx.strokeStyle = getGraphLinkColor(theme, {
+                selectedNodeId: selectedId,
+                isConnected,
+            });
+            ctx.lineWidth = isConnected ? 2 / globalScale : 0.5 / globalScale;
+            ctx.stroke();
+        },
+        [selectedNodeId, theme],
+    );
+
+    return (
+        <div
+            ref={containerRef}
+            className="surface-base graph-canvas relative min-h-[420px] overflow-hidden md:min-h-[520px] xl:h-[min(44rem,calc(100vh-10rem))]"
+            style={{ '--graph-bg': graphTheme.background } as React.CSSProperties}
+        >
+            <div className="surface-floating absolute top-3 right-3 z-10 flex flex-col gap-1.5 px-3 py-2.5">
+                <div className="flex items-center gap-2">
+                    <span
+                        className="legend-dot h-2.5 w-2.5 shrink-0 rounded-full"
+                        style={{ '--legend-color': graphTheme.legendHub } as React.CSSProperties}
+                    />
+                    <Text as="span" variant="label" weight="medium" tone="secondary">
+                        Hub notes (4+ connections)
+                    </Text>
+                </div>
+                <div className="flex items-center gap-2">
+                    <span
+                        className="legend-dot h-2.5 w-2.5 shrink-0 rounded-full"
+                        style={{ '--legend-color': graphTheme.nodeConnected } as React.CSSProperties}
+                    />
+                    <Text as="span" variant="label" weight="medium" tone="secondary">
+                        Connected notes
+                    </Text>
+                </div>
+            </div>
+            <div aria-hidden="true">
+                <ForceGraph2D
+                    ref={graphRef as React.MutableRefObject<never>}
+                    graphData={graphData}
+                    width={dimensions.width}
+                    height={dimensions.height}
+                    nodeId="id"
+                    nodeLabel=""
+                    nodeCanvasObject={nodeCanvasObject}
+                    nodePointerAreaPaint={(node: GraphNode & { x?: number; y?: number }, color, ctx) => {
+                        ctx.beginPath();
+                        ctx.arc(
+                            node.x || 0,
+                            node.y || 0,
+                            Math.max(getNodeSize(node.connections) + 4, 10),
+                            0,
+                            2 * Math.PI,
+                        );
+                        ctx.fillStyle = color;
+                        ctx.fill();
+                    }}
+                    linkCanvasObject={linkCanvasObject}
+                    linkCanvasObjectMode={() => 'replace'}
+                    linkDirectionalParticles={0}
+                    onNodeClick={handleNodeClick}
+                    onNodeHover={handleNodeHover}
+                    onBackgroundClick={onClearSelection}
+                    onNodeDrag={handleNodeDrag}
+                    onNodeDragEnd={handleNodeDragEnd}
+                    warmupTicks={30}
+                    cooldownTicks={80}
+                    d3AlphaDecay={0.05}
+                    d3VelocityDecay={0.3}
+                    enableZoomInteraction={true}
+                    enablePanInteraction={true}
+                    minZoom={0.3}
+                    maxZoom={5}
+                />
+            </div>
+        </div>
+    );
+}

--- a/packages/client/src/pages/GraphExplorerPanel.tsx
+++ b/packages/client/src/pages/GraphExplorerPanel.tsx
@@ -1,7 +1,7 @@
 import { Link } from '@tanstack/react-router';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import classNames from 'classnames';
-import { useEffect, useRef } from 'react';
+import { type KeyboardEvent, useCallback, useEffect, useRef } from 'react';
 
 import type { GraphNode } from '~/apis/note.api';
 import * as Icon from '~/components/icon';
@@ -34,6 +34,7 @@ export function GraphExplorerPanel({
     selectedNodeId,
 }: GraphExplorerPanelProps) {
     const nodeListRef = useRef<HTMLDivElement>(null);
+    const previousNodeSearchQueryRef = useRef(nodeSearchQuery);
     const rowVirtualizer = useVirtualizer<HTMLDivElement, HTMLDivElement>({
         count: filteredGraphNodes.length,
         estimateSize: () => GRAPH_NODE_ROW_ESTIMATED_SIZE,
@@ -48,9 +49,59 @@ export function GraphExplorerPanel({
     const selectedNodeStatus = selectedNode
         ? `${selectedNode.title || 'Untitled'} selected, ${selectedNode.connections} links`
         : 'No graph node selected';
+    const graphResultsSummary = `${filteredGraphNodes.length} shown`;
     const virtualRows = rowVirtualizer.getVirtualItems();
 
+    const handleNodeListKeyDown = useCallback(
+        (event: KeyboardEvent<HTMLDivElement>) => {
+            if (event.currentTarget !== event.target || event.altKey || event.ctrlKey || event.metaKey) {
+                return;
+            }
+
+            const viewportSize = nodeListRef.current?.clientHeight || GRAPH_NODE_ROW_ESTIMATED_SIZE * 8;
+            const currentOffset = nodeListRef.current?.scrollTop ?? 0;
+            const maxOffset = Math.max(0, rowVirtualizer.getTotalSize() - viewportSize);
+            const pageStep = Math.max(GRAPH_NODE_ROW_ESTIMATED_SIZE, viewportSize - GRAPH_NODE_ROW_ESTIMATED_SIZE);
+            let nextOffset: number | null = null;
+
+            switch (event.key) {
+                case 'ArrowDown':
+                    nextOffset = currentOffset + GRAPH_NODE_ROW_ESTIMATED_SIZE;
+                    break;
+                case 'ArrowUp':
+                    nextOffset = currentOffset - GRAPH_NODE_ROW_ESTIMATED_SIZE;
+                    break;
+                case 'PageDown':
+                    nextOffset = currentOffset + pageStep;
+                    break;
+                case 'PageUp':
+                    nextOffset = currentOffset - pageStep;
+                    break;
+                case 'Home':
+                    nextOffset = 0;
+                    break;
+                case 'End':
+                    nextOffset = maxOffset;
+                    break;
+                default:
+                    return;
+            }
+
+            event.preventDefault();
+            rowVirtualizer.scrollToOffset(Math.min(maxOffset, Math.max(0, nextOffset)), { behavior: 'auto' });
+        },
+        [rowVirtualizer],
+    );
+
     useEffect(() => {
+        const didSearchQueryChange = previousNodeSearchQueryRef.current !== nodeSearchQuery;
+        previousNodeSearchQueryRef.current = nodeSearchQuery;
+
+        if (didSearchQueryChange) {
+            rowVirtualizer.scrollToOffset(0, { behavior: 'auto' });
+            return;
+        }
+
         if (!selectedNodeId) {
             return;
         }
@@ -67,7 +118,7 @@ export function GraphExplorerPanel({
             align: 'auto',
             behavior: prefersReducedMotion ? 'auto' : 'smooth',
         });
-    }, [filteredGraphNodes, rowVirtualizer, selectedNodeId]);
+    }, [filteredGraphNodes, nodeSearchQuery, rowVirtualizer, selectedNodeId]);
 
     return (
         <section
@@ -170,8 +221,16 @@ export function GraphExplorerPanel({
                         <Text as="h3" variant="label" weight="semibold">
                             Notes
                         </Text>
-                        <Text as="span" variant="meta" tone="tertiary" className="shrink-0">
-                            {filteredGraphNodes.length} shown
+                        <Text
+                            id="graph-node-results-summary"
+                            as="span"
+                            aria-live="polite"
+                            aria-atomic="true"
+                            variant="meta"
+                            tone="tertiary"
+                            className="shrink-0"
+                        >
+                            {graphResultsSummary}
                         </Text>
                     </div>
                     <div className="relative mt-2">
@@ -186,16 +245,23 @@ export function GraphExplorerPanel({
                             onChange={(event) => onNodeSearchQueryChange(event.target.value)}
                             placeholder="Find a note"
                             aria-label="Search graph"
+                            aria-describedby="graph-node-results-summary"
                             className="pl-9"
                         />
                     </div>
                 </div>
+                <Text id="graph-node-list-keyboard-help" as="p" className="sr-only">
+                    Focus the graph notes list and use arrow, page, home, or end keys to browse more results.
+                </Text>
                 {filteredGraphNodes.length > 0 ? (
                     <div
                         ref={nodeListRef}
                         role="list"
                         aria-label="Graph notes"
-                        className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto"
+                        aria-describedby="graph-node-results-summary graph-node-list-keyboard-help"
+                        tabIndex={0}
+                        onKeyDown={handleNodeListKeyDown}
+                        className="focus-ring-soft min-h-0 flex-1 overflow-x-hidden overflow-y-auto outline-none"
                     >
                         <div className="relative w-full" style={{ height: `${rowVirtualizer.getTotalSize()}px` }}>
                             {virtualRows.map((virtualRow) => {

--- a/packages/client/src/pages/GraphExplorerPanel.tsx
+++ b/packages/client/src/pages/GraphExplorerPanel.tsx
@@ -49,7 +49,7 @@ export function GraphExplorerPanel({
     const selectedNodeStatus = selectedNode
         ? `${selectedNode.title || 'Untitled'} selected, ${selectedNode.connections} links`
         : 'No graph node selected';
-    const graphResultsSummary = `${filteredGraphNodes.length} shown`;
+    const graphResultsSummary = `${filteredGraphNodes.length} graph notes shown`;
     const virtualRows = rowVirtualizer.getVirtualItems();
 
     const handleNodeListKeyDown = useCallback(
@@ -125,19 +125,57 @@ export function GraphExplorerPanel({
             className="surface-base flex min-h-[420px] flex-col overflow-hidden md:min-h-[520px] xl:h-[min(44rem,calc(100vh-10rem))]"
             aria-labelledby="graph-explorer-heading"
         >
-            <div className="border-b border-border-subtle/80 px-4 py-3.5">
-                <div className="flex items-start gap-3">
-                    <span className="mt-0.5 inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-[12px] border border-border-subtle bg-muted text-fg-secondary">
-                        <Icon.Graph className="h-4 w-4" aria-hidden="true" />
-                    </span>
-                    <div className="min-w-0">
-                        <Text id="graph-explorer-heading" as="h2" variant="body" weight="semibold">
+            <div className="border-b border-border-subtle/80 px-4 py-3">
+                <div className="flex items-center justify-between gap-3">
+                    <div className="flex min-w-0 items-center gap-2 text-fg-tertiary">
+                        <Icon.Graph className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                        <Text
+                            id="graph-explorer-heading"
+                            as="h2"
+                            variant="label"
+                            weight="semibold"
+                            className="text-current"
+                        >
                             Graph Explorer
                         </Text>
-                        <Text as="p" variant="meta" tone="tertiary" className="mt-0.5">
-                            Connection index
-                        </Text>
                     </div>
+                    <Text
+                        id="graph-node-results-summary"
+                        as="span"
+                        aria-live="polite"
+                        aria-atomic="true"
+                        variant="meta"
+                        tone="tertiary"
+                        className="shrink-0"
+                    >
+                        {graphResultsSummary}
+                    </Text>
+                </div>
+                <div className="relative mt-2.5">
+                    <Icon.Search
+                        className="pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-fg-tertiary"
+                        aria-hidden="true"
+                    />
+                    <Input
+                        id="graph-node-search"
+                        size="sm"
+                        value={nodeSearchQuery}
+                        onChange={(event) => onNodeSearchQueryChange(event.target.value)}
+                        placeholder="Find graph notes"
+                        aria-label="Search graph notes"
+                        aria-describedby="graph-node-results-summary"
+                        className={classNames('pl-9', nodeSearchQuery && 'pr-9')}
+                    />
+                    {nodeSearchQuery && (
+                        <button
+                            type="button"
+                            onClick={() => onNodeSearchQueryChange('')}
+                            className="focus-ring-soft absolute top-1/2 right-1.5 inline-flex h-6 w-6 -translate-y-1/2 items-center justify-center rounded-[8px] text-fg-tertiary outline-none transition-colors hover:bg-hover-subtle hover:text-fg-default"
+                            aria-label="Clear graph search"
+                        >
+                            <Icon.Close className="h-3.5 w-3.5" aria-hidden="true" />
+                        </button>
+                    )}
                 </div>
             </div>
 
@@ -151,7 +189,7 @@ export function GraphExplorerPanel({
                     : selectedNodeStatus}
             </Text>
 
-            <div className="border-b border-border-subtle/80 px-4 py-3">
+            <div className="border-b border-border-subtle/80 px-4 py-2.5">
                 {selectedNode ? (
                     <div className="min-w-0">
                         <div className="flex items-start justify-between gap-3">
@@ -204,52 +242,15 @@ export function GraphExplorerPanel({
                         )}
                     </div>
                 ) : (
-                    <div>
-                        <Text as="p" variant="body" weight="semibold">
-                            No graph node selected
-                        </Text>
-                        <Text as="p" variant="meta" tone="tertiary" className="mt-0.5">
-                            {graphNodes[0]?.title ? `Most linked: ${graphNodes[0].title}` : 'No linked notes'}
-                        </Text>
-                    </div>
+                    <Text as="p" variant="meta" tone="secondary">
+                        {graphNodes[0]?.title
+                            ? `Select a node to preview links. Most linked: ${graphNodes[0].title}`
+                            : 'Select a node to preview links.'}
+                    </Text>
                 )}
             </div>
 
             <div className="flex min-h-0 flex-1 flex-col">
-                <div className="border-b border-border-subtle/60 px-4 py-2.5">
-                    <div className="flex items-center justify-between gap-3">
-                        <Text as="h3" variant="label" weight="semibold">
-                            Notes
-                        </Text>
-                        <Text
-                            id="graph-node-results-summary"
-                            as="span"
-                            aria-live="polite"
-                            aria-atomic="true"
-                            variant="meta"
-                            tone="tertiary"
-                            className="shrink-0"
-                        >
-                            {graphResultsSummary}
-                        </Text>
-                    </div>
-                    <div className="relative mt-2">
-                        <Icon.Search
-                            className="pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-fg-tertiary"
-                            aria-hidden="true"
-                        />
-                        <Input
-                            id="graph-node-search"
-                            size="sm"
-                            value={nodeSearchQuery}
-                            onChange={(event) => onNodeSearchQueryChange(event.target.value)}
-                            placeholder="Find a note"
-                            aria-label="Search graph"
-                            aria-describedby="graph-node-results-summary"
-                            className="pl-9"
-                        />
-                    </div>
-                </div>
                 <Text id="graph-node-list-keyboard-help" as="p" className="sr-only">
                     Focus the graph notes list and use arrow, page, home, or end keys to browse more results.
                 </Text>

--- a/packages/client/src/pages/GraphExplorerPanel.tsx
+++ b/packages/client/src/pages/GraphExplorerPanel.tsx
@@ -1,0 +1,292 @@
+import { Link } from '@tanstack/react-router';
+import { useVirtualizer } from '@tanstack/react-virtual';
+import classNames from 'classnames';
+import { useEffect, useRef } from 'react';
+
+import type { GraphNode } from '~/apis/note.api';
+import * as Icon from '~/components/icon';
+import { Input, Text } from '~/components/ui';
+import { NOTE_ROUTE } from '~/modules/url';
+
+const GRAPH_NODE_ROW_ESTIMATED_SIZE = 57;
+
+interface GraphExplorerPanelProps {
+    filteredGraphNodes: GraphNode[];
+    graphNodes: GraphNode[];
+    nodeSearchQuery: string;
+    onClearSelection: () => void;
+    onNodeSearchQueryChange: (query: string) => void;
+    onSelectNode: (nodeId: string) => void;
+    selectedConnectedNodes: GraphNode[];
+    selectedNode: GraphNode | null;
+    selectedNodeId: string | null;
+}
+
+export function GraphExplorerPanel({
+    filteredGraphNodes,
+    graphNodes,
+    nodeSearchQuery,
+    onClearSelection,
+    onNodeSearchQueryChange,
+    onSelectNode,
+    selectedConnectedNodes,
+    selectedNode,
+    selectedNodeId,
+}: GraphExplorerPanelProps) {
+    const nodeListRef = useRef<HTMLDivElement>(null);
+    const rowVirtualizer = useVirtualizer<HTMLDivElement, HTMLDivElement>({
+        count: filteredGraphNodes.length,
+        estimateSize: () => GRAPH_NODE_ROW_ESTIMATED_SIZE,
+        getItemKey: (index) => filteredGraphNodes[index]?.id ?? index,
+        getScrollElement: () => nodeListRef.current,
+        initialRect: { width: 360, height: 480 },
+        overscan: 8,
+    });
+
+    const visibleSelectedConnections = selectedConnectedNodes.slice(0, 4);
+    const remainingSelectedConnectionCount = selectedConnectedNodes.length - visibleSelectedConnections.length;
+    const selectedNodeStatus = selectedNode
+        ? `${selectedNode.title || 'Untitled'} selected, ${selectedNode.connections} links`
+        : 'No graph node selected';
+    const virtualRows = rowVirtualizer.getVirtualItems();
+
+    useEffect(() => {
+        if (!selectedNodeId) {
+            return;
+        }
+
+        const selectedIndex = filteredGraphNodes.findIndex((node) => node.id === selectedNodeId);
+        if (selectedIndex < 0) {
+            return;
+        }
+
+        const prefersReducedMotion =
+            typeof window.matchMedia === 'function' && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+        rowVirtualizer.scrollToIndex(selectedIndex, {
+            align: 'auto',
+            behavior: prefersReducedMotion ? 'auto' : 'smooth',
+        });
+    }, [filteredGraphNodes, rowVirtualizer, selectedNodeId]);
+
+    return (
+        <section
+            className="surface-base flex min-h-[420px] flex-col overflow-hidden md:min-h-[520px] xl:h-[min(44rem,calc(100vh-10rem))]"
+            aria-labelledby="graph-explorer-heading"
+        >
+            <div className="border-b border-border-subtle/80 px-4 py-3.5">
+                <div className="flex items-start gap-3">
+                    <span className="mt-0.5 inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-[12px] border border-border-subtle bg-muted text-fg-secondary">
+                        <Icon.Graph className="h-4 w-4" aria-hidden="true" />
+                    </span>
+                    <div className="min-w-0">
+                        <Text id="graph-explorer-heading" as="h2" variant="body" weight="semibold">
+                            Graph Explorer
+                        </Text>
+                        <Text as="p" variant="meta" tone="tertiary" className="mt-0.5">
+                            Connection index
+                        </Text>
+                    </div>
+                </div>
+            </div>
+
+            <Text id="graph-selection-status" as="p" role="status" aria-live="polite" className="sr-only">
+                {selectedNode
+                    ? `${selectedNodeStatus}${
+                          selectedConnectedNodes.length > 0
+                              ? `. Linked to ${selectedConnectedNodes.map((node) => node.title || 'Untitled').join(', ')}`
+                              : ''
+                      }`
+                    : selectedNodeStatus}
+            </Text>
+
+            <div className="border-b border-border-subtle/80 px-4 py-3">
+                {selectedNode ? (
+                    <div className="min-w-0">
+                        <div className="flex items-start justify-between gap-3">
+                            <div className="min-w-0">
+                                <Text as="p" variant="body" weight="semibold" truncate>
+                                    {selectedNode.title || 'Untitled'}
+                                </Text>
+                                <Text as="p" variant="meta" tone="tertiary" className="mt-0.5">
+                                    {selectedNode.connections} links
+                                </Text>
+                            </div>
+                            <div className="flex shrink-0 items-center gap-1">
+                                <button
+                                    type="button"
+                                    onClick={onClearSelection}
+                                    className="focus-ring-soft inline-flex h-8 w-8 items-center justify-center rounded-[10px] text-fg-secondary outline-none transition-colors hover:bg-hover-subtle hover:text-fg-default"
+                                    aria-label="Deselect node"
+                                >
+                                    <Icon.Close className="h-3.5 w-3.5" aria-hidden="true" />
+                                </button>
+                                <Link
+                                    to={NOTE_ROUTE}
+                                    params={{ id: selectedNode.id }}
+                                    aria-label={`Open ${selectedNode.title || 'Untitled'}`}
+                                    className="focus-ring-soft inline-flex h-8 w-8 items-center justify-center rounded-[10px] text-fg-secondary outline-none transition-colors hover:bg-hover-subtle hover:text-fg-default"
+                                >
+                                    <Icon.ArrowRight className="h-4 w-4" aria-hidden="true" />
+                                </Link>
+                            </div>
+                        </div>
+                        {visibleSelectedConnections.length > 0 && (
+                            <div className="mt-2 flex flex-wrap gap-1.5">
+                                {visibleSelectedConnections.map((node) => (
+                                    <Link
+                                        key={node.id}
+                                        to={NOTE_ROUTE}
+                                        params={{ id: node.id }}
+                                        className="focus-ring-soft inline-flex max-w-full items-center gap-1 rounded-full border border-border-subtle bg-subtle px-2 py-0.5 text-xs font-medium text-fg-secondary outline-none transition-colors hover:border-border-secondary hover:bg-hover-subtle hover:text-fg-default"
+                                    >
+                                        <Icon.LinkIcon className="h-3 w-3 shrink-0" aria-hidden="true" />
+                                        <span className="truncate">{node.title || 'Untitled'}</span>
+                                    </Link>
+                                ))}
+                                {remainingSelectedConnectionCount > 0 && (
+                                    <span className="inline-flex items-center rounded-full border border-border-subtle px-2 py-0.5 text-xs font-medium text-fg-tertiary">
+                                        +{remainingSelectedConnectionCount}
+                                    </span>
+                                )}
+                            </div>
+                        )}
+                    </div>
+                ) : (
+                    <div>
+                        <Text as="p" variant="body" weight="semibold">
+                            No graph node selected
+                        </Text>
+                        <Text as="p" variant="meta" tone="tertiary" className="mt-0.5">
+                            {graphNodes[0]?.title ? `Most linked: ${graphNodes[0].title}` : 'No linked notes'}
+                        </Text>
+                    </div>
+                )}
+            </div>
+
+            <div className="flex min-h-0 flex-1 flex-col">
+                <div className="border-b border-border-subtle/60 px-4 py-2.5">
+                    <div className="flex items-center justify-between gap-3">
+                        <Text as="h3" variant="label" weight="semibold">
+                            Notes
+                        </Text>
+                        <Text as="span" variant="meta" tone="tertiary" className="shrink-0">
+                            {filteredGraphNodes.length} shown
+                        </Text>
+                    </div>
+                    <div className="relative mt-2">
+                        <Icon.Search
+                            className="pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-fg-tertiary"
+                            aria-hidden="true"
+                        />
+                        <Input
+                            id="graph-node-search"
+                            size="sm"
+                            value={nodeSearchQuery}
+                            onChange={(event) => onNodeSearchQueryChange(event.target.value)}
+                            placeholder="Find a note"
+                            aria-label="Search graph"
+                            className="pl-9"
+                        />
+                    </div>
+                </div>
+                {filteredGraphNodes.length > 0 ? (
+                    <div
+                        ref={nodeListRef}
+                        role="list"
+                        aria-label="Graph notes"
+                        className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto"
+                    >
+                        <div className="relative w-full" style={{ height: `${rowVirtualizer.getTotalSize()}px` }}>
+                            {virtualRows.map((virtualRow) => {
+                                const node = filteredGraphNodes[virtualRow.index];
+                                if (!node) {
+                                    return null;
+                                }
+
+                                const isSelected = selectedNodeId === node.id;
+                                const nodeTitle = node.title || 'Untitled';
+
+                                return (
+                                    <div
+                                        key={virtualRow.key}
+                                        ref={rowVirtualizer.measureElement}
+                                        role="listitem"
+                                        aria-posinset={virtualRow.index + 1}
+                                        aria-setsize={filteredGraphNodes.length}
+                                        data-index={virtualRow.index}
+                                        className={classNames(
+                                            'absolute top-0 left-0 w-full min-w-0 overflow-hidden border-b border-border-subtle/60',
+                                            virtualRow.index === filteredGraphNodes.length - 1 && 'border-b-0',
+                                        )}
+                                        style={{ transform: `translateY(${virtualRow.start}px)` }}
+                                    >
+                                        <div
+                                            className={classNames(
+                                                'grid min-w-0 grid-cols-[minmax(0,1fr)_3.5rem] items-center overflow-hidden transition-colors',
+                                                isSelected
+                                                    ? 'bg-elevated text-fg-default'
+                                                    : 'text-fg-secondary hover:bg-hover-subtle hover:text-fg-default',
+                                            )}
+                                        >
+                                            <button
+                                                type="button"
+                                                aria-pressed={isSelected}
+                                                aria-describedby={isSelected ? 'graph-selection-status' : undefined}
+                                                onClick={() => onSelectNode(node.id)}
+                                                className="focus-ring-soft group grid min-w-0 grid-cols-[3px_minmax(0,1fr)_2.75rem] items-center gap-3 overflow-hidden px-4 py-3 text-left outline-none"
+                                            >
+                                                <span
+                                                    className={classNames(
+                                                        'h-8 rounded-full transition-colors',
+                                                        isSelected
+                                                            ? 'bg-fg-default'
+                                                            : 'bg-border-subtle group-hover:bg-border-secondary',
+                                                    )}
+                                                    aria-hidden="true"
+                                                />
+                                                <span className="min-w-0 overflow-hidden">
+                                                    <Text
+                                                        as="span"
+                                                        variant="meta"
+                                                        weight={isSelected ? 'semibold' : 'medium'}
+                                                        truncate
+                                                        className="block min-w-0"
+                                                    >
+                                                        {nodeTitle}
+                                                    </Text>
+                                                </span>
+                                                <Text
+                                                    as="span"
+                                                    variant="label"
+                                                    weight="medium"
+                                                    tone={isSelected ? 'secondary' : 'tertiary'}
+                                                    className="min-w-8 justify-self-end text-right tabular-nums"
+                                                >
+                                                    <span aria-hidden="true">{node.connections}</span>
+                                                    <span className="sr-only">{node.connections} links</span>
+                                                </Text>
+                                            </button>
+                                            <Link
+                                                to={NOTE_ROUTE}
+                                                params={{ id: node.id }}
+                                                aria-label={`Open ${nodeTitle}`}
+                                                className="focus-ring-soft inline-flex h-9 w-9 shrink-0 items-center justify-center justify-self-center rounded-[10px] text-fg-secondary outline-none transition-colors hover:bg-hover-subtle hover:text-fg-default"
+                                            >
+                                                <Icon.ArrowRight className="h-4 w-4" aria-hidden="true" />
+                                            </Link>
+                                        </div>
+                                    </div>
+                                );
+                            })}
+                        </div>
+                    </div>
+                ) : (
+                    <Text as="p" variant="meta" tone="tertiary" className="px-4 py-5 text-center">
+                        No matching graph nodes
+                    </Text>
+                )}
+            </div>
+        </section>
+    );
+}

--- a/packages/client/src/pages/graph-data.ts
+++ b/packages/client/src/pages/graph-data.ts
@@ -1,0 +1,81 @@
+import type { GraphLink, GraphNode, NoteGraph } from '~/apis/note.api';
+
+export interface GraphData {
+    nodes: GraphNode[];
+    links: GraphLink[];
+}
+
+export function getNodeSize(connections: number) {
+    if (connections <= 1) return 3.5;
+    if (connections <= 3) return 4.5;
+    if (connections <= 6) return 5.5;
+    return Math.min(7, 5.5 + Math.sqrt(connections) * 0.5);
+}
+
+export function createConnectedGraphData(data: NoteGraph): GraphData | null {
+    if (data.nodes.length === 0) {
+        return null;
+    }
+
+    const connectedNodes = data.nodes.filter((node) => node.connections > 0);
+    if (connectedNodes.length === 0) {
+        return null;
+    }
+
+    const connectedIds = new Set(connectedNodes.map((node) => node.id));
+    return {
+        nodes: connectedNodes,
+        links: data.links.filter((link) => connectedIds.has(link.source) && connectedIds.has(link.target)),
+    };
+}
+
+export function createAdjacencyMap(links: GraphLink[]) {
+    const map = new Map<string, Set<string>>();
+
+    for (const link of links) {
+        if (!map.has(link.source)) map.set(link.source, new Set());
+        if (!map.has(link.target)) map.set(link.target, new Set());
+        map.get(link.source)?.add(link.target);
+        map.get(link.target)?.add(link.source);
+    }
+
+    return map;
+}
+
+export function sortGraphNodes(nodes: GraphNode[]) {
+    return [...nodes].sort((a, b) => b.connections - a.connections || a.title.localeCompare(b.title));
+}
+
+export function filterGraphNodes(nodes: GraphNode[], query: string) {
+    const normalizedQuery = query.trim().toLowerCase();
+    if (!normalizedQuery) {
+        return nodes;
+    }
+
+    return nodes.filter((node) => node.title.toLowerCase().includes(normalizedQuery));
+}
+
+export function getSelectedGraphNode(nodes: GraphNode[], selectedNodeId: string | null) {
+    if (!selectedNodeId) {
+        return null;
+    }
+
+    return nodes.find((node) => node.id === selectedNodeId) ?? null;
+}
+
+export function getConnectedGraphNodes(
+    nodes: GraphNode[],
+    adjacencyMap: Map<string, Set<string>>,
+    selectedNodeId: string | null,
+) {
+    if (!selectedNodeId) {
+        return [];
+    }
+
+    const connectedIds = adjacencyMap.get(selectedNodeId);
+    if (!connectedIds) {
+        return [];
+    }
+
+    return nodes.filter((node) => connectedIds.has(node.id));
+}

--- a/packages/client/src/pages/useGraphSelection.ts
+++ b/packages/client/src/pages/useGraphSelection.ts
@@ -1,0 +1,42 @@
+import { getRouteApi } from '@tanstack/react-router';
+import { useCallback } from 'react';
+
+import { GRAPH_ROUTE, NOTE_ROUTE } from '~/modules/url';
+
+const Route = getRouteApi(GRAPH_ROUTE);
+
+export function useGraphSelection() {
+    const navigate = Route.useNavigate();
+    const { selected } = Route.useSearch();
+    const selectedNodeId = selected ?? null;
+
+    const selectNode = useCallback(
+        (nodeId: string | null) => {
+            navigate({
+                search: (prev) => ({
+                    ...prev,
+                    selected: nodeId ?? undefined,
+                }),
+                replace: true,
+            });
+        },
+        [navigate],
+    );
+
+    const openNode = useCallback(
+        (nodeId: string) => {
+            navigate({
+                to: NOTE_ROUTE,
+                params: { id: nodeId },
+            });
+        },
+        [navigate],
+    );
+
+    return {
+        selectedNodeId,
+        selectNode,
+        clearSelection: () => selectNode(null),
+        openNode,
+    };
+}

--- a/packages/client/src/router.tsx
+++ b/packages/client/src/router.tsx
@@ -4,6 +4,7 @@ import { RouteErrorView, RouteNotFoundView, RoutePendingView } from '~/component
 import { SiteLayout } from '~/components/layout';
 import {
     validateCalendarSearch,
+    validateGraphSearch,
     validateHomeSearch,
     validatePaginationSearch,
     validateSearchPageSearch,
@@ -81,6 +82,7 @@ const graphRoute = createRoute({
     pendingComponent: () => (
         <RoutePendingView title="Loading graph" description="Preparing the linked note constellation." />
     ),
+    validateSearch: validateGraphSearch,
 });
 
 const searchRoute = createRoute({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,6 +175,9 @@ importers:
       '@tanstack/react-router':
         specifier: ^1.166.3
         version: 1.166.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@tanstack/react-virtual':
+        specifier: ^3.14.3
+        version: 3.14.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       axios:
         specifier: ^1.15.2
         version: 1.16.0
@@ -2471,6 +2474,12 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  '@tanstack/react-virtual@3.14.3':
+    resolution: {integrity: sha512-k/cnHPVaOfn46hSbiY6n4Dzf4QjCGWSF40zR5QIIYUqPAjpA6TN7InfYmcMiDVQGP2iUn9xsRbAl8u1v3UmeVQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   '@tanstack/router-core@1.166.2':
     resolution: {integrity: sha512-zn3NhENOAX9ToQiX077UV2OH3aJKOvV2ZMNZZxZ3gDG3i3WqL8NfWfEgetEAfMN37/Mnt90PpotYgf7IyuoKqQ==}
     engines: {node: '>=20.19'}
@@ -2480,6 +2489,9 @@ packages:
 
   '@tanstack/store@0.9.2':
     resolution: {integrity: sha512-K013lUJEFJK2ofFQ/hZKJUmCnpcV00ebLyOyFOWQvyQHUOZp/iYO84BM6aOGiV81JzwbX0APTVmW8YI7yiG5oA==}
+
+  '@tanstack/virtual-core@3.17.1':
+    resolution: {integrity: sha512-VZyW2Uiml5tmBZwPGrSD3Sz73OxzljQMCmzYHsUTPEuTsERf5xwa+uWb01xEzkz3ZSYTjj8NEb/mKHvgKxyZdA==}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -7792,6 +7804,12 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       use-sync-external-store: 1.6.0(react@19.2.4)
 
+  '@tanstack/react-virtual@3.14.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@tanstack/virtual-core': 3.17.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
   '@tanstack/router-core@1.166.2':
     dependencies:
       '@tanstack/history': 1.161.4
@@ -7805,6 +7823,8 @@ snapshots:
   '@tanstack/store@0.7.7': {}
 
   '@tanstack/store@0.9.2': {}
+
+  '@tanstack/virtual-core@3.17.1': {}
 
   '@testing-library/dom@10.4.1':
     dependencies:


### PR DESCRIPTION
## :dart: Goal
Add an accessible Graph Explorer path for the Knowledge Graph so users can find, select, restore, and open graph nodes without relying on pointer-only canvas interactions.

## :hammer_and_wrench: Core Changes
- Split the graph screen into page composition, canvas rendering, explorer panel, graph-data derivation, and route-selection hook modules.
- Reworked explorer row actions so selecting a node and opening a note are separate controls.
- Persisted selected graph node state in route search as `?selected=<noteId>` and restore it on refresh/back navigation.
- Added selected-node status text, selected context, related-note quick links, and selected-row scroll positioning.
- Added immediate graph-note search with `@tanstack/react-virtual`, resetting virtualizer offset on search changes so filtered results do not show stale blank space.
- Preserved list context for assistive technology with `role=list`, `role=listitem`, `aria-posinset`, and `aria-setsize` on virtualized rows.
- Added a focusable keyboard scroll target for the virtualized notes list and live result-count feedback tied to the search input.
- Tightened the explorer header/search hierarchy, moved the result count into the header, added a clear-search action, and reduced inactive selected-context weight.

## :brain: Key Decisions
- Treat the explorer as the official accessible path for graph navigation while keeping the canvas hidden from assistive technology.
- Use URL search for selected-node state because this selection should survive refresh, restore, and history navigation.
- Keep node selection and note opening as separate actions to avoid mixing focus, selection, and navigation semantics.
- Keep search filtering immediate after adding virtualization; `useDeferredValue` caused input/list state to drift visually, while virtualization handles DOM scale directly.
- Reset the virtualizer to the top on search changes before selected-node scrolling can run, so search results begin from the first match.
- Keep release impact as `release: minor` because this adds a user-visible Graph Explorer path, not only hidden accessibility metadata.

## :test_tube: Verification Guide
- `pnpm --filter @ocean-brain/client exec vitest run src/pages/Graph.spec.tsx src/modules/route-search.spec.ts --maxWorkers 1` -> 2 files / 13 tests passed
- `pnpm --filter @ocean-brain/client exec vitest run src/modules/local-demo/operation-coverage.spec.ts --maxWorkers 1` -> 1 file / 1 test passed
- `pnpm --filter @ocean-brain/client lint` -> passed
- `pnpm --filter @ocean-brain/client type-check` -> passed
- `pnpm --filter @ocean-brain/client build` -> passed with existing Vite chunk-size warnings
- `VITE_DEMO_MODE=local-only pnpm --filter @ocean-brain/client build` -> passed with existing Vite chunk-size warnings and local-demo dynamic/static import warning
- local-only build preview + Playwright `/graph` smoke -> `Knowledge Graph`, `Graph Explorer`, graph note list, and graph node buttons rendered with no page errors or failed requests
- `pnpm check:encoding` -> passed
- Team-agent review -> search/virtualizer, a11y/UX, and test coverage findings reviewed; search reset override, virtual-list keyboard scroll, live result feedback, and sidebar search hierarchy were fixed

## :white_check_mark: Checklist
- [x] Local validation for changed client scope is complete
- [x] Local-only demo build and `/graph` preview smoke are verified
- [x] Team-agent review completed and follow-up findings addressed
- [x] Graph PR scope is documented in the related Ocean Brain task
- [x] PR title follows `<emoji> <subject>` and subject starts with an English verb
- [x] PR body follows the required template headings
- [x] Release impact label applied: `release: minor`