### PR TITLE
🐛 Scope interaction motion and selection

### DIFF
--- a/packages/client/src/components/schema/TableOfContents/TableOfContents.tsx
+++ b/packages/client/src/components/schema/TableOfContents/TableOfContents.tsx
@@ -84,8 +84,10 @@ const TableOfContentsComponent = () => {
         editor.setTextCursorPosition(headingId);
         const element = document.querySelector(`[data-id="${headingId}"]`);
         if (element) {
+            const prefersReducedMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false;
+
             element.scrollIntoView({
-                behavior: 'smooth',
+                behavior: prefersReducedMotion ? 'auto' : 'smooth',
                 block: 'center',
             });
         }

--- a/packages/client/src/components/ui/Button/variants.ts
+++ b/packages/client/src/components/ui/Button/variants.ts
@@ -7,6 +7,7 @@ export const buttonVariants = cva(
         'justify-center',
         'gap-2',
         'whitespace-nowrap',
+        'select-none',
         'font-medium',
         'transition-colors',
         'duration-200',

--- a/packages/client/src/components/ui/MoreButton/MoreButton.tsx
+++ b/packages/client/src/components/ui/MoreButton/MoreButton.tsx
@@ -7,6 +7,7 @@ const moreButtonVariants = cva(
         'focus-ring-soft',
         'inline-flex',
         'shrink-0',
+        'select-none',
         'items-center',
         'justify-center',
         'bg-transparent',

--- a/packages/client/src/components/view/ViewSectionTableRenderer.spec.tsx
+++ b/packages/client/src/components/view/ViewSectionTableRenderer.spec.tsx
@@ -3,7 +3,6 @@ import userEvent from '@testing-library/user-event';
 
 import type { Note } from '~/models/note.model';
 import type { ViewSection } from '~/models/view.model';
-import { NOTE_ROUTE } from '~/modules/url';
 import ViewSectionTableRenderer from './ViewSectionTableRenderer';
 
 const mockNavigate = vi.fn();
@@ -106,21 +105,20 @@ describe('<ViewSectionTableRenderer />', () => {
         expect(within(table).getByText('Doing')).toBeInTheDocument();
     });
 
-    it('opens the note when a table row is activated', async () => {
+    it('opens notes through the title link instead of the whole table row', async () => {
         const user = userEvent.setup();
 
         renderTable();
 
-        const row = screen.getByRole('link', { name: /Ocean Brain task/i }).closest('tr');
+        const link = screen.getByRole('link', { name: /Ocean Brain task/i });
+        const row = link.closest('tr');
 
         expect(row).toBeInTheDocument();
+        expect(link).toHaveAttribute('href', '/note-1');
 
         await user.click(row!);
 
-        expect(mockNavigate).toHaveBeenCalledWith({
-            to: NOTE_ROUTE,
-            params: { id: 'note-1' },
-        });
+        expect(mockNavigate).not.toHaveBeenCalled();
     });
 
     it('keeps notes without tags or properties visible with empty table cells', () => {

--- a/packages/client/src/components/view/ViewSectionTableRenderer.tsx
+++ b/packages/client/src/components/view/ViewSectionTableRenderer.tsx
@@ -1,4 +1,4 @@
-import { Link, useNavigate } from '@tanstack/react-router';
+import { Link } from '@tanstack/react-router';
 
 import { Button, Text } from '~/components/ui';
 import type { Note, NoteProperty } from '~/models/note.model';
@@ -130,7 +130,6 @@ export default function ViewSectionTableRenderer({
     isSortPending,
     surface = 'flush',
 }: ViewSectionTableRendererProps) {
-    const navigate = useNavigate();
     const visibleColumns = normalizeViewTableColumns(section.displayOptions?.tableColumns);
     const tableMinWidth = getTableMinWidth(visibleColumns);
     const surfaceClassName =
@@ -144,13 +143,6 @@ export default function ViewSectionTableRenderer({
     const loadingRowClassName = surface === 'card' ? 'bg-elevated' : 'bg-transparent';
     const tableHeadClassName = surface === 'card' ? 'bg-subtle/65' : 'bg-subtle/45';
     const tableBodyClassName = surface === 'card' ? 'bg-elevated' : 'bg-transparent';
-
-    const openNote = (noteId: string) => {
-        void navigate({
-            to: NOTE_ROUTE,
-            params: { id: noteId },
-        });
-    };
 
     const renderHeaderCell = (column: ViewTableColumn) => {
         const sortBy = SORTABLE_TABLE_COLUMNS[column];
@@ -221,7 +213,6 @@ export default function ViewSectionTableRenderer({
                                 to={NOTE_ROUTE}
                                 params={{ id: note.id }}
                                 className="focus-ring-soft rounded-[6px] outline-none transition-colors hover:text-fg-default/85"
-                                onClick={(event) => event.stopPropagation()}
                             >
                                 {note.title || 'Untitled'}
                             </Link>
@@ -287,11 +278,7 @@ export default function ViewSectionTableRenderer({
                 </thead>
                 <tbody className={tableBodyClassName}>
                     {notes.map((note) => (
-                        <tr
-                            key={note.id}
-                            className="h-12 cursor-pointer border-b border-border-subtle/70 transition-colors last:border-b-0 hover:bg-hover-subtle"
-                            onClick={() => openNote(note.id)}
-                        >
+                        <tr key={note.id} className="h-12 border-b border-border-subtle/70 last:border-b-0">
                             {visibleColumns.map((column) => renderCell(note, column))}
                         </tr>
                     ))}

--- a/packages/client/src/styles/main.scss
+++ b/packages/client/src/styles/main.scss
@@ -25,7 +25,6 @@ body,
     height: 100%;
     margin: 0;
     padding: 0;
-    user-select: none;
     overflow: hidden;
 }
 

--- a/packages/client/src/styles/tailwind.css
+++ b/packages/client/src/styles/tailwind.css
@@ -416,6 +416,15 @@ html.dark .surface-base {
 }
 
 @media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        scroll-behavior: auto !important;
+        transition-duration: 0.01ms !important;
+    }
+
     .save-progress-ring-active {
         --save-progress: 100%;
         animation: none;
@@ -432,6 +441,7 @@ html.dark .surface-base {
 /* Graph canvas */
 .graph-canvas {
     background: var(--graph-bg);
+    user-select: none;
 }
 
 /* Legend dot */


### PR DESCRIPTION
## :dart: Goal

Scope the lower-priority accessibility and UX cleanup from Ocean Brain note 1600 without adding broad UI-coupled accessibility test coverage.

## :hammer_and_wrench: Core Changes

- Removed global `user-select: none` so note/content text remains selectable by default.
- Scoped non-selection behavior to direct interaction surfaces: shared buttons, MoreButton, and the graph canvas.
- Added a reduced-motion CSS baseline and made Table of Contents programmatic scrolling respect `prefers-reduced-motion`.
- Removed whole-row navigation affordance from view section tables; the note title link is now the only navigation target.
- Kept regression coverage minimal by updating the existing table renderer test for the changed row-click contract.

## :brain: Key Decisions

- This is a patch release because it fixes existing accessibility/UX behavior without adding a new user capability.
- No broad accessibility assertion suite was added here; lint/static checks cover the static layer, while the test only protects the concrete behavior changed in this PR.
- Team-agent review by Darwin found no blocking issues.

## :test_tube: Verification Guide

- `pnpm --filter @ocean-brain/client exec vitest run --maxWorkers 1 src/components/view/ViewSectionTableRenderer.spec.tsx`
- `pnpm --filter @ocean-brain/client lint`
- `pnpm --filter @ocean-brain/client type-check`
- `pnpm check:encoding`
- `pnpm --filter @ocean-brain/client test:ci`
- `pnpm --filter @ocean-brain/client build`

## :white_check_mark: Checklist

- [x] Release label: `release: patch`
- [x] Team-agent review completed before publishing the PR
- [x] Accessibility cleanup remains scoped to selection, motion, and table row affordance behavior
- [x] Tests are limited to the changed behavior contract
