### PR TITLE
🐛 Fix mobile layout bottom spacing

### DIFF
--- a/packages/client/src/components/layout/SiteLayout/LayoutShell.tsx
+++ b/packages/client/src/components/layout/SiteLayout/LayoutShell.tsx
@@ -93,8 +93,8 @@ const contentClassName = classNames(
     'overflow-x-clip',
     'px-4',
     'pt-4',
-    "after:block",
-    "after:h-4",
+    'after:block',
+    'after:h-4',
     "after:content-['']",
     'max-md:after:h-24',
 );

--- a/packages/client/src/components/layout/SiteLayout/LayoutShell.tsx
+++ b/packages/client/src/components/layout/SiteLayout/LayoutShell.tsx
@@ -93,8 +93,10 @@ const contentClassName = classNames(
     'overflow-x-clip',
     'px-4',
     'pt-4',
-    'pb-4',
-    'max-md:pb-[calc(6rem+env(safe-area-inset-bottom))]',
+    "after:block",
+    "after:h-4",
+    "after:content-['']",
+    'max-md:after:h-24',
 );
 
 interface LayoutShellProps {


### PR DESCRIPTION
## :dart: Goal
- Fix mobile note lists appearing flush against the bottom edge of the layout.
- Keep the existing mobile scroll boundary behavior while restoring visible end spacing for long content.

## :hammer_and_wrench: Core Changes
- Replaced layout bottom padding with an end-of-content spacer on the shared site content wrapper.
- Kept the existing flex scroll container structure intact to avoid regressing the mobile scroll boundary fix.
- Simplified mobile bottom spacing to a fixed Tailwind height instead of an inline calculation.

## :brain: Key Decisions
- Used a generated end spacer so the extra space follows long page content instead of staying inside a constrained flex box.
- Avoided page-by-page fixes because the issue belongs to the shared layout wrapper.
- Avoided adding tests for exact spacing values because those values are visual tuning, not a stable behavior contract.

## :test_tube: Verification Guide
### How to verify
1. Run `pnpm --filter @ocean-brain/client build`.
2. Open a note list page on a narrow/mobile viewport.
3. Scroll to the end of the list.

### Expected result
- The client build succeeds.
- The final list item has visible bottom breathing room instead of touching the viewport edge.
- The mobile scroll boundary behavior remains intact.

## :white_check_mark: Checklist
- [ ] Lint completed
- [ ] Type-check completed
- [ ] Tests completed
- [x] Documentation updated (if needed)
