### PR TITLE
🛠 Automate release PR creation

### DIFF
--- a/.github/workflows/RELEASE_PR.yml
+++ b/.github/workflows/RELEASE_PR.yml
@@ -1,0 +1,125 @@
+name: RELEASE PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: Semver release type to prepare
+        required: true
+        default: patch
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  create-release-pr:
+    name: Create release PR
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Bump CLI package version
+        id: version
+        shell: bash
+        run: |
+          current_version="$(node -p "JSON.parse(require('node:fs').readFileSync('packages/cli/package.json', 'utf8')).version")"
+
+          cd packages/cli
+          version_output="$(npm version "$RELEASE_TYPE" --no-git-tag-version)"
+          version="${version_output#v}"
+
+          echo "current_version=${current_version}" >> "$GITHUB_OUTPUT"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "tag=v${version}" >> "$GITHUB_OUTPUT"
+          echo "branch=chore/release-v${version}" >> "$GITHUB_OUTPUT"
+        env:
+          RELEASE_TYPE: ${{ inputs.release_type }}
+
+      - name: Stop if release branch already exists
+        shell: bash
+        run: |
+          if git ls-remote --exit-code --heads origin '${{ steps.version.outputs.branch }}' >/dev/null; then
+            echo "Release branch already exists: ${{ steps.version.outputs.branch }}" >&2
+            echo "Delete or finish the existing release PR before creating another one." >&2
+            exit 1
+          fi
+
+          if git ls-remote --exit-code --tags origin '${{ steps.version.outputs.tag }}' >/dev/null; then
+            echo "Release tag already exists: ${{ steps.version.outputs.tag }}" >&2
+            echo "Choose a different release type or inspect the existing release." >&2
+            exit 1
+          fi
+
+      - name: Commit release bump
+        shell: bash
+        run: |
+          if git diff --quiet -- packages/cli/package.json; then
+            echo "No version change was produced for packages/cli/package.json" >&2
+            exit 1
+          fi
+
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git checkout -b '${{ steps.version.outputs.branch }}'
+          git add packages/cli/package.json
+          git commit -m '🔖 Bump version to ${{ steps.version.outputs.version }}'
+          git push origin '${{ steps.version.outputs.branch }}'
+
+      - name: Create release PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          cat > /tmp/release-pr-body.md <<'BODY'
+          ## :dart: Goal
+          Prepare the ${{ steps.version.outputs.tag }} ${{ inputs.release_type }} release with an automated release branch and PR.
+
+          ## :hammer_and_wrench: Core Changes
+          - Bump `packages/cli/package.json` from `${{ steps.version.outputs.current_version }}` to `${{ steps.version.outputs.version }}`.
+          - Use the release branch `${{ steps.version.outputs.branch }}` so `CLI_SMOKE` runs on this PR.
+
+          ## :brain: Key Decisions
+          - The release tag is expected to be `${{ steps.version.outputs.tag }}` after this PR is merged.
+          - This PR does not deploy by itself; deployment still requires the explicit `${{ steps.version.outputs.tag }}` tag push from merged `main`.
+
+          ## :test_tube: Verification Guide
+          - GitHub Actions: required PR CI (`lint`, `type-check`, `build`) must pass.
+          - GitHub Actions: `CLI_SMOKE` must pass for `${{ steps.version.outputs.branch }}`.
+          - After merge and tag push, monitor the `RELEASE` workflow.
+
+          ## :white_check_mark: Checklist
+          - [ ] Required PR CI passed
+          - [ ] `CLI_SMOKE` passed
+          - [ ] Expected tag confirmed: `${{ steps.version.outputs.tag }}`
+          - [ ] Release notes will be finalized after the `RELEASE` workflow creates the GitHub Release
+          BODY
+
+          pr_url="$(gh pr create \
+            --base main \
+            --head '${{ steps.version.outputs.branch }}' \
+            --title '🔖 Bump version to ${{ steps.version.outputs.version }}' \
+            --body-file /tmp/release-pr-body.md)"
+
+          pr_number="${pr_url##*/}"
+
+          gh api \
+            --method POST \
+            "repos/${{ github.repository }}/issues/${pr_number}/labels" \
+            --field labels[]='release: ${{ inputs.release_type }}'

--- a/docs/process/DEPLOYMENT_RELEASE_STRATEGY.md
+++ b/docs/process/DEPLOYMENT_RELEASE_STRATEGY.md
@@ -69,7 +69,7 @@ git push origin v0.3.1
 4. Copies artifacts into `packages/cli/server/**`
 - Result: only CLI is published to npm, with bundled server/client artifacts.
 
-## 6. Manual Release Runbook
+## 6. Release Preparation Runbook
 1. Verify release package
 - Required: latest `CLI_SMOKE` workflow is green for the release target PR or commit.
 - Required before tagging: confirm the release commit on `main` has already passed the required PR CI (`lint`, `type-check`, `build`). The tag-triggered `RELEASE` workflow publishes artifacts; it is not a replacement for main-branch quality validation.
@@ -80,23 +80,29 @@ git push origin v0.3.1
 - PR merge list:
   `git log v<previous-version>..HEAD --merges --pretty=format:"%s"`
 
-3. Bump version
-- `node scripts/release/bump-version.mjs <version>`
-- This updates only `packages/cli/package.json`.
+3. Create the release PR from GitHub Actions
+- Go to **Actions → RELEASE PR → Run workflow**.
+- Select the semver release type:
+  - `patch`: `0.7.3` → `0.7.4`
+  - `minor`: `0.7.3` → `0.8.0`
+  - `major`: `0.7.3` → `1.0.0`
+- The workflow runs `npm version <release-type> --no-git-tag-version` in `packages/cli`.
+- The workflow creates a dedicated release branch named `chore/release-v<version>`.
+- The workflow commits only the version bump in `packages/cli/package.json`.
+- The workflow opens a release PR titled `🔖 Bump version to <version>`.
+- Do not create the release branch or release bump commit from a local checkout in the normal release flow.
 
-4. Create dedicated release branch
-- `git checkout -b chore/release-v<version>`
+4. Review the release PR
+- Confirm the expected tag is `v<version>`.
+- Confirm exactly one release impact label is applied: `release: patch`, `release: minor`, or `release: major`.
+- Confirm the release PR contains the verification plan.
 
-5. Commit version bump
-- `git add packages/cli/package.json`
-- `git commit -m "🔖 Bump version to <version>"`
-- Version bump must be a separate PR. Direct release bumps on `main` are not allowed.
+5. Verify and merge the release PR to `main`
+- Required PR CI (`lint`, `type-check`, `build`) must pass.
+- `CLI_SMOKE` must pass on the `chore/release-v<version>` release PR branch.
+- Version bump must remain a separate PR. Direct release bumps on `main` are not allowed.
 
-6. Open and merge release PR to `main`
-- PR title: `🔖 Bump version to <version>`
-- PR body must include expected tag (`v<version>`) and verification result.
-
-7. Trigger release explicitly from merged `main`
+6. Trigger release explicitly from merged `main`
 
 ```bash
 git checkout main
@@ -108,7 +114,7 @@ git push origin v<version>
 - This tag push is the supported release trigger.
 - Do not treat PR merge itself as deployment.
 
-8. Monitor the `RELEASE` workflow
+7. Monitor the `RELEASE` workflow
 - Example:
 
 ```bash
@@ -117,7 +123,7 @@ gh run list --workflow RELEASE.yml --limit 5
 
 - Wait for npm publish, Docker publish, and manifest jobs to finish.
 
-9. Finalize GitHub Release note
+8. Finalize GitHub Release note
 - Open the created release page after `RELEASE` creates it.
 - For patch releases, start from GitHub generated notes and preserve the PR-linked bullet format.
 - For minor and major releases, treat auto-generated notes as a draft and replace the body with the final note before sharing the release externally.


### PR DESCRIPTION
## :dart: Goal
- Make release PR preparation start from GitHub Actions instead of a local manual release branch.
- Reduce release risk by always creating the `chore/release-v*` version bump PR through one repeatable workflow.

## :hammer_and_wrench: Core Changes
- Add the `RELEASE PR` workflow with a `workflow_dispatch` release type choice: `patch`, `minor`, or `major`.
- Use `npm version <release-type> --no-git-tag-version` in `packages/cli` so semver bumping is delegated to npm without auto commit/tag creation.
- Have the workflow create `chore/release-v<version>`, commit the CLI version bump, open the release PR, and attach the matching release impact label.
- Update the release strategy document so the normal release preparation path starts from Actions.

## :brain: Key Decisions
- The workflow accepts release type, not a raw version, to avoid manual version calculation mistakes.
- The release PR still does not deploy; deployment remains the explicit `v<version>` tag push after the release PR passes CI and is merged.
- Existing `CLI_SMOKE` behavior is preserved: it runs for `chore/release-v*` PRs.

## :test_tube: Verification Guide
### How to verify
1. Review `.github/workflows/RELEASE_PR.yml`.
2. Confirm `docs/process/DEPLOYMENT_RELEASE_STRATEGY.md` points release preparation to Actions.
3. After merge, run `RELEASE PR` manually with `patch` and confirm it creates `chore/release-v0.7.4` and a `🔖 Bump version to 0.7.4` PR.

### Expected result
- The workflow computes the next version from `packages/cli/package.json` through `npm version`.
- The generated release PR receives `release: patch`, `release: minor`, or `release: major` according to the selected release type.
- `CLI_SMOKE` runs on the generated `chore/release-v*` PR.

## :white_check_mark: Checklist
- [x] Lint completed (`git diff --check`)
- [ ] Type-check completed (not needed; workflow/docs only)
- [ ] Tests completed (not needed; workflow/docs only)
- [x] Documentation updated (if needed)
