### PR TITLE
🛠 Dispatch release PR checks

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   ci:

--- a/.github/workflows/RELEASE_PR.yml
+++ b/.github/workflows/RELEASE_PR.yml
@@ -14,6 +14,7 @@ on:
           - major
 
 permissions:
+  actions: write
   contents: write
   pull-requests: write
   issues: write
@@ -123,3 +124,6 @@ jobs:
             --method POST \
             "repos/${{ github.repository }}/issues/${pr_number}/labels" \
             --field labels[]='release: ${{ inputs.release_type }}'
+
+          gh workflow run CI.yml --ref '${{ steps.version.outputs.branch }}'
+          gh workflow run CLI_SMOKE.yml --ref '${{ steps.version.outputs.branch }}'


### PR DESCRIPTION
## :dart: Goal
- Ensure automated release PRs still run actual GitHub CI and CLI smoke verification.
- Avoid relying on `pull_request` events that are suppressed for branches pushed by `GITHUB_TOKEN`.

## :hammer_and_wrench: Core Changes
- Add `workflow_dispatch` support to `CI.yml`.
- Grant the `RELEASE PR` workflow `actions: write` permission.
- Dispatch `CI.yml` and `CLI_SMOKE.yml` for the generated `chore/release-v*` branch after the release PR is created.

## :brain: Key Decisions
- Keep the release PR creation flow on `GITHUB_TOKEN` instead of requiring a personal access token secret.
- Use explicit `workflow_dispatch` runs because GitHub does not automatically trigger downstream pull-request workflows from `GITHUB_TOKEN` branch pushes.

## :test_tube: Verification Guide
### How to verify
1. Run `RELEASE PR` with `patch` after this PR is merged.
2. Confirm the generated release PR is created.
3. Confirm `CI` and `CLI_SMOKE` runs start for the generated `chore/release-v*` branch.

### Expected result
- Release PR creation succeeds.
- CI and CLI smoke verification run against the release branch head commit.

## :white_check_mark: Checklist
- [x] Lint completed (`git diff --check`)
- [ ] Type-check completed (not needed; workflow-only change)
- [ ] Tests completed (not needed; workflow-only change)
- [ ] Documentation updated (not needed)
