### PR TITLE
🧪 Resolve catalog deps in CLI tarball

### DIFF
--- a/.github/workflows/RELEASE.yml
+++ b/.github/workflows/RELEASE.yml
@@ -37,9 +37,12 @@ jobs:
       - name: Build & prepare publish
         run: node scripts/release/prepublish.mjs
 
+      - name: Pack CLI package
+        id: pack
+        run: node scripts/ci/pack-cli-tarball.mjs
+
       - name: Publish ocean-brain
-        working-directory: packages/cli
-        run: npm publish --provenance --access public
+        run: npm publish "${{ steps.pack.outputs.path }}" --provenance --access public
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/docs/process/DEPLOYMENT_RELEASE_STRATEGY.md
+++ b/docs/process/DEPLOYMENT_RELEASE_STRATEGY.md
@@ -47,7 +47,8 @@ git push origin v0.3.1
 1. `publish-npm`
 - Installs Node 22 and pnpm
 - Runs `node scripts/release/prepublish.mjs`
-- Publishes with `npm publish --provenance --access public` from `packages/cli`
+- Packs the CLI with `pnpm pack` so workspace `catalog:` dependencies are resolved in the tarball.
+- Publishes that tarball with `npm publish --provenance --access public`.
 - Uses npm trusted publishing (OIDC) via GitHub Actions
 - Creates a GitHub Release with auto-generated notes (`generate_release_notes: true`)
 
@@ -67,7 +68,7 @@ git push origin v0.3.1
 2. Builds `@ocean-brain/server`
 3. Builds `ocean-brain` (CLI)
 4. Copies artifacts into `packages/cli/server/**`
-- Result: only CLI is published to npm, with bundled server/client artifacts.
+- Result: only CLI is published to npm, with bundled server/client artifacts and registry-compatible dependency ranges.
 
 ## 6. Release Preparation Runbook
 1. Verify release package

--- a/scripts/ci/pack-cli-tarball.mjs
+++ b/scripts/ci/pack-cli-tarball.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { execSync } from 'child_process';
+import { spawnSync } from 'child_process';
 import { appendFileSync, mkdirSync } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -12,27 +12,39 @@ const tempDir = path.join(rootDir, '.tmp');
 
 mkdirSync(tempDir, { recursive: true });
 
-const output = execSync(
-    `npm pack --pack-destination "${tempDir}"`,
+const result = spawnSync(
+    'pnpm',
+    ['--dir', cliDir, 'pack', '--pack-destination', tempDir],
     {
-        cwd: cliDir,
+        cwd: rootDir,
         encoding: 'utf8',
         stdio: ['ignore', 'pipe', 'inherit'],
         env: process.env
     }
 );
 
+if (result.error) {
+    throw result.error;
+}
+
+if (result.status !== 0) {
+    throw new Error(`pnpm pack failed with exit code ${result.status}`);
+}
+
+const output = result.stdout;
+
 const lines = output
     .split(/\r?\n/)
     .map(line => line.trim())
     .filter(Boolean);
 
-const tarball = lines[lines.length - 1];
+const tarball = lines.findLast(line => line.endsWith('.tgz'));
 if (!tarball) {
-    throw new Error('Failed to resolve packed tarball filename.');
+    throw new Error('Failed to resolve packed tarball path.');
 }
 
-const relativePath = path.posix.join('.tmp', tarball);
+const tarballPath = path.isAbsolute(tarball) ? tarball : path.join(tempDir, tarball);
+const relativePath = path.relative(rootDir, tarballPath).split(path.sep).join(path.posix.sep);
 console.log(`Tarball: ${relativePath}`);
 
 if (process.env.GITHUB_OUTPUT) {


### PR DESCRIPTION
## :dart: Goal
Fix CLI release packaging so npm/npx consumers can install the published package when workspace dependencies use pnpm `catalog:` ranges.

## :hammer_and_wrench: Core Changes
- Use `pnpm pack` in `scripts/ci/pack-cli-tarball.mjs` so `catalog:` dependencies are resolved in the generated tarball.
- Publish the packed tarball in `RELEASE.yml` with `npm publish <tarball> --provenance --access public`.
- Update the release strategy doc to describe the tarball-based publish flow.

## :test_tube: Verification
- `git diff --check`
- `node scripts/ci/pack-cli-tarball.mjs`
- Verified packed `package.json` has no `catalog:` dependency values.
- `CLI_SMOKE_PORT=6684 node scripts/ci/smoke-cli-npx.mjs .tmp/ocean-brain-0.7.3.tgz`
