### PR TITLE
🧪 Split E2E release workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,9 +39,3 @@ jobs:
 
       - name: Build
         run: pnpm build
-
-      - name: Install Playwright browsers
-        run: pnpm exec playwright install --with-deps chromium
-
-      - name: E2E
-        run: pnpm test:e2e

--- a/.github/workflows/E2E.yml
+++ b/.github/workflows/E2E.yml
@@ -1,0 +1,31 @@
+name: E2E
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  e2e:
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'chore/release-v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install pnpm
+        run: npm install -g pnpm@10.25.0
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: E2E
+        run: pnpm test:e2e

--- a/.github/workflows/RELEASE_PR.yml
+++ b/.github/workflows/RELEASE_PR.yml
@@ -101,11 +101,13 @@ jobs:
 
           ## :test_tube: Verification Guide
           - GitHub Actions: required PR CI (`lint`, `type-check`, `build`) must pass.
+          - GitHub Actions: `E2E` must pass for `${{ steps.version.outputs.branch }}`.
           - GitHub Actions: `CLI_SMOKE` must pass for `${{ steps.version.outputs.branch }}`.
           - After merge and tag push, monitor the `RELEASE` workflow.
 
           ## :white_check_mark: Checklist
           - [ ] Required PR CI passed
+          - [ ] `E2E` passed
           - [ ] `CLI_SMOKE` passed
           - [ ] Expected tag confirmed: `${{ steps.version.outputs.tag }}`
           - [ ] Release notes will be finalized after the `RELEASE` workflow creates the GitHub Release

--- a/docs/process/DEPLOYMENT_RELEASE_STRATEGY.md
+++ b/docs/process/DEPLOYMENT_RELEASE_STRATEGY.md
@@ -71,8 +71,8 @@ git push origin v0.3.1
 
 ## 6. Release Preparation Runbook
 1. Verify release package
-- Required: latest `CLI_SMOKE` workflow is green for the release target PR or commit.
-- Required before tagging: confirm the release commit on `main` has already passed the required PR CI (`lint`, `type-check`, `build`). The tag-triggered `RELEASE` workflow publishes artifacts; it is not a replacement for main-branch quality validation.
+- Required: latest `E2E` and `CLI_SMOKE` workflows are green for the release target PR or commit.
+- Required before tagging: confirm the release commit on `main` has already passed the required PR CI (`lint`, `type-check`, `build`) plus release-only `E2E` and `CLI_SMOKE`. The tag-triggered `RELEASE` workflow publishes artifacts; it is not a replacement for main-branch quality validation.
 
 2. Collect unreleased changes before version bump
 - Commit list:
@@ -99,6 +99,7 @@ git push origin v0.3.1
 
 5. Verify and merge the release PR to `main`
 - Required PR CI (`lint`, `type-check`, `build`) must pass.
+- `E2E` must pass on the `chore/release-v<version>` release PR branch.
 - `CLI_SMOKE` must pass on the `chore/release-v<version>` release PR branch.
 - Version bump must remain a separate PR. Direct release bumps on `main` are not allowed.
 

--- a/docs/process/DEV_CONVENTION.md
+++ b/docs/process/DEV_CONVENTION.md
@@ -36,6 +36,7 @@ Updated: 2026-06-05
 - Server start script includes `prisma migrate deploy`.
 - Use `node scripts/release/prepublish.mjs` for release artifact preparation.
 - CLI publish validation is covered by `CLI_SMOKE` CI.
+- Browser E2E validation is split into the `E2E` workflow and is required for release PRs or manual verification, not every PR.
 
 ## 6. Related Documents
 - Git rules: `docs/process/GIT_CONVENTION.md`


### PR DESCRIPTION
## :dart: Goal
Reduce default PR CI cost by moving browser E2E out of the main CI workflow while keeping it required for release verification.

## :hammer_and_wrench: Core Changes
- Remove Playwright install and `pnpm test:e2e` from `CI.yml`.
- Add a dedicated `E2E.yml` workflow.
- Run E2E for `workflow_dispatch` or release PR branches (`chore/release-v*`).
- Update release PR checklist and process docs to require E2E for releases.

## :brain: Key Decisions
- Normal PR CI stays focused on encoding, prisma generate, lint, type-check, tests, and build.
- Browser E2E remains available manually and required in the release path.

## :test_tube: Verification Guide
- `git diff --check`
- GitHub Actions: CI should pass without E2E steps.

## :white_check_mark: Checklist
- [ ] CI passed
- [ ] E2E release requirement documented
