### PR TITLE
🚦 Verify published release artifacts

### DIFF
--- a/.github/workflows/RELEASE.yml
+++ b/.github/workflows/RELEASE.yml
@@ -44,13 +44,46 @@ jobs:
       - name: Publish ocean-brain
         run: npm publish "${{ steps.pack.outputs.path }}" --provenance --access public
 
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+  verify-npm:
+    needs: publish-npm
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
-          generate_release_notes: true
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      - name: Upgrade npm for npx verification
+        run: npm install -g npm@11.11.0
+
+      - name: Wait for npm package propagation
+        shell: bash
+        run: |
+          for attempt in {1..30}; do
+            if npm view "ocean-brain@${{ steps.version.outputs.version }}" version; then
+              exit 0
+            fi
+
+            echo "npm package is not visible yet ($attempt/30); retrying in 10s..."
+            sleep 10
+          done
+
+          echo "npm package did not become visible: ocean-brain@${{ steps.version.outputs.version }}" >&2
+          exit 1
+
+      - name: Verify published npx package
+        run: CLI_SMOKE_PORT=6685 node scripts/ci/smoke-cli-npx.mjs "ocean-brain@${{ steps.version.outputs.version }}"
 
   publish-docker:
-    needs: publish-npm
+    needs: verify-npm
     strategy:
       matrix:
         include:
@@ -133,3 +166,29 @@ jobs:
             -t ${{ env.IMAGE }}:${{ steps.version.outputs.version }} \
             -t ${{ env.IMAGE }}:latest \
             $(printf '${{ env.IMAGE }}@sha256:%s ' *)
+
+  verify-docker:
+    needs: publish-docker-manifest
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Verify published Docker image
+        run: node scripts/ci/smoke-docker-image.mjs "${{ env.IMAGE }}:${{ steps.version.outputs.version }}"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true

--- a/docs/process/DEPLOYMENT_RELEASE_STRATEGY.md
+++ b/docs/process/DEPLOYMENT_RELEASE_STRATEGY.md
@@ -50,17 +50,27 @@ git push origin v0.3.1
 - Packs the CLI with `pnpm pack` so workspace `catalog:` dependencies are resolved in the tarball.
 - Publishes that tarball with `npm publish --provenance --access public`.
 - Uses npm trusted publishing (OIDC) via GitHub Actions
-- Creates a GitHub Release with auto-generated notes (`generate_release_notes: true`)
 
-2. `publish-docker`
+2. `verify-npm`
 - Runs after successful `publish-npm`
+- Waits for `ocean-brain@<version>` to become visible on npm with retry before verification.
+- Runs `npx ocean-brain@<version>` smoke verification against the actually published package.
+
+3. `publish-docker`
+- Runs only after successful `verify-npm`
 - Extracts version from tag (`vX.Y.Z` -> `X.Y.Z`)
 - Builds and pushes per architecture via DockerHub
 - Requires `DOCKERHUB_USERNAME`, `DOCKERHUB_TOKEN`
 
-3. `publish-docker-manifest`
+4. `publish-docker-manifest`
 - Combines architecture digests into one manifest
 - Pushes final tags: `<version>`, `latest`
+
+5. `verify-docker`
+- Runs after successful `publish-docker-manifest`
+- Pulls `baealex/ocean-brain:<version>` with retry to tolerate registry propagation delay.
+- Runs the published Docker image and verifies the web shell, auth session endpoint, and GraphQL endpoint.
+- Creates the GitHub Release with auto-generated notes (`generate_release_notes: true`) only after Docker verification passes.
 
 ## 5. Prepublish Build Strategy
 - `scripts/release/prepublish.mjs` standardizes release artifacts.
@@ -123,10 +133,10 @@ git push origin v<version>
 gh run list --workflow RELEASE.yml --limit 5
 ```
 
-- Wait for npm publish, Docker publish, and manifest jobs to finish.
+- Wait for npm publish, npm verification, Docker publish, manifest, and Docker verification jobs to finish.
 
 8. Finalize GitHub Release note
-- Open the created release page after `RELEASE` creates it.
+- Open the created release page after `verify-docker` creates it.
 - For patch releases, start from GitHub generated notes and preserve the PR-linked bullet format.
 - For minor and major releases, treat auto-generated notes as a draft and replace the body with the final note before sharing the release externally.
 

--- a/scripts/ci/smoke-cli-npx.mjs
+++ b/scripts/ci/smoke-cli-npx.mjs
@@ -6,8 +6,18 @@ import os from 'os';
 import path from 'path';
 import { pathToFileURL } from 'url';
 
-const [, , tarballArg] = process.argv;
-const tarballPath = tarballArg ? path.resolve(tarballArg) : null;
+const [, , packageArg] = process.argv;
+
+function resolveNpxPackageSpec(spec) {
+    const looksLikePath = spec.endsWith('.tgz')
+        || spec.startsWith('.')
+        || spec.startsWith('/')
+        || /^[A-Za-z]:[\\/]/.test(spec);
+
+    return looksLikePath ? path.resolve(spec) : spec;
+}
+
+const packageSpec = packageArg ? resolveNpxPackageSpec(packageArg) : null;
 const host = '127.0.0.1';
 const port = Number(process.env.CLI_SMOKE_PORT ?? '6683');
 const rootUrl = `http://${host}:${port}`;
@@ -46,11 +56,11 @@ export function extractLocalAssetPaths(html) {
         .filter(assetPath => assetPath.startsWith('/assets/'));
 }
 
-export function buildSmokeScenarios(resolvedTarballPath) {
+export function buildSmokeScenarios(resolvedPackageSpec) {
     const baseArgs = [
         '--yes',
         '--package',
-        resolvedTarballPath,
+        resolvedPackageSpec,
         'ocean-brain',
         'serve',
         '--port',
@@ -415,13 +425,13 @@ async function runScenario(scenario) {
 }
 
 async function main() {
-    if (!tarballPath) {
-        console.error('Usage: node scripts/ci/smoke-cli-npx.mjs <path-to-cli-tarball>');
+    if (!packageSpec) {
+        console.error('Usage: node scripts/ci/smoke-cli-npx.mjs <path-to-cli-tarball-or-package-spec>');
         process.exit(1);
     }
 
     try {
-        for (const scenario of buildSmokeScenarios(tarballPath)) {
+        for (const scenario of buildSmokeScenarios(packageSpec)) {
             await runScenario(scenario);
         }
         console.log('CLI smoke test passed.');
@@ -430,7 +440,7 @@ async function main() {
     }
 }
 
-if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
     main()
         .then(() => {
             process.exit(0);

--- a/scripts/ci/smoke-docker-image.mjs
+++ b/scripts/ci/smoke-docker-image.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'child_process';
+
+const [, , image] = process.argv;
+const host = '127.0.0.1';
+const hostPort = Number(process.env.DOCKER_SMOKE_PORT ?? '6686');
+const rootUrl = `http://${host}:${hostPort}`;
+const containerName = `ocean-brain-smoke-${process.pid}-${Date.now()}`;
+const retryAttempts = Number(process.env.DOCKER_SMOKE_PULL_ATTEMPTS ?? '20');
+const retryDelayMs = Number(process.env.DOCKER_SMOKE_PULL_DELAY_MS ?? '15000');
+const readyTimeoutMs = Number(process.env.DOCKER_SMOKE_READY_TIMEOUT_MS ?? '120000');
+
+const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+
+function run(command, args, options = {}) {
+    const result = spawnSync(command, args, {
+        encoding: 'utf8',
+        stdio: options.stdio ?? 'inherit',
+        env: process.env
+    });
+
+    if (result.error) throw result.error;
+    if (result.status !== 0) {
+        throw new Error(`${command} ${args.join(' ')} failed with exit code ${result.status}`);
+    }
+
+    return result;
+}
+
+async function pullWithRetry() {
+    for (let attempt = 1; attempt <= retryAttempts; attempt++) {
+        const result = spawnSync('docker', ['pull', image], {
+            encoding: 'utf8',
+            stdio: 'inherit',
+            env: process.env
+        });
+
+        if (result.status === 0) return;
+        if (attempt === retryAttempts) {
+            throw new Error(`docker pull failed after ${retryAttempts} attempts: ${image}`);
+        }
+
+        console.log(`docker pull did not succeed yet (${attempt}/${retryAttempts}); retrying in ${retryDelayMs}ms...`);
+        await sleep(retryDelayMs);
+    }
+}
+
+async function waitForReady() {
+    const deadline = Date.now() + readyTimeoutMs;
+
+    while (Date.now() < deadline) {
+        try {
+            const response = await fetch(`${rootUrl}/api/auth/session`, {
+                signal: AbortSignal.timeout(3000)
+            });
+            if (response.status === 200) return;
+        } catch {
+            // Container is not ready yet.
+        }
+
+        await sleep(1000);
+    }
+
+    throw new Error(`Docker image did not become ready within ${readyTimeoutMs}ms`);
+}
+
+async function assertOpenMode() {
+    const sessionResponse = await fetch(`${rootUrl}/api/auth/session`, {
+        signal: AbortSignal.timeout(5000)
+    });
+    if (sessionResponse.status !== 200) {
+        throw new Error(`/api/auth/session returned HTTP ${sessionResponse.status}`);
+    }
+
+    const session = await sessionResponse.json();
+    if (session.mode !== 'open' || session.authRequired !== false) {
+        throw new Error(`/api/auth/session returned unexpected payload: ${JSON.stringify(session)}`);
+    }
+}
+
+async function assertClientShell() {
+    const response = await fetch(`${rootUrl}/`, {
+        signal: AbortSignal.timeout(5000)
+    });
+    if (response.status !== 200) {
+        throw new Error(`/ returned HTTP ${response.status}`);
+    }
+
+    const html = await response.text();
+    if (!html.includes('id="root"')) {
+        throw new Error('/ did not return the SPA root element');
+    }
+}
+
+async function assertGraphql() {
+    const response = await fetch(`${rootUrl}/graphql`, {
+        method: 'POST',
+        signal: AbortSignal.timeout(5000),
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+            query: '{ allImages(pagination: {limit: 1, offset: 0}) { totalCount } }'
+        })
+    });
+
+    if (response.status !== 200) {
+        throw new Error(`/graphql returned HTTP ${response.status}`);
+    }
+
+    const bodyText = await response.text();
+    if (bodyText.includes('"errors"')) {
+        throw new Error(`GraphQL returned errors: ${bodyText}`);
+    }
+}
+
+function cleanup() {
+    spawnSync('docker', ['logs', containerName], { stdio: 'inherit' });
+    spawnSync('docker', ['rm', '-f', containerName], { stdio: 'ignore' });
+}
+
+async function main() {
+    if (!image) {
+        console.error('Usage: node scripts/ci/smoke-docker-image.mjs <image>');
+        process.exit(1);
+    }
+
+    await pullWithRetry();
+
+    try {
+        run('docker', [
+            'run',
+            '--rm',
+            '--detach',
+            '--name', containerName,
+            '--publish', `${host}:${hostPort}:6683`,
+            '--env', 'OCEAN_BRAIN_ALLOW_INSECURE_NO_AUTH=true',
+            image
+        ]);
+
+        await waitForReady();
+        await assertOpenMode();
+        await assertClientShell();
+        await assertGraphql();
+        console.log(`Docker smoke test passed: ${image}`);
+    } finally {
+        cleanup();
+    }
+}
+
+main().catch(error => {
+    console.error(error);
+    cleanup();
+    process.exit(1);
+});


### PR DESCRIPTION
## :dart: Goal
Make the release workflow verify the actual published npm package and Docker image before considering a release complete.

## :hammer_and_wrench: Core Changes
- Add `verify-npm` after `publish-npm` and before Docker publishing.
- Wait for npm registry propagation with retry before running published-package verification.
- Extend the npx smoke script so it can verify either a local tarball or a package spec like `ocean-brain@0.7.4`.
- Add Docker image smoke verification after the multi-arch manifest is pushed.
- Move GitHub Release creation to the end of Docker verification.
- Update the release strategy documentation with the new pipeline order.

## :brain: Key Decisions
- Docker publishing is gated by successful npm verification.
- Docker verification includes pull retry to tolerate registry propagation.
- Post-publish checks stay focused on distribution artifact smoke, not full E2E.

## :test_tube: Verification Guide
- `node --check scripts/ci/smoke-cli-npx.mjs`
- `node --check scripts/ci/smoke-docker-image.mjs`
- `node -e "import('./scripts/ci/smoke-cli-npx.mjs').then(m=>console.log(m.buildSmokeScenarios('ocean-brain@0.7.4')[0].args.slice(0,4).join(' ')))"`
- `git diff --check`

## :white_check_mark: Checklist
- [ ] CI passed
- [ ] Release workflow order reviewed
