### PR TITLE
🧪 Build app before E2E

### DIFF
--- a/.github/workflows/E2E.yml
+++ b/.github/workflows/E2E.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Build app
+        run: pnpm build
+
       - name: Install Playwright browsers
         run: pnpm exec playwright install --with-deps chromium
 


### PR DESCRIPTION
## :dart: Goal
Fix the split E2E workflow so it prepares the production client/server artifacts before running Playwright.

## :hammer_and_wrench: Core Changes
- Add `pnpm build` before Playwright browser install and `pnpm test:e2e`.

## :brain: Key Decisions
- `playwright.config.ts` copies `packages/client/dist` into `packages/server/client/dist`, so the E2E workflow must build first after being split out from CI.

## :test_tube: Verification Guide
- `git diff --check`
- GitHub Actions: E2E should no longer fail with missing `packages/client/dist` on release PR branches.

## :white_check_mark: Checklist
- [ ] CI passed
