### PR TITLE
🪟 Resolve pnpm command on Windows smoke

### DIFF
--- a/scripts/ci/pack-cli-tarball.mjs
+++ b/scripts/ci/pack-cli-tarball.mjs
@@ -12,8 +12,10 @@ const tempDir = path.join(rootDir, '.tmp');
 
 mkdirSync(tempDir, { recursive: true });
 
+const pnpmBin = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm';
+
 const result = spawnSync(
-    'pnpm',
+    pnpmBin,
     ['--dir', cliDir, 'pack', '--pack-destination', tempDir],
     {
         cwd: rootDir,


### PR DESCRIPTION
## :dart: Goal
Fix Windows CLI_SMOKE after switching CLI packaging from `npm pack` to `pnpm pack`.

## :hammer_and_wrench: Core Changes
- Resolve the pnpm executable as `pnpm.cmd` on Windows and `pnpm` elsewhere in `scripts/ci/pack-cli-tarball.mjs`.

## :brain: Key Decisions
- Keep using `spawnSync` with explicit argv so shell quoting is not required.
- Only adjust executable resolution; packaging behavior stays unchanged.

## :test_tube: Verification Guide
- `git diff --check`
- `node --check scripts/ci/pack-cli-tarball.mjs`
- GitHub Actions: Windows `CLI_SMOKE` should pass.

## :white_check_mark: Checklist
- [ ] CI passed
- [ ] Windows `CLI_SMOKE` passed on release branch after this is merged
