### PR TITLE
🐛 Resolve version metadata from server

### DIFF
--- a/packages/client/src/modules/app-version.ts
+++ b/packages/client/src/modules/app-version.ts
@@ -1,5 +1,4 @@
 export const OCEAN_BRAIN_RELEASES_URL = 'https://github.com/baealex/ocean-brain/releases';
-export const OCEAN_BRAIN_VERSION = __OCEAN_BRAIN_VERSION__;
 
 export const formatVersionLabel = (version: string) => {
     return /^\d+\.\d+\.\d+/.test(version) ? `v${version}` : version;

--- a/packages/client/src/modules/local-demo/client.ts
+++ b/packages/client/src/modules/local-demo/client.ts
@@ -1,5 +1,5 @@
 import type { McpAdminStatus } from '~/apis/mcp-admin.api';
-import { formatMcpVersionRequirement, OCEAN_BRAIN_RELEASES_URL, OCEAN_BRAIN_VERSION } from '~/modules/app-version';
+import { OCEAN_BRAIN_RELEASES_URL } from '~/modules/app-version';
 import type { GraphQueryRequest, GraphQueryResponse } from '../graph-query-types';
 import { cacheLocalPlugin } from './plugins/cache';
 import { imagesLocalPlugin } from './plugins/images';
@@ -30,9 +30,9 @@ const graphHandlers = localDemoPlugins.reduce<Record<string, LocalGraphHandler>>
 const withLocalDemoMcpServerInfo = (mcp: Omit<McpAdminStatus, 'server'>): McpAdminStatus => ({
     ...mcp,
     server: {
-        version: OCEAN_BRAIN_VERSION,
+        version: 'local-demo',
         releaseUrl: OCEAN_BRAIN_RELEASES_URL,
-        mcpVersionRequirement: formatMcpVersionRequirement(OCEAN_BRAIN_VERSION),
+        mcpVersionRequirement: 'unknown',
     },
 });
 

--- a/packages/client/src/modules/local-demo/mcp-status.spec.ts
+++ b/packages/client/src/modules/local-demo/mcp-status.spec.ts
@@ -1,11 +1,11 @@
 import { fetchLocalDemoMcpAdminStatus } from './client';
 
 describe('fetchLocalDemoMcpAdminStatus', () => {
-    it('returns build version metadata for local-only demo builds', async () => {
+    it('returns explicit local-only demo version metadata', async () => {
         const status = await fetchLocalDemoMcpAdminStatus();
 
-        expect(status.server.version).toMatch(/^\d+\.\d+\.\d+/);
-        expect(status.server.mcpVersionRequirement).toMatch(/^\d+\.\d+\.x$/);
+        expect(status.server.version).toBe('local-demo');
+        expect(status.server.mcpVersionRequirement).toBe('unknown');
         expect(status.server.releaseUrl).toBe('https://github.com/baealex/ocean-brain/releases');
     });
 });

--- a/packages/client/src/pages/setting/index.tsx
+++ b/packages/client/src/pages/setting/index.tsx
@@ -4,12 +4,7 @@ import { fetchMcpAdminStatus } from '~/apis/mcp-admin.api';
 import * as Icon from '~/components/icon';
 import { PageLayout } from '~/components/shared';
 import { Text } from '~/components/ui';
-import {
-    formatMcpVersionRequirement,
-    formatVersionLabel,
-    OCEAN_BRAIN_RELEASES_URL,
-    OCEAN_BRAIN_VERSION,
-} from '~/modules/app-version';
+import { formatVersionLabel, OCEAN_BRAIN_RELEASES_URL } from '~/modules/app-version';
 import {
     SETTINGS_MANAGE_IMAGE_ROUTE,
     SETTINGS_MCP_ROUTE,
@@ -23,15 +18,11 @@ const mcpAdminStatusQueryKey = ['mcp-admin', 'status'] as const;
 
 const Setting = () => {
     const { theme, toggleTheme } = useTheme((state) => state);
-    const { data: status } = useQuery({
+    const { data: status, isLoading: isStatusLoading } = useQuery({
         queryKey: mcpAdminStatusQueryKey,
         queryFn: fetchMcpAdminStatus,
     });
-    const versionInfo = status?.server ?? {
-        version: OCEAN_BRAIN_VERSION,
-        releaseUrl: OCEAN_BRAIN_RELEASES_URL,
-        mcpVersionRequirement: formatMcpVersionRequirement(OCEAN_BRAIN_VERSION),
-    };
+    const versionInfo = status?.server;
     const itemClassName =
         'focus-ring-soft surface-base group flex items-start justify-between gap-3.5 px-4 py-3.5 text-left text-fg-default outline-none transition-colors hover:bg-hover-subtle';
     const leadingClassName =
@@ -39,7 +30,12 @@ const Setting = () => {
     const iconClassName = 'h-6 w-6';
     const sectionLabelClassName = 'text-fg-tertiary';
     const contentClassName = 'min-w-0 flex flex-col gap-0.5 pt-0.5';
-    const versionLabel = formatVersionLabel(versionInfo.version);
+    const versionLabel = versionInfo
+        ? formatVersionLabel(versionInfo.version)
+        : isStatusLoading
+          ? 'checking…'
+          : 'unknown';
+    const releasesUrl = versionInfo?.releaseUrl ?? OCEAN_BRAIN_RELEASES_URL;
 
     return (
         <PageLayout title="Settings" description="Manage display, workspace tools, and advanced connections">
@@ -174,7 +170,7 @@ const Setting = () => {
                 <Text as="p" variant="meta" tone="tertiary" className="border-t border-border-subtle pt-4">
                     Ocean Brain {versionLabel} ·{' '}
                     <a
-                        href={versionInfo.releaseUrl}
+                        href={releasesUrl}
                         target="_blank"
                         rel="noreferrer"
                         className="font-medium text-fg-secondary underline-offset-4 hover:underline"

--- a/packages/client/src/vite-env.d.ts
+++ b/packages/client/src/vite-env.d.ts
@@ -7,5 +7,3 @@ interface ImportMetaEnv {
 interface ImportMeta {
     readonly env: ImportMetaEnv;
 }
-
-declare const __OCEAN_BRAIN_VERSION__: string;

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -1,6 +1,5 @@
 import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
-import { readFileSync } from 'fs';
 import path from 'path';
 import svgr from 'vite-plugin-svgr';
 import { defineConfig } from 'vitest/config';
@@ -18,9 +17,6 @@ const mcpAdminAdapterPath = isLocalOnlyDemoBuild
 const imageUploadAdapterPath = isLocalOnlyDemoBuild
     ? './src/apis/image-upload-adapter.local.ts'
     : './src/apis/image-upload-adapter.ts';
-const cliPackageJson = JSON.parse(readFileSync(path.resolve(__dirname, '../cli/package.json'), 'utf-8')) as {
-    version: string;
-};
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -51,9 +47,6 @@ export default defineConfig({
             },
             { find: '~', replacement: path.resolve(__dirname, './src') },
         ],
-    },
-    define: {
-        __OCEAN_BRAIN_VERSION__: JSON.stringify(cliPackageJson.version),
     },
     build: {
         sourcemap: false,

--- a/packages/server/src/modules/app-version.test.ts
+++ b/packages/server/src/modules/app-version.test.ts
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { getOceanBrainVersionInfo, parseMajorMinorVersion, resolveOceanBrainVersion } from './app-version.js';
+
+test('parseMajorMinorVersion accepts semantic version strings with optional prefix and metadata', () => {
+    assert.deepEqual(parseMajorMinorVersion('v1.2.3'), { major: 1, minor: 2 });
+    assert.deepEqual(parseMajorMinorVersion('1.2.3-beta.1'), { major: 1, minor: 2 });
+    assert.equal(parseMajorMinorVersion('local-demo'), null);
+});
+
+test('resolveOceanBrainVersion prefers package metadata over environment overrides', () => {
+    const previousVersion = process.env.OCEAN_BRAIN_VERSION;
+    process.env.OCEAN_BRAIN_VERSION = '99.99.99';
+
+    try {
+        assert.notEqual(resolveOceanBrainVersion(), '99.99.99');
+    } finally {
+        if (previousVersion === undefined) {
+            delete process.env.OCEAN_BRAIN_VERSION;
+        } else {
+            process.env.OCEAN_BRAIN_VERSION = previousVersion;
+        }
+    }
+});
+
+test('getOceanBrainVersionInfo returns server-owned release metadata', () => {
+    const info = getOceanBrainVersionInfo();
+
+    assert.match(info.version, /^\d+\.\d+\.\d+/);
+    assert.match(info.mcpVersionRequirement, /^\d+\.\d+\.x$/);
+    assert.equal(info.releaseUrl, 'https://github.com/baealex/ocean-brain/releases');
+});

--- a/packages/server/src/modules/app-version.ts
+++ b/packages/server/src/modules/app-version.ts
@@ -51,15 +51,15 @@ const getVersionCandidatePaths = () => {
 };
 
 export const resolveOceanBrainVersion = () => {
-    if (process.env.OCEAN_BRAIN_VERSION) {
-        return normalizeVersion(process.env.OCEAN_BRAIN_VERSION);
-    }
-
     for (const candidatePath of getVersionCandidatePaths()) {
         const version = readPackageVersion(candidatePath);
         if (version) {
             return normalizeVersion(version);
         }
+    }
+
+    if (process.env.OCEAN_BRAIN_VERSION) {
+        return normalizeVersion(process.env.OCEAN_BRAIN_VERSION);
     }
 
     return '0.0.0';


### PR DESCRIPTION
## :dart: Goal
- Fix the dev/runtime crash caused by client-side `__OCEAN_BRAIN_VERSION__` not being defined.
- Make version metadata come from the running server package instead of client build-time constants.
- Keep npm, Docker, and local workspace execution aligned with the package version that is actually running.

## :hammer_and_wrench: Core Changes
- Remove the client Vite `define` constant and the `__OCEAN_BRAIN_VERSION__` declaration.
- Read version metadata in Settings from the MCP admin status response returned by the server.
- Show `checking…` while server metadata is loading and `unknown` if it cannot be loaded.
- Mark local-only demo metadata explicitly as `local-demo` with an unknown MCP version requirement.
- Prefer server package metadata over `OCEAN_BRAIN_VERSION` environment fallback when resolving the server version.
- Add server tests covering version parsing, package metadata precedence, and release metadata.

## :brain: Key Decisions
- Chose server-owned version metadata as the source of truth because the server package is what npm and Docker actually execute.
- Kept `OCEAN_BRAIN_VERSION` only as a final fallback for unusual packaged layouts where package metadata cannot be read.
- Avoided client build-time environment injection so builds cannot accidentally publish or serve mismatched version metadata.
- Treated this as a patch because it fixes runtime metadata resolution without changing public user-facing contracts.

## :test_tube: Verification Guide
### How to verify
1. Run `pnpm check:encoding`.
2. Run `pnpm --filter client lint`.
3. Run `pnpm --filter @ocean-brain/server lint`.
4. Run `pnpm --filter client type-check`.
5. Run `pnpm --filter client test --run src/pages/setting/index.spec.tsx src/modules/local-demo/mcp-status.spec.ts`.
6. Run `pnpm --filter client build`.
7. Run `pnpm --filter @ocean-brain/server test -- src/modules/app-version.test.ts`.
8. Run `pnpm --filter @ocean-brain/server type-check`.

### Expected result
- All commands pass.
- Client bundles no longer contain or require `__OCEAN_BRAIN_VERSION__`.
- Settings version metadata comes from the server status response when available.
- Local-only demo reports `local-demo` instead of pretending to know a package release version.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Build completed
- [x] Release impact label selected: `release: patch`
