### PR TITLE
✨ Simplify login screen

### DIFF
--- a/packages/server/src/features/auth/http/login-page.html
+++ b/packages/server/src/features/auth/http/login-page.html
@@ -62,11 +62,19 @@
             width: min(392px, 100%);
         }
         .brand {
+            display: flex;
+            align-items: center;
+            gap: 10px;
             margin-bottom: 14px;
             color: var(--fg-tertiary);
             font-size: 12px;
             font-weight: 700;
             line-height: 1.4;
+        }
+        .brand img {
+            width: 28px;
+            height: 28px;
+            border-radius: 8px;
         }
         .panel {
             padding: 24px;
@@ -77,19 +85,16 @@
                 inset 0 1px 0 rgba(255, 255, 255, 0.1),
                 0 1px 4px -2px rgba(23, 29, 38, 0.04);
         }
-        h1 {
-            margin: 0;
-            color: var(--fg-default);
-            font-size: 1.375rem;
-            line-height: 1.3;
-            font-weight: 700;
-        }
-        .lead {
-            margin: 6px 0 22px;
-            color: var(--fg-tertiary);
-            font-size: 0.875rem;
-            line-height: 1.5;
-            font-weight: 500;
+        .sr-only {
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            padding: 0;
+            margin: -1px;
+            overflow: hidden;
+            clip: rect(0, 0, 0, 0);
+            white-space: nowrap;
+            border: 0;
         }
         label {
             display: block;
@@ -124,12 +129,6 @@
             outline: none;
             border-color: var(--border-focus);
             box-shadow: 0 0 0 4px var(--accent-soft-primary);
-        }
-        .hint {
-            margin-top: 10px;
-            color: var(--fg-tertiary);
-            font-size: 0.75rem;
-            line-height: 1.4;
         }
         button {
             width: 100%;
@@ -187,10 +186,9 @@
 </head>
 <body>
     <main class="shell">
-        <div class="brand">Ocean Brain</div>
+        <div class="brand"><img src="/icon.png" alt="" aria-hidden="true" />Ocean Brain</div>
         <section class="panel" aria-labelledby="login-title">
-            <h1 id="login-title">Sign in</h1>
-            <p class="lead">Enter the workspace password to continue.</p>
+            <h1 id="login-title" class="sr-only">Sign in</h1>
             <!-- OCEAN_BRAIN_LOGIN_ERROR -->
             <form method="post" action="/login">
                 <!-- OCEAN_BRAIN_CSRF_INPUT -->
@@ -201,7 +199,6 @@
                 </div>
                 <button type="submit">Sign in</button>
             </form>
-            <div class="hint">This session must be authenticated before the workspace loads.</div>
         </section>
     </main>
 </body>

--- a/packages/server/src/features/auth/http/pages.test.ts
+++ b/packages/server/src/features/auth/http/pages.test.ts
@@ -146,7 +146,8 @@ test('password mode blocks client routes until the server-side login form succee
 
     assert.equal(loginPage.status, 200);
     assert.match(loginPageHtml, /Ocean Brain/);
-    assert.match(loginPageHtml, /Enter the workspace password to continue/);
+    assert.doesNotMatch(loginPageHtml, /Enter the workspace password to continue/);
+    assert.doesNotMatch(loginPageHtml, /This session must be authenticated/);
     assert.match(loginPageHtml, /<form method="post" action="\/login">/);
     assert.match(loginPageHtml, /name="_csrf"/);
     assert.match(loginPageHtml, /name="next" value="\/notes"/);

--- a/tests/e2e/auth-shell.spec.ts
+++ b/tests/e2e/auth-shell.spec.ts
@@ -9,7 +9,7 @@ test('unauthenticated users see the login page and authenticated users load the 
     await page.goto('/');
 
     await expect(page).toHaveURL(/\/login\?next=%2F$/);
-    await expect(page.getByText('Enter the workspace password to continue')).toBeVisible();
+    await expect(page.getByText('Ocean Brain')).toBeVisible();
     await expect(page.getByLabel('Password')).toBeVisible();
     await expect(page.getByRole('button', { name: 'Sign in' })).toBeVisible();
 


### PR DESCRIPTION
## :dart: Goal

- Make the password login page feel lighter with the smallest possible surface change.

## :hammer_and_wrench: Core Changes

- Removed the visible helper copy above and below the login form.
- Added the existing `/icon.png` mark next to the Ocean Brain brand label.
- Hid the duplicated visible `Sign in` heading while keeping it available to assistive technologies.
- Kept the existing server-rendered login form, CSRF field, and next redirect behavior unchanged.

## :brain: Key Decisions

- Avoided a React login migration to keep auth, CSRF, dev proxy, and session recovery behavior untouched.
- Reused the existing login page CSS and design tokens instead of introducing a new visual system.
- Marked this as `release: patch` because it is a backward-compatible UI polish change without a new capability.

## :test_tube: Verification Guide

- `pnpm --filter server test --run src/features/auth/http/pages.test.ts` — passed
- `pnpm --filter server lint` — passed
- `pnpm check:encoding` — passed
- `pnpm build:server && CI=1 pnpm test:e2e tests/e2e/auth-shell.spec.ts` — passed

## :white_check_mark: Checklist

- [x] Login page remains server-rendered.
- [x] Auth form, CSRF input, and `next` redirect behavior remain unchanged.
- [x] Visible login copy is reduced to the brand, password field, and sign-in button.
- [x] Exactly one release impact label is applied.
