### PR TITLE
✨ Decouple MCP compatibility from app version

### DIFF
--- a/docs/process/DEPLOYMENT_RELEASE_STRATEGY.md
+++ b/docs/process/DEPLOYMENT_RELEASE_STRATEGY.md
@@ -91,7 +91,13 @@ git push origin v0.3.1
 - PR merge list:
   `git log v<previous-version>..HEAD --merges --pretty=format:"%s"`
 
-3. Create the release PR from GitHub Actions
+3. Confirm MCP compatibility impact
+- Check whether the release contains an incompatible MCP contract change.
+- MCP contract changes include tool input/output shape changes, removed/renamed GraphQL fields used by MCP, required auth/header changes, or changed read/write behavior.
+- If MCP compatibility is not broken, do not change `oceanBrain.mcpCompatibilityVersion`.
+- If MCP compatibility is broken, update `oceanBrain.mcpCompatibilityVersion` in `packages/cli/package.json` intentionally and document the required MCP compatibility range in the release PR.
+
+4. Create the release PR from GitHub Actions
 - Go to **Actions → RELEASE PR → Run workflow**.
 - Select the semver release type:
   - `patch`: `0.7.3` → `0.7.4`
@@ -103,18 +109,19 @@ git push origin v0.3.1
 - The workflow opens a release PR titled `🔖 Bump version to <version>`.
 - Do not create the release branch or release bump commit from a local checkout in the normal release flow.
 
-4. Review the release PR
+5. Review the release PR
 - Confirm the expected tag is `v<version>`.
 - Confirm exactly one release impact label is applied: `release: patch`, `release: minor`, or `release: major`.
 - Confirm the release PR contains the verification plan.
+- Confirm `oceanBrain.mcpCompatibilityVersion` changed only when MCP compatibility is intentionally broken.
 
-5. Verify and merge the release PR to `main`
+6. Verify and merge the release PR to `main`
 - Required PR CI (`lint`, `type-check`, `build`) must pass.
 - `E2E` must pass on the `chore/release-v<version>` release PR branch.
 - `CLI_SMOKE` must pass on the `chore/release-v<version>` release PR branch.
 - Version bump must remain a separate PR. Direct release bumps on `main` are not allowed.
 
-6. Trigger release explicitly from merged `main`
+7. Trigger release explicitly from merged `main`
 
 ```bash
 git checkout main
@@ -126,7 +133,7 @@ git push origin v<version>
 - This tag push is the supported release trigger.
 - Do not treat PR merge itself as deployment.
 
-7. Monitor the `RELEASE` workflow
+8. Monitor the `RELEASE` workflow
 - Example:
 
 ```bash
@@ -135,7 +142,7 @@ gh run list --workflow RELEASE.yml --limit 5
 
 - Wait for npm publish, npm verification, Docker publish, manifest, and Docker verification jobs to finish.
 
-8. Finalize GitHub Release note
+9. Finalize GitHub Release note
 - Open the created release page after `verify-docker` creates it.
 - For patch releases, start from GitHub generated notes and preserve the PR-linked bullet format.
 - For minor and major releases, treat auto-generated notes as a draft and replace the body with the final note before sharing the release externally.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -49,5 +49,8 @@
         "sqlite3": "catalog:",
         "winston": "catalog:",
         "zod": "^3.25.0"
+    },
+    "oceanBrain": {
+        "mcpCompatibilityVersion": "0.7.0"
     }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -51,6 +51,6 @@
         "zod": "^3.25.0"
     },
     "oceanBrain": {
-        "mcpCompatibilityVersion": "0.7.0"
+        "mcpCompatibilityVersion": "0.8.0"
     }
 }

--- a/packages/cli/src/mcp.ts
+++ b/packages/cli/src/mcp.ts
@@ -18,13 +18,22 @@ import { formatPropertyQueryResponse, type PropertyQueryResult } from './mcp-pro
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(
     fs.readFileSync(path.resolve(__dirname, '..', 'package.json'), 'utf-8')
-) as { version: string };
+) as { oceanBrain?: { mcpCompatibilityVersion?: string }; version: string };
+
+if (!pkg.oceanBrain?.mcpCompatibilityVersion) {
+    throw new Error('Ocean Brain MCP compatibility version is required in package metadata.');
+}
 
 export const OCEAN_BRAIN_MCP_VERSION_HEADER = 'X-Ocean-Brain-MCP-Version';
+export const OCEAN_BRAIN_MCP_COMPATIBILITY_VERSION_HEADER = 'X-Ocean-Brain-MCP-Compatibility-Version';
+export const OCEAN_BRAIN_MCP_CLIENT_VERSION_HEADER = 'X-Ocean-Brain-MCP-Client-Version';
+export const OCEAN_BRAIN_MCP_COMPATIBILITY_VERSION = pkg.oceanBrain.mcpCompatibilityVersion;
 
 export const createMcpRequestHeaders = (token: string | undefined) => ({
     'Content-Type': 'application/json',
-    [OCEAN_BRAIN_MCP_VERSION_HEADER]: pkg.version,
+    [OCEAN_BRAIN_MCP_VERSION_HEADER]: OCEAN_BRAIN_MCP_COMPATIBILITY_VERSION,
+    [OCEAN_BRAIN_MCP_COMPATIBILITY_VERSION_HEADER]: OCEAN_BRAIN_MCP_COMPATIBILITY_VERSION,
+    [OCEAN_BRAIN_MCP_CLIENT_VERSION_HEADER]: pkg.version,
     ...(token ? { Authorization: `Bearer ${token}` } : {})
 });
 

--- a/packages/cli/test/mcp.test.ts
+++ b/packages/cli/test/mcp.test.ts
@@ -1,7 +1,14 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { createMcpRequestHeaders, fetchMcpNoteWriteBaseline, OCEAN_BRAIN_MCP_VERSION_HEADER } from '../src/mcp.js';
+import {
+    createMcpRequestHeaders,
+    fetchMcpNoteWriteBaseline,
+    OCEAN_BRAIN_MCP_CLIENT_VERSION_HEADER,
+    OCEAN_BRAIN_MCP_COMPATIBILITY_VERSION,
+    OCEAN_BRAIN_MCP_COMPATIBILITY_VERSION_HEADER,
+    OCEAN_BRAIN_MCP_VERSION_HEADER,
+} from '../src/mcp.js';
 
 test('fetchMcpNoteWriteBaseline requests the side-effect-free MCP HTTP baseline endpoint', async () => {
     const requests: Array<{
@@ -43,10 +50,12 @@ test('fetchMcpNoteWriteBaseline requests the side-effect-free MCP HTTP baseline 
     ]);
 });
 
-test('createMcpRequestHeaders includes the MCP package version contract header', () => {
+test('createMcpRequestHeaders includes MCP compatibility and client version headers', () => {
     const headers = createMcpRequestHeaders('token-a');
 
     assert.equal(headers['Content-Type'], 'application/json');
     assert.equal(headers.Authorization, 'Bearer token-a');
-    assert.match(headers[OCEAN_BRAIN_MCP_VERSION_HEADER], /^\d+\.\d+\.\d+/);
+    assert.equal(headers[OCEAN_BRAIN_MCP_VERSION_HEADER], OCEAN_BRAIN_MCP_COMPATIBILITY_VERSION);
+    assert.equal(headers[OCEAN_BRAIN_MCP_COMPATIBILITY_VERSION_HEADER], OCEAN_BRAIN_MCP_COMPATIBILITY_VERSION);
+    assert.match(headers[OCEAN_BRAIN_MCP_CLIENT_VERSION_HEADER], /^\d+\.\d+\.\d+/);
 });

--- a/packages/client/src/apis/mcp-admin.types.ts
+++ b/packages/client/src/apis/mcp-admin.types.ts
@@ -10,5 +10,11 @@ export interface McpAdminStatus {
         version: string;
         releaseUrl: string;
         mcpVersionRequirement: string;
+        mcp?: {
+            compatibilityVersion: string;
+            compatibilityRequirement: string;
+            compatibilityVersionHeader: string;
+            clientVersionHeader: string;
+        };
     };
 }

--- a/packages/client/src/modules/local-demo/client.ts
+++ b/packages/client/src/modules/local-demo/client.ts
@@ -33,6 +33,12 @@ const withLocalDemoMcpServerInfo = (mcp: Omit<McpAdminStatus, 'server'>): McpAdm
         version: 'local-demo',
         releaseUrl: OCEAN_BRAIN_RELEASES_URL,
         mcpVersionRequirement: 'unknown',
+        mcp: {
+            compatibilityVersion: 'unknown',
+            compatibilityRequirement: 'unknown',
+            compatibilityVersionHeader: 'X-Ocean-Brain-MCP-Compatibility-Version',
+            clientVersionHeader: 'X-Ocean-Brain-MCP-Client-Version',
+        },
     },
 });
 

--- a/packages/client/src/modules/local-demo/mcp-status.spec.ts
+++ b/packages/client/src/modules/local-demo/mcp-status.spec.ts
@@ -6,6 +6,7 @@ describe('fetchLocalDemoMcpAdminStatus', () => {
 
         expect(status.server.version).toBe('local-demo');
         expect(status.server.mcpVersionRequirement).toBe('unknown');
+        expect(status.server.mcp?.compatibilityRequirement).toBe('unknown');
         expect(status.server.releaseUrl).toBe('https://github.com/baealex/ocean-brain/releases');
     });
 });

--- a/packages/client/src/pages/setting/index.spec.tsx
+++ b/packages/client/src/pages/setting/index.spec.tsx
@@ -29,10 +29,10 @@ const createMcpStatus = (overrides: Partial<McpAdminStatus> = {}): McpAdminStatu
     server: {
         version: '0.7.3',
         releaseUrl: 'https://github.com/baealex/ocean-brain/releases',
-        mcpVersionRequirement: '0.7.x',
+        mcpVersionRequirement: '0.8.x',
         mcp: {
-            compatibilityVersion: '0.7.0',
-            compatibilityRequirement: '0.7.x',
+            compatibilityVersion: '0.8.0',
+            compatibilityRequirement: '0.8.x',
             compatibilityVersionHeader: 'X-Ocean-Brain-MCP-Compatibility-Version',
             clientVersionHeader: 'X-Ocean-Brain-MCP-Client-Version',
         },

--- a/packages/client/src/pages/setting/index.spec.tsx
+++ b/packages/client/src/pages/setting/index.spec.tsx
@@ -30,6 +30,12 @@ const createMcpStatus = (overrides: Partial<McpAdminStatus> = {}): McpAdminStatu
         version: '0.7.3',
         releaseUrl: 'https://github.com/baealex/ocean-brain/releases',
         mcpVersionRequirement: '0.7.x',
+        mcp: {
+            compatibilityVersion: '0.7.0',
+            compatibilityRequirement: '0.7.x',
+            compatibilityVersionHeader: 'X-Ocean-Brain-MCP-Compatibility-Version',
+            clientVersionHeader: 'X-Ocean-Brain-MCP-Client-Version',
+        },
     },
     ...overrides,
 });

--- a/packages/client/src/pages/setting/mcp.spec.tsx
+++ b/packages/client/src/pages/setting/mcp.spec.tsx
@@ -21,10 +21,10 @@ const createMcpStatus = (overrides: Partial<McpAdminStatus> = {}): McpAdminStatu
     server: {
         version: '0.7.3',
         releaseUrl: 'https://github.com/baealex/ocean-brain/releases',
-        mcpVersionRequirement: '0.7.x',
+        mcpVersionRequirement: '0.8.x',
         mcp: {
-            compatibilityVersion: '0.7.0',
-            compatibilityRequirement: '0.7.x',
+            compatibilityVersion: '0.8.0',
+            compatibilityRequirement: '0.8.x',
             compatibilityVersionHeader: 'X-Ocean-Brain-MCP-Compatibility-Version',
             clientVersionHeader: 'X-Ocean-Brain-MCP-Client-Version',
         },
@@ -65,10 +65,10 @@ describe('<McpSetting />', () => {
                 server: {
                     version: '0.8.0',
                     releaseUrl: 'https://github.com/baealex/ocean-brain/releases',
-                    mcpVersionRequirement: '0.7.x',
+                    mcpVersionRequirement: '0.8.x',
                     mcp: {
-                        compatibilityVersion: '0.7.0',
-                        compatibilityRequirement: '0.7.x',
+                        compatibilityVersion: '0.8.0',
+                        compatibilityRequirement: '0.8.x',
                         compatibilityVersionHeader: 'X-Ocean-Brain-MCP-Compatibility-Version',
                         clientVersionHeader: 'X-Ocean-Brain-MCP-Client-Version',
                     },
@@ -78,7 +78,7 @@ describe('<McpSetting />', () => {
 
         renderPage();
 
-        expect(await screen.findByText('MCP compatibility 0.7.x')).toBeInTheDocument();
+        expect(await screen.findByText('MCP compatibility 0.8.x')).toBeInTheDocument();
     });
 
     it('submits enabled toggle and refreshes status', async () => {

--- a/packages/client/src/pages/setting/mcp.spec.tsx
+++ b/packages/client/src/pages/setting/mcp.spec.tsx
@@ -22,6 +22,12 @@ const createMcpStatus = (overrides: Partial<McpAdminStatus> = {}): McpAdminStatu
         version: '0.7.3',
         releaseUrl: 'https://github.com/baealex/ocean-brain/releases',
         mcpVersionRequirement: '0.7.x',
+        mcp: {
+            compatibilityVersion: '0.7.0',
+            compatibilityRequirement: '0.7.x',
+            compatibilityVersionHeader: 'X-Ocean-Brain-MCP-Compatibility-Version',
+            clientVersionHeader: 'X-Ocean-Brain-MCP-Client-Version',
+        },
     },
     ...overrides,
 });
@@ -51,6 +57,28 @@ describe('<McpSetting />', () => {
         renderPage();
 
         expect(await screen.findByLabelText(/ocean brain url/i)).toHaveValue(window.location.origin);
+    });
+
+    it('uses server MCP compatibility requirement instead of app version for CLI guidance', async () => {
+        vi.mocked(mcpAdminApi.fetchMcpAdminStatus).mockResolvedValue(
+            createMcpStatus({
+                server: {
+                    version: '0.8.0',
+                    releaseUrl: 'https://github.com/baealex/ocean-brain/releases',
+                    mcpVersionRequirement: '0.7.x',
+                    mcp: {
+                        compatibilityVersion: '0.7.0',
+                        compatibilityRequirement: '0.7.x',
+                        compatibilityVersionHeader: 'X-Ocean-Brain-MCP-Compatibility-Version',
+                        clientVersionHeader: 'X-Ocean-Brain-MCP-Client-Version',
+                    },
+                },
+            }),
+        );
+
+        renderPage();
+
+        expect(await screen.findByText('MCP compatibility 0.7.x')).toBeInTheDocument();
     });
 
     it('submits enabled toggle and refreshes status', async () => {

--- a/packages/client/src/pages/setting/mcp.tsx
+++ b/packages/client/src/pages/setting/mcp.tsx
@@ -93,14 +93,12 @@ const createConnectionOutput = (clientGuide: ClientGuide, serverUrl: string, tok
     ].join('\n');
 };
 
-const getMcpCliRequirement = (version?: string) => {
-    if (!version) {
-        return 'Ocean Brain CLI';
+const getMcpCompatibilityLabel = (requirement?: string) => {
+    if (!requirement || requirement === 'unknown') {
+        return 'MCP compatibility';
     }
 
-    const [major, minor] = version.split('.');
-
-    return major && minor ? `Ocean Brain CLI v${major}.${minor}.x` : 'Ocean Brain CLI';
+    return `MCP compatibility ${requirement}`;
 };
 
 const clientGuideLabel: Record<ClientGuide, string> = {
@@ -154,7 +152,7 @@ const McpSetting = () => {
     const hasActiveToken = status?.hasActiveToken ?? false;
     const canToggle = !isLoading && !setEnabledMutation.isPending;
     const normalizedTokenFilePath = tokenFilePath.trim() || defaultTokenFilePath;
-    const mcpCliRequirement = getMcpCliRequirement(status?.server.version);
+    const mcpCompatibilityLabel = getMcpCompatibilityLabel(status?.server.mcpVersionRequirement);
     const tokenStatusText = hasActiveToken ? '1 active token' : 'No active token';
     const outputLabel = clientGuide === 'json' ? 'Token file and MCP JSON' : `${clientGuideLabel[clientGuide]} setup`;
     const tokenValue = issuedToken || 'PASTE_TOKEN_HERE';
@@ -252,7 +250,7 @@ const McpSetting = () => {
                             tone="tertiary"
                             className="rounded-full border border-border-subtle bg-hover-subtle px-2.5 py-1"
                         >
-                            {mcpCliRequirement}
+                            {mcpCompatibilityLabel}
                         </Text>
                     </div>
 

--- a/packages/server/src/features/mcp-admin/http/handlers.test.ts
+++ b/packages/server/src/features/mcp-admin/http/handlers.test.ts
@@ -176,7 +176,14 @@ test('POST /api/mcp-admin/enabled toggles enabled state for authenticated sessio
 
     assert.equal(enabled.status, 200);
     assert.equal(enabled.body.enabled, true);
-    assert.equal(typeof (enabled.body.server as { version?: unknown }).version, 'string');
+    const serverInfo = enabled.body.server as {
+        mcp?: { compatibilityRequirement?: unknown };
+        mcpVersionRequirement?: unknown;
+        version?: unknown;
+    };
+    assert.equal(typeof serverInfo.version, 'string');
+    assert.equal(serverInfo.mcpVersionRequirement, '0.7.x');
+    assert.equal(serverInfo.mcp?.compatibilityRequirement, '0.7.x');
 });
 
 test('POST /api/mcp-admin/token/revoke revokes active token for authenticated session', async (t) => {

--- a/packages/server/src/features/mcp-admin/http/handlers.test.ts
+++ b/packages/server/src/features/mcp-admin/http/handlers.test.ts
@@ -182,8 +182,8 @@ test('POST /api/mcp-admin/enabled toggles enabled state for authenticated sessio
         version?: unknown;
     };
     assert.equal(typeof serverInfo.version, 'string');
-    assert.equal(serverInfo.mcpVersionRequirement, '0.7.x');
-    assert.equal(serverInfo.mcp?.compatibilityRequirement, '0.7.x');
+    assert.equal(serverInfo.mcpVersionRequirement, '0.8.x');
+    assert.equal(serverInfo.mcp?.compatibilityRequirement, '0.8.x');
 });
 
 test('POST /api/mcp-admin/token/revoke revokes active token for authenticated session', async (t) => {

--- a/packages/server/src/modules/app-version.test.ts
+++ b/packages/server/src/modules/app-version.test.ts
@@ -34,7 +34,7 @@ test('resolveOceanBrainVersion prefers package metadata over environment overrid
 });
 
 test('resolveMcpCompatibilityVersion reads package compatibility metadata separately from app version', () => {
-    assert.equal(resolveMcpCompatibilityVersion(), '0.7.0');
+    assert.equal(resolveMcpCompatibilityVersion(), '0.8.0');
     assert.notEqual(resolveMcpCompatibilityVersion(), resolveOceanBrainVersion());
 });
 
@@ -57,13 +57,13 @@ test('resolveMcpCompatibilityVersion requires explicit compatibility metadata', 
 test('buildOceanBrainVersionInfo keeps app version and MCP compatibility requirement independent', () => {
     const info = buildOceanBrainVersionInfo({
         version: '0.8.0',
-        mcpCompatibilityVersion: '0.7.0',
+        mcpCompatibilityVersion: '0.8.0',
     });
 
     assert.equal(info.version, '0.8.0');
-    assert.equal(info.mcpVersionRequirement, '0.7.x');
-    assert.equal(info.mcp.compatibilityVersion, '0.7.0');
-    assert.equal(info.mcp.compatibilityRequirement, '0.7.x');
+    assert.equal(info.mcpVersionRequirement, '0.8.x');
+    assert.equal(info.mcp.compatibilityVersion, '0.8.0');
+    assert.equal(info.mcp.compatibilityRequirement, '0.8.x');
 });
 
 test('getOceanBrainVersionInfo returns server-owned release and MCP compatibility metadata', () => {

--- a/packages/server/src/modules/app-version.test.ts
+++ b/packages/server/src/modules/app-version.test.ts
@@ -1,6 +1,16 @@
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import test from 'node:test';
-import { getOceanBrainVersionInfo, parseMajorMinorVersion, resolveOceanBrainVersion } from './app-version.js';
+import {
+    buildOceanBrainVersionInfo,
+    getOceanBrainVersionInfo,
+    parseMajorMinorVersion,
+    resolveMcpCompatibilityVersion,
+    resolveMcpCompatibilityVersionFromPaths,
+    resolveOceanBrainVersion,
+} from './app-version.js';
 
 test('parseMajorMinorVersion accepts semantic version strings with optional prefix and metadata', () => {
     assert.deepEqual(parseMajorMinorVersion('v1.2.3'), { major: 1, minor: 2 });
@@ -23,10 +33,45 @@ test('resolveOceanBrainVersion prefers package metadata over environment overrid
     }
 });
 
-test('getOceanBrainVersionInfo returns server-owned release metadata', () => {
+test('resolveMcpCompatibilityVersion reads package compatibility metadata separately from app version', () => {
+    assert.equal(resolveMcpCompatibilityVersion(), '0.7.0');
+    assert.notEqual(resolveMcpCompatibilityVersion(), resolveOceanBrainVersion());
+});
+
+test('resolveMcpCompatibilityVersion requires explicit compatibility metadata', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ocean-brain-version-'));
+    const packageJsonPath = path.join(tempDir, 'package.json');
+
+    try {
+        fs.writeFileSync(packageJsonPath, JSON.stringify({ version: '9.9.9' }));
+
+        assert.throws(
+            () => resolveMcpCompatibilityVersionFromPaths([packageJsonPath]),
+            /MCP compatibility version is required/,
+        );
+    } finally {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+});
+
+test('buildOceanBrainVersionInfo keeps app version and MCP compatibility requirement independent', () => {
+    const info = buildOceanBrainVersionInfo({
+        version: '0.8.0',
+        mcpCompatibilityVersion: '0.7.0',
+    });
+
+    assert.equal(info.version, '0.8.0');
+    assert.equal(info.mcpVersionRequirement, '0.7.x');
+    assert.equal(info.mcp.compatibilityVersion, '0.7.0');
+    assert.equal(info.mcp.compatibilityRequirement, '0.7.x');
+});
+
+test('getOceanBrainVersionInfo returns server-owned release and MCP compatibility metadata', () => {
     const info = getOceanBrainVersionInfo();
 
     assert.match(info.version, /^\d+\.\d+\.\d+/);
     assert.match(info.mcpVersionRequirement, /^\d+\.\d+\.x$/);
+    assert.equal(info.mcp.compatibilityVersion, resolveMcpCompatibilityVersion());
+    assert.equal(info.mcp.compatibilityRequirement, info.mcpVersionRequirement);
     assert.equal(info.releaseUrl, 'https://github.com/baealex/ocean-brain/releases');
 });

--- a/packages/server/src/modules/app-version.ts
+++ b/packages/server/src/modules/app-version.ts
@@ -4,10 +4,31 @@ import path from 'path';
 import { paths } from '~/paths.js';
 
 export const OCEAN_BRAIN_RELEASES_URL = 'https://github.com/baealex/ocean-brain/releases';
+export const OCEAN_BRAIN_MCP_COMPATIBILITY_VERSION_HEADER = 'X-Ocean-Brain-MCP-Compatibility-Version';
+export const OCEAN_BRAIN_MCP_CLIENT_VERSION_HEADER = 'X-Ocean-Brain-MCP-Client-Version';
 
 interface MajorMinorVersion {
     major: number;
     minor: number;
+}
+
+interface PackageMetadata {
+    oceanBrain?: {
+        mcpCompatibilityVersion?: unknown;
+    };
+    version?: unknown;
+}
+
+export interface OceanBrainVersionInfo {
+    version: string;
+    releaseUrl: string;
+    mcpVersionRequirement: string;
+    mcp: {
+        compatibilityVersion: string;
+        compatibilityRequirement: string;
+        compatibilityVersionHeader: string;
+        clientVersionHeader: string;
+    };
 }
 
 const normalizeVersion = (version: string) => version.trim().replace(/^v/i, '');
@@ -25,19 +46,32 @@ export const parseMajorMinorVersion = (version: string): MajorMinorVersion | nul
     };
 };
 
-export const formatMcpVersionRequirement = (serverVersion: string) => {
-    const parsed = parseMajorMinorVersion(serverVersion);
+export const formatMcpVersionRequirement = (mcpCompatibilityVersion: string) => {
+    const parsed = parseMajorMinorVersion(mcpCompatibilityVersion);
     return parsed ? `${parsed.major}.${parsed.minor}.x` : 'unknown';
 };
 
-const readPackageVersion = (packageJsonPath: string) => {
+const readPackageMetadata = (packageJsonPath: string): PackageMetadata | undefined => {
     try {
-        const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8')) as { version?: unknown };
-        return typeof packageJson.version === 'string' ? packageJson.version : undefined;
+        return JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8')) as PackageMetadata;
     } catch {
         return undefined;
     }
 };
+
+const readPackageVersion = (packageJsonPath: string) => {
+    const packageJson = readPackageMetadata(packageJsonPath);
+    return typeof packageJson?.version === 'string' ? packageJson.version : undefined;
+};
+
+const readPackageMcpCompatibilityVersion = (packageJsonPath: string) => {
+    const packageJson = readPackageMetadata(packageJsonPath);
+    const version = packageJson?.oceanBrain?.mcpCompatibilityVersion;
+    return typeof version === 'string' ? version : undefined;
+};
+
+const createMissingMcpCompatibilityVersionError = () =>
+    new Error('Ocean Brain MCP compatibility version is required in package metadata.');
 
 const getVersionCandidatePaths = () => {
     return Array.from(
@@ -65,12 +99,44 @@ export const resolveOceanBrainVersion = () => {
     return '0.0.0';
 };
 
-export const getOceanBrainVersionInfo = () => {
-    const version = resolveOceanBrainVersion();
+export const resolveMcpCompatibilityVersionFromPaths = (candidatePaths: string[]) => {
+    for (const candidatePath of candidatePaths) {
+        const version = readPackageMcpCompatibilityVersion(candidatePath);
+        if (version) {
+            return normalizeVersion(version);
+        }
+    }
+
+    throw createMissingMcpCompatibilityVersionError();
+};
+
+export const resolveMcpCompatibilityVersion = () => resolveMcpCompatibilityVersionFromPaths(getVersionCandidatePaths());
+
+export const buildOceanBrainVersionInfo = ({
+    mcpCompatibilityVersion,
+    version,
+}: {
+    mcpCompatibilityVersion: string;
+    version: string;
+}): OceanBrainVersionInfo => {
+    const compatibilityVersion = normalizeVersion(mcpCompatibilityVersion);
+    const compatibilityRequirement = formatMcpVersionRequirement(compatibilityVersion);
 
     return {
-        version,
+        version: normalizeVersion(version),
         releaseUrl: OCEAN_BRAIN_RELEASES_URL,
-        mcpVersionRequirement: formatMcpVersionRequirement(version),
+        mcpVersionRequirement: compatibilityRequirement,
+        mcp: {
+            compatibilityVersion,
+            compatibilityRequirement,
+            compatibilityVersionHeader: OCEAN_BRAIN_MCP_COMPATIBILITY_VERSION_HEADER,
+            clientVersionHeader: OCEAN_BRAIN_MCP_CLIENT_VERSION_HEADER,
+        },
     };
 };
+
+export const getOceanBrainVersionInfo = () =>
+    buildOceanBrainVersionInfo({
+        version: resolveOceanBrainVersion(),
+        mcpCompatibilityVersion: resolveMcpCompatibilityVersion(),
+    });

--- a/packages/server/src/modules/mcp-auth.ts
+++ b/packages/server/src/modules/mcp-auth.ts
@@ -2,7 +2,12 @@ import type { NextFunction, Request, RequestHandler, Response } from 'express';
 import type { ValidationRule } from 'graphql';
 import { GraphQLError } from 'graphql';
 
-import { getOceanBrainVersionInfo, parseMajorMinorVersion } from './app-version.js';
+import {
+    getOceanBrainVersionInfo,
+    OCEAN_BRAIN_MCP_CLIENT_VERSION_HEADER,
+    OCEAN_BRAIN_MCP_COMPATIBILITY_VERSION_HEADER,
+    parseMajorMinorVersion,
+} from './app-version.js';
 import type { AuthConfig } from './auth-mode.js';
 
 export interface McpTokenValidationResult {
@@ -18,27 +23,47 @@ export interface McpAdminAuthPort {
 const JSON_HEADERS = { 'Content-Type': 'application/json' };
 export const OCEAN_BRAIN_MCP_VERSION_HEADER = 'X-Ocean-Brain-MCP-Version';
 
-const readMcpVersion = (req: Request) => {
-    const value = req.headers[OCEAN_BRAIN_MCP_VERSION_HEADER.toLowerCase()];
+const readHeaderValue = (req: Request, headerName: string) => {
+    const value = req.headers[headerName.toLowerCase()];
     return Array.isArray(value) ? value[0] : value;
 };
 
-export const isMcpVersionCompatible = (serverVersion: string, mcpVersion: string) => {
-    const server = parseMajorMinorVersion(serverVersion);
-    const mcp = parseMajorMinorVersion(mcpVersion);
+const readMcpCompatibilityVersion = (req: Request) =>
+    readHeaderValue(req, OCEAN_BRAIN_MCP_COMPATIBILITY_VERSION_HEADER) ??
+    readHeaderValue(req, OCEAN_BRAIN_MCP_VERSION_HEADER);
 
-    return Boolean(server && mcp && server.major === mcp.major && server.minor === mcp.minor);
+const readMcpClientVersion = (req: Request) =>
+    readHeaderValue(req, OCEAN_BRAIN_MCP_CLIENT_VERSION_HEADER) ?? readHeaderValue(req, OCEAN_BRAIN_MCP_VERSION_HEADER);
+
+export const isMcpVersionCompatible = (requiredMcpCompatibilityVersion: string, mcpCompatibilityVersion: string) => {
+    const required = parseMajorMinorVersion(requiredMcpCompatibilityVersion);
+    const mcp = parseMajorMinorVersion(mcpCompatibilityVersion);
+
+    return Boolean(required && mcp && required.major === mcp.major && required.minor === mcp.minor);
 };
 
-const createMcpVersionCompatibilityMessage = (serverVersion: string, mcpVersion: string | undefined) => {
-    const mcpVersionText = mcpVersion ? `v${mcpVersion}` : 'not provided';
+const createMcpVersionCompatibilityMessage = ({
+    mcpClientVersion,
+    mcpCompatibilityVersion,
+    requiredMcpCompatibilityVersion,
+    serverVersion,
+}: {
+    mcpClientVersion?: string;
+    mcpCompatibilityVersion?: string;
+    requiredMcpCompatibilityVersion: string;
+    serverVersion: string;
+}) => {
+    const mcpCompatibilityVersionText = mcpCompatibilityVersion ? `v${mcpCompatibilityVersion}` : 'not provided';
+    const mcpClientVersionText = mcpClientVersion ? `v${mcpClientVersion}` : 'not provided';
 
     return [
-        'Ocean Brain MCP and server versions are incompatible.',
+        'Ocean Brain MCP compatibility versions are incompatible.',
         `Server: v${serverVersion}`,
-        `MCP: ${mcpVersionText}`,
+        `Required MCP compatibility: ${requiredMcpCompatibilityVersion}`,
+        `MCP compatibility: ${mcpCompatibilityVersionText}`,
+        `MCP client: ${mcpClientVersionText}`,
         '',
-        'Please update Ocean Brain MCP to match the server minor version.',
+        'Please update Ocean Brain MCP to a compatible release.',
         getOceanBrainVersionInfo().releaseUrl,
     ].join('\n');
 };
@@ -104,17 +129,29 @@ export const createMcpAuthMiddleware = (_authConfig: AuthConfig, mcpAdminAuth: M
             }
 
             const versionInfo = getOceanBrainVersionInfo();
-            const mcpVersion = readMcpVersion(req);
+            const mcpCompatibilityVersion = readMcpCompatibilityVersion(req);
+            const mcpClientVersion = readMcpClientVersion(req);
 
-            if (!mcpVersion || !isMcpVersionCompatible(versionInfo.version, mcpVersion)) {
+            if (
+                !mcpCompatibilityVersion ||
+                !isMcpVersionCompatible(versionInfo.mcp.compatibilityVersion, mcpCompatibilityVersion)
+            ) {
                 res.status(426)
                     .set(JSON_HEADERS)
                     .json({
                         code: 'MCP_VERSION_INCOMPATIBLE',
-                        message: createMcpVersionCompatibilityMessage(versionInfo.version, mcpVersion),
+                        message: createMcpVersionCompatibilityMessage({
+                            serverVersion: versionInfo.version,
+                            requiredMcpCompatibilityVersion: versionInfo.mcp.compatibilityRequirement,
+                            mcpCompatibilityVersion,
+                            mcpClientVersion,
+                        }),
                         serverVersion: versionInfo.version,
-                        mcpVersion: mcpVersion ?? null,
+                        mcpVersion: mcpClientVersion ?? mcpCompatibilityVersion ?? null,
+                        mcpClientVersion: mcpClientVersion ?? null,
+                        mcpCompatibilityVersion: mcpCompatibilityVersion ?? null,
                         requiredMcpVersion: versionInfo.mcpVersionRequirement,
+                        requiredMcpCompatibilityVersion: versionInfo.mcp.compatibilityRequirement,
                         releaseUrl: versionInfo.releaseUrl,
                     })
                     .end();

--- a/packages/server/test/mcp-auth.test.ts
+++ b/packages/server/test/mcp-auth.test.ts
@@ -360,8 +360,8 @@ test('mcp version guard blocks compatibility minor version differences', async (
     assert.equal(body.mcpCompatibilityVersion, createIncompatibleMcpVersion());
     assert.equal(body.mcpClientVersion, resolveOceanBrainVersion());
     assert.equal(body.serverVersion, resolveOceanBrainVersion());
-    assert.equal(body.requiredMcpVersion, '0.7.x');
-    assert.equal(body.requiredMcpCompatibilityVersion, '0.7.x');
+    assert.equal(body.requiredMcpVersion, '0.8.x');
+    assert.equal(body.requiredMcpCompatibilityVersion, '0.8.x');
     assert.match(String(body.message), /Please update Ocean Brain MCP/);
     assert.match(String(body.message), /https:\/\/github\.com\/baealex\/ocean-brain\/releases/);
 });

--- a/packages/server/test/mcp-auth.test.ts
+++ b/packages/server/test/mcp-auth.test.ts
@@ -3,30 +3,45 @@ import type { AddressInfo } from 'node:net';
 import test, { type TestContext } from 'node:test';
 import { createAppWithMcpAuth } from '../src/app.js';
 import type { McpAdminService } from '../src/features/mcp-admin/service.js';
-import { parseMajorMinorVersion, resolveOceanBrainVersion } from '../src/modules/app-version.js';
+import {
+    OCEAN_BRAIN_MCP_CLIENT_VERSION_HEADER,
+    OCEAN_BRAIN_MCP_COMPATIBILITY_VERSION_HEADER,
+    parseMajorMinorVersion,
+    resolveMcpCompatibilityVersion,
+    resolveOceanBrainVersion,
+} from '../src/modules/app-version.js';
 import { AUTH_SESSION_COOKIE_NAME, type AuthConfig } from '../src/modules/auth-mode.js';
 import { OCEAN_BRAIN_MCP_VERSION_HEADER } from '../src/modules/mcp-auth.js';
 
 const createCompatibleMcpVersion = (patch = 999) => {
-    const version = parseMajorMinorVersion(resolveOceanBrainVersion());
+    const version = parseMajorMinorVersion(resolveMcpCompatibilityVersion());
     assert.ok(version);
 
     return `${version.major}.${version.minor}.${patch}`;
 };
 
 const createIncompatibleMcpVersion = () => {
-    const version = parseMajorMinorVersion(resolveOceanBrainVersion());
+    const version = parseMajorMinorVersion(resolveMcpCompatibilityVersion());
     assert.ok(version);
 
     return `${version.major}.${version.minor + 1}.0`;
 };
 
-const createMcpHeaders = (bearerToken?: string, options: { mcpVersion?: string | null } = {}) => {
+const createMcpHeaders = (
+    bearerToken?: string,
+    options: { legacyMcpVersion?: string | null; mcpClientVersion?: string | null; mcpVersion?: string | null } = {},
+) => {
     const mcpVersion = Object.hasOwn(options, 'mcpVersion') ? options.mcpVersion : createCompatibleMcpVersion();
+    const legacyMcpVersion = Object.hasOwn(options, 'legacyMcpVersion') ? options.legacyMcpVersion : mcpVersion;
+    const mcpClientVersion = Object.hasOwn(options, 'mcpClientVersion')
+        ? options.mcpClientVersion
+        : resolveOceanBrainVersion();
 
     return {
         'Content-Type': 'application/json',
-        ...(mcpVersion ? { [OCEAN_BRAIN_MCP_VERSION_HEADER]: mcpVersion } : {}),
+        ...(legacyMcpVersion ? { [OCEAN_BRAIN_MCP_VERSION_HEADER]: legacyMcpVersion } : {}),
+        ...(mcpVersion ? { [OCEAN_BRAIN_MCP_COMPATIBILITY_VERSION_HEADER]: mcpVersion } : {}),
+        ...(mcpClientVersion ? { [OCEAN_BRAIN_MCP_CLIENT_VERSION_HEADER]: mcpClientVersion } : {}),
         ...(bearerToken ? { Authorization: `Bearer ${bearerToken}` } : {}),
     };
 };
@@ -266,7 +281,7 @@ test('mcp disabled state blocks MCP graphql access even with a valid token', asy
     assert.equal(query.body.code, 'MCP_DISABLED');
 });
 
-test('mcp version guard allows patch version differences', async (t) => {
+test('mcp version guard allows compatibility patch version differences', async (t) => {
     const { baseUrl } = await startServer(
         t,
         createOpenAuthConfig(),
@@ -284,7 +299,49 @@ test('mcp version guard allows patch version differences', async (t) => {
     assert.equal(body.code, 'INVALID_NOTE_TITLE');
 });
 
-test('mcp version guard blocks minor version differences', async (t) => {
+test('mcp version guard allows compatible clients even when app client version differs', async (t) => {
+    const { baseUrl } = await startServer(
+        t,
+        createOpenAuthConfig(),
+        createMcpAdminAuth({ enabled: true, expectedToken: 'mcp-secret' }),
+    );
+
+    const response = await fetch(`${baseUrl}/api/mcp/notes/create`, {
+        method: 'POST',
+        headers: createMcpHeaders('mcp-secret', {
+            mcpClientVersion: '0.8.0',
+            mcpVersion: createCompatibleMcpVersion(123),
+        }),
+        body: JSON.stringify({}),
+    });
+    const body = (await response.json()) as Record<string, unknown>;
+
+    assert.equal(response.status, 400);
+    assert.equal(body.code, 'INVALID_NOTE_TITLE');
+});
+
+test('mcp version guard allows legacy compatibility header fallback during migration', async (t) => {
+    const { baseUrl } = await startServer(
+        t,
+        createOpenAuthConfig(),
+        createMcpAdminAuth({ enabled: true, expectedToken: 'mcp-secret' }),
+    );
+
+    const response = await fetch(`${baseUrl}/api/mcp/notes/create`, {
+        method: 'POST',
+        headers: createMcpHeaders('mcp-secret', {
+            legacyMcpVersion: createCompatibleMcpVersion(456),
+            mcpVersion: null,
+        }),
+        body: JSON.stringify({}),
+    });
+    const body = (await response.json()) as Record<string, unknown>;
+
+    assert.equal(response.status, 400);
+    assert.equal(body.code, 'INVALID_NOTE_TITLE');
+});
+
+test('mcp version guard blocks compatibility minor version differences', async (t) => {
     const { baseUrl } = await startServer(
         t,
         createOpenAuthConfig(),
@@ -300,8 +357,11 @@ test('mcp version guard blocks minor version differences', async (t) => {
 
     assert.equal(response.status, 426);
     assert.equal(body.code, 'MCP_VERSION_INCOMPATIBLE');
-    assert.equal(body.mcpVersion, createIncompatibleMcpVersion());
+    assert.equal(body.mcpCompatibilityVersion, createIncompatibleMcpVersion());
+    assert.equal(body.mcpClientVersion, resolveOceanBrainVersion());
     assert.equal(body.serverVersion, resolveOceanBrainVersion());
+    assert.equal(body.requiredMcpVersion, '0.7.x');
+    assert.equal(body.requiredMcpCompatibilityVersion, '0.7.x');
     assert.match(String(body.message), /Please update Ocean Brain MCP/);
     assert.match(String(body.message), /https:\/\/github\.com\/baealex\/ocean-brain\/releases/);
 });
@@ -315,7 +375,7 @@ test('mcp version guard blocks requests without an MCP version header after auth
 
     const response = await fetch(`${baseUrl}/graphql/mcp`, {
         method: 'POST',
-        headers: createMcpHeaders('mcp-secret', { mcpVersion: null }),
+        headers: createMcpHeaders('mcp-secret', { mcpClientVersion: null, mcpVersion: null }),
         body: JSON.stringify({ query: 'query { __typename }' }),
     });
     const body = (await response.json()) as Record<string, unknown>;
@@ -323,6 +383,7 @@ test('mcp version guard blocks requests without an MCP version header after auth
     assert.equal(response.status, 426);
     assert.equal(body.code, 'MCP_VERSION_INCOMPATIBLE');
     assert.equal(body.mcpVersion, null);
+    assert.equal(body.mcpCompatibilityVersion, null);
 });
 
 test('enabled state still requires a valid bearer token on the MCP note delete endpoint', async (t) => {


### PR DESCRIPTION
## :dart: Goal
- Decouple MCP compatibility from the Ocean Brain app/package version so normal app releases do not accidentally force MCP client/server upgrades.
- Introduce the initial MCP compatibility contract for the upcoming `0.8.x` release line.
- Make MCP compatibility changes explicit only when the MCP contract is intentionally broken.

## :hammer_and_wrench: Core Changes
- Added explicit `oceanBrain.mcpCompatibilityVersion` package metadata as the MCP compatibility source of truth.
- Set the initial MCP compatibility version to `0.8.0`, while the package `version` remains on the current pre-release value until the release PR bumps it.
- Added MCP compatibility/client version headers while keeping the legacy MCP version header as a migration fallback.
- Updated server MCP auth/version guard and MCP admin status metadata to use compatibility version requirements.
- Updated MCP settings UI/local demo types to display MCP compatibility requirements instead of deriving them from app version.
- Documented the release checklist for MCP compatibility-breaking changes.

## :brain: Key Decisions
- App/server version and MCP compatibility version are intentionally independent.
- `mcpCompatibilityVersion` is required metadata; it does not fall back to the app version to avoid accidental lockstep behavior.
- The initial compatibility requirement is `0.8.x` because this compatibility contract starts with the upcoming `0.8.0` release.
- MCP compatibility is compared by major/minor range, so patch-level MCP compatibility updates remain accepted.
- Legacy `X-Ocean-Brain-MCP-Version` remains supported during migration, but new clients send explicit compatibility and client-version headers.
- Release impact: `release: minor`.
- Expected release version: `0.8.0`.
- Tag plan: `v0.8.0` after the release PR is merged through the normal release flow.
- CLI_SMOKE: required before release tagging; local CLI MCP tests passed in this PR validation.

## :test_tube: Verification Guide
### How to verify
1. `pnpm --filter server test --run src/modules/app-version.test.ts test/mcp-auth.test.ts src/features/mcp-admin/http/handlers.test.ts`
2. `pnpm --filter client test --run src/pages/setting/mcp.spec.tsx src/pages/setting/index.spec.tsx`
3. `pnpm --filter ocean-brain test -- mcp.test.ts`
4. `pnpm --filter server type-check && pnpm --filter client type-check && pnpm --filter ocean-brain type-check`
5. `pnpm --filter server lint && pnpm --filter client lint`
6. `pnpm check:encoding`
7. `pnpm build`

### Expected result
- Server MCP compatibility/version tests pass.
- Client MCP settings tests display `MCP compatibility 0.8.x`.
- CLI MCP request header tests pass.
- Type-check, lint, encoding check, and build all complete successfully.
- Vite may print existing chunk-size warnings during build, but the build should exit successfully.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)