### PR TITLE
♻️ Improve graph mobile layout

### DIFF
--- a/packages/client/src/pages/Graph.tsx
+++ b/packages/client/src/pages/Graph.tsx
@@ -1,5 +1,6 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { useMemo, useState } from 'react';
+import classNames from 'classnames';
+import { useEffect, useMemo, useState } from 'react';
 
 import { fetchNoteGraph } from '~/apis/note.api';
 import { QueryBoundary, QueryErrorView } from '~/components/app';
@@ -19,14 +20,54 @@ import { useGraphSelection } from './useGraphSelection';
 
 const graphPageFallback = (
     <PageLayout title="Knowledge Graph" description={<Skeleton width={184} height={16} className="rounded-full" />}>
-        <div className="flex h-[600px] items-center justify-center">
-            <Skeleton width="100%" height="100%" />
+        <div className="mb-3 grid min-w-0 grid-cols-2 gap-2 xl:hidden" aria-hidden="true">
+            <Skeleton width="100%" height={36} className="rounded-[12px]" />
+            <Skeleton width="100%" height={36} className="rounded-[12px]" />
+        </div>
+        <div className="grid min-w-0 gap-4 xl:grid-cols-[minmax(0,1fr)_23rem]">
+            <div className="surface-base h-[min(34rem,calc(100dvh-12rem))] min-h-[420px] w-full max-w-full overflow-hidden md:h-[520px] xl:order-1 xl:h-[min(44rem,calc(100vh-10rem))]">
+                <Skeleton width="100%" height="100%" />
+            </div>
+            <div className="surface-base hidden h-[min(34rem,calc(100dvh-12rem))] min-h-[420px] w-full max-w-full flex-col gap-3 p-4 md:h-[520px] xl:order-2 xl:flex xl:h-[min(44rem,calc(100vh-10rem))]">
+                <div className="flex items-center justify-between gap-3">
+                    <Skeleton width={120} height={14} className="rounded-full" />
+                    <Skeleton width={92} height={12} className="rounded-full" />
+                </div>
+                <Skeleton width="100%" height={34} className="rounded-[12px]" />
+                <Skeleton width="78%" height={12} className="rounded-full" />
+                <div className="flex min-h-0 flex-1 flex-col gap-2">
+                    {Array.from({ length: 6 }).map((_, index) => (
+                        <Skeleton key={index} width="100%" height={40} className="rounded-[12px]" />
+                    ))}
+                </div>
+            </div>
         </div>
     </PageLayout>
 );
 
+type GraphMobileTab = 'graph' | 'list';
+
+function useIsGraphMobileLayout() {
+    const [isMobileLayout, setIsMobileLayout] = useState(() =>
+        typeof window === 'undefined' ? false : window.matchMedia('(max-width: 1279px)').matches,
+    );
+
+    useEffect(() => {
+        const mediaQuery = window.matchMedia('(max-width: 1279px)');
+        const handleChange = () => setIsMobileLayout(mediaQuery.matches);
+
+        handleChange();
+        mediaQuery.addEventListener('change', handleChange);
+        return () => mediaQuery.removeEventListener('change', handleChange);
+    }, []);
+
+    return isMobileLayout;
+}
+
 function GraphContent() {
     const [nodeSearchQuery, setNodeSearchQuery] = useState('');
+    const [activeMobileTab, setActiveMobileTab] = useState<GraphMobileTab>('graph');
+    const isMobileLayout = useIsGraphMobileLayout();
     const { clearSelection, openNode, selectNode, selectedNodeId } = useGraphSelection();
 
     const { data } = useSuspenseQuery({
@@ -72,26 +113,88 @@ function GraphContent() {
             title="Knowledge Graph"
             description={`${graphData.nodes.length} linked notes, ${graphData.links.length} connections`}
         >
-            <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_23rem]">
-                <GraphCanvas
-                    adjacencyMap={adjacencyMap}
-                    graphData={graphData}
-                    onClearSelection={clearSelection}
-                    onOpenNode={openNode}
-                    onSelectNode={selectNode}
-                    selectedNodeId={selectedNodeId}
-                />
-                <GraphExplorerPanel
-                    filteredGraphNodes={filteredGraphNodes}
-                    graphNodes={graphNodes}
-                    nodeSearchQuery={nodeSearchQuery}
-                    onClearSelection={clearSelection}
-                    onNodeSearchQueryChange={setNodeSearchQuery}
-                    onSelectNode={selectNode}
-                    selectedConnectedNodes={selectedConnectedNodes}
-                    selectedNode={selectedNode}
-                    selectedNodeId={selectedNodeId}
-                />
+            <div
+                role="tablist"
+                aria-label="Graph mobile view"
+                className="surface-base mb-3 grid min-w-0 grid-cols-2 gap-1 p-1 xl:hidden"
+            >
+                <button
+                    type="button"
+                    role="tab"
+                    id="graph-mobile-tab-graph"
+                    aria-controls="graph-mobile-panel-graph"
+                    aria-selected={activeMobileTab === 'graph'}
+                    onClick={() => setActiveMobileTab('graph')}
+                    className={classNames(
+                        'focus-ring-soft rounded-[10px] px-3 py-2 text-sm font-semibold outline-none transition-colors',
+                        activeMobileTab === 'graph'
+                            ? 'bg-elevated text-fg-default shadow-sm'
+                            : 'text-fg-secondary hover:bg-hover-subtle hover:text-fg-default',
+                    )}
+                >
+                    Graph
+                </button>
+                <button
+                    type="button"
+                    role="tab"
+                    id="graph-mobile-tab-list"
+                    aria-controls="graph-mobile-panel-list"
+                    aria-selected={activeMobileTab === 'list'}
+                    onClick={() => setActiveMobileTab('list')}
+                    className={classNames(
+                        'focus-ring-soft rounded-[10px] px-3 py-2 text-sm font-semibold outline-none transition-colors',
+                        activeMobileTab === 'list'
+                            ? 'bg-elevated text-fg-default shadow-sm'
+                            : 'text-fg-secondary hover:bg-hover-subtle hover:text-fg-default',
+                    )}
+                >
+                    List
+                </button>
+            </div>
+            <div className="grid min-w-0 gap-4 xl:grid-cols-[minmax(0,1fr)_23rem]">
+                <div
+                    id="graph-mobile-panel-graph"
+                    role="tabpanel"
+                    aria-labelledby="graph-mobile-tab-graph"
+                    aria-hidden={isMobileLayout && activeMobileTab !== 'graph'}
+                    inert={isMobileLayout && activeMobileTab !== 'graph' ? true : undefined}
+                    className={classNames(
+                        'col-start-1 row-start-1 min-w-0 xl:col-auto xl:row-auto xl:order-1 xl:pointer-events-auto xl:visible',
+                        activeMobileTab === 'graph' ? 'pointer-events-auto visible' : 'pointer-events-none invisible',
+                    )}
+                >
+                    <GraphCanvas
+                        adjacencyMap={adjacencyMap}
+                        graphData={graphData}
+                        onClearSelection={clearSelection}
+                        onOpenNode={openNode}
+                        onSelectNode={selectNode}
+                        selectedNodeId={selectedNodeId}
+                    />
+                </div>
+                <div
+                    id="graph-mobile-panel-list"
+                    role="tabpanel"
+                    aria-labelledby="graph-mobile-tab-list"
+                    aria-hidden={isMobileLayout && activeMobileTab !== 'list'}
+                    inert={isMobileLayout && activeMobileTab !== 'list' ? true : undefined}
+                    className={classNames(
+                        'col-start-1 row-start-1 min-w-0 xl:col-auto xl:row-auto xl:order-2 xl:pointer-events-auto xl:visible',
+                        activeMobileTab === 'list' ? 'pointer-events-auto visible' : 'pointer-events-none invisible',
+                    )}
+                >
+                    <GraphExplorerPanel
+                        filteredGraphNodes={filteredGraphNodes}
+                        graphNodes={graphNodes}
+                        nodeSearchQuery={nodeSearchQuery}
+                        onClearSelection={clearSelection}
+                        onNodeSearchQueryChange={setNodeSearchQuery}
+                        onSelectNode={selectNode}
+                        selectedConnectedNodes={selectedConnectedNodes}
+                        selectedNode={selectedNode}
+                        selectedNodeId={selectedNodeId}
+                    />
+                </div>
             </div>
         </PageLayout>
     );

--- a/packages/client/src/pages/GraphCanvas.tsx
+++ b/packages/client/src/pages/GraphCanvas.tsx
@@ -33,8 +33,8 @@ export function GraphCanvas({
     const containerRef = useRef<HTMLDivElement>(null);
     const graphRef = useRef<ForceGraphInstance | null>(null);
     const [dimensions, setDimensions] = useState({
-        width: 800,
-        height: 600,
+        width: 0,
+        height: 420,
     });
 
     const { theme } = useTheme((state) => state);
@@ -55,16 +55,28 @@ export function GraphCanvas({
             }
 
             const rect = containerRef.current.getBoundingClientRect();
-            const isCompactLayout = rect.width < 768;
+            if (rect.width <= 0 || rect.height <= 0) {
+                return;
+            }
+
             setDimensions({
                 width: rect.width,
-                height: isCompactLayout ? Math.max(420, Math.min(520, rect.width * 1.25)) : Math.max(600, rect.height),
+                height: rect.height,
             });
         };
 
         updateDimensions();
+
+        const resizeObserver = typeof ResizeObserver === 'function' ? new ResizeObserver(updateDimensions) : null;
+        if (resizeObserver && containerRef.current) {
+            resizeObserver.observe(containerRef.current);
+        }
+
         window.addEventListener('resize', updateDimensions);
-        return () => window.removeEventListener('resize', updateDimensions);
+        return () => {
+            resizeObserver?.disconnect();
+            window.removeEventListener('resize', updateDimensions);
+        };
     }, []);
 
     useEffect(() => {
@@ -198,7 +210,7 @@ export function GraphCanvas({
     return (
         <div
             ref={containerRef}
-            className="surface-base graph-canvas relative min-h-[420px] overflow-hidden md:min-h-[520px] xl:h-[min(44rem,calc(100vh-10rem))]"
+            className="surface-base graph-canvas relative h-[min(34rem,calc(100dvh-12rem))] min-h-[420px] w-full max-w-full overflow-hidden md:h-[520px] xl:h-[min(44rem,calc(100vh-10rem))]"
             style={{ '--graph-bg': graphTheme.background } as React.CSSProperties}
         >
             <div className="surface-floating absolute top-3 right-3 z-10 flex flex-col gap-1.5 px-3 py-2.5">

--- a/packages/client/src/pages/GraphExplorerPanel.tsx
+++ b/packages/client/src/pages/GraphExplorerPanel.tsx
@@ -44,8 +44,6 @@ export function GraphExplorerPanel({
         overscan: 8,
     });
 
-    const visibleSelectedConnections = selectedConnectedNodes.slice(0, 4);
-    const remainingSelectedConnectionCount = selectedConnectedNodes.length - visibleSelectedConnections.length;
     const selectedNodeStatus = selectedNode
         ? `${selectedNode.title || 'Untitled'} selected, ${selectedNode.connections} links`
         : 'No graph node selected';
@@ -122,7 +120,7 @@ export function GraphExplorerPanel({
 
     return (
         <section
-            className="surface-base flex min-h-[420px] flex-col overflow-hidden md:min-h-[520px] xl:h-[min(44rem,calc(100vh-10rem))]"
+            className="surface-base flex h-[min(34rem,calc(100dvh-12rem))] min-h-[420px] w-full max-w-full flex-col overflow-hidden md:h-[520px] xl:h-[min(44rem,calc(100vh-10rem))]"
             aria-labelledby="graph-explorer-heading"
         >
             <div className="border-b border-border-subtle/80 px-4 py-3">
@@ -189,60 +187,41 @@ export function GraphExplorerPanel({
                     : selectedNodeStatus}
             </Text>
 
-            <div className="border-b border-border-subtle/80 px-4 py-2.5">
+            <div className="flex h-[76px] shrink-0 items-center overflow-hidden border-b border-border-subtle/80 px-4 py-2.5">
                 {selectedNode ? (
-                    <div className="min-w-0">
-                        <div className="flex items-start justify-between gap-3">
-                            <div className="min-w-0">
-                                <Text as="p" variant="body" weight="semibold" truncate>
-                                    {selectedNode.title || 'Untitled'}
-                                </Text>
-                                <Text as="p" variant="meta" tone="tertiary" className="mt-0.5">
-                                    {selectedNode.connections} links
-                                </Text>
-                            </div>
-                            <div className="flex shrink-0 items-center gap-1">
-                                <button
-                                    type="button"
-                                    onClick={onClearSelection}
-                                    className="focus-ring-soft inline-flex h-8 w-8 items-center justify-center rounded-[10px] text-fg-secondary outline-none transition-colors hover:bg-hover-subtle hover:text-fg-default"
-                                    aria-label="Deselect node"
-                                >
-                                    <Icon.Close className="h-3.5 w-3.5" aria-hidden="true" />
-                                </button>
-                                <Link
-                                    to={NOTE_ROUTE}
-                                    params={{ id: selectedNode.id }}
-                                    aria-label={`Open ${selectedNode.title || 'Untitled'}`}
-                                    className="focus-ring-soft inline-flex h-8 w-8 items-center justify-center rounded-[10px] text-fg-secondary outline-none transition-colors hover:bg-hover-subtle hover:text-fg-default"
-                                >
-                                    <Icon.ArrowRight className="h-4 w-4" aria-hidden="true" />
-                                </Link>
-                            </div>
+                    <div className="flex min-w-0 flex-1 items-center justify-between gap-3 overflow-hidden">
+                        <div className="min-w-0 flex-1">
+                            <Text as="p" variant="body" weight="semibold" truncate>
+                                {selectedNode.title || 'Untitled'}
+                            </Text>
+                            <Text as="p" variant="meta" tone="tertiary" className="mt-0.5">
+                                {selectedNode.connections} links
+                                {selectedConnectedNodes.length > 0
+                                    ? ` · ${selectedConnectedNodes.length} connected notes`
+                                    : ''}
+                            </Text>
                         </div>
-                        {visibleSelectedConnections.length > 0 && (
-                            <div className="mt-2 flex flex-wrap gap-1.5">
-                                {visibleSelectedConnections.map((node) => (
-                                    <Link
-                                        key={node.id}
-                                        to={NOTE_ROUTE}
-                                        params={{ id: node.id }}
-                                        className="focus-ring-soft inline-flex max-w-full items-center gap-1 rounded-full border border-border-subtle bg-subtle px-2 py-0.5 text-xs font-medium text-fg-secondary outline-none transition-colors hover:border-border-secondary hover:bg-hover-subtle hover:text-fg-default"
-                                    >
-                                        <Icon.LinkIcon className="h-3 w-3 shrink-0" aria-hidden="true" />
-                                        <span className="truncate">{node.title || 'Untitled'}</span>
-                                    </Link>
-                                ))}
-                                {remainingSelectedConnectionCount > 0 && (
-                                    <span className="inline-flex items-center rounded-full border border-border-subtle px-2 py-0.5 text-xs font-medium text-fg-tertiary">
-                                        +{remainingSelectedConnectionCount}
-                                    </span>
-                                )}
-                            </div>
-                        )}
+                        <div className="flex shrink-0 items-center gap-1">
+                            <button
+                                type="button"
+                                onClick={onClearSelection}
+                                className="focus-ring-soft inline-flex h-8 w-8 items-center justify-center rounded-[10px] text-fg-secondary outline-none transition-colors hover:bg-hover-subtle hover:text-fg-default"
+                                aria-label="Deselect node"
+                            >
+                                <Icon.Close className="h-3.5 w-3.5" aria-hidden="true" />
+                            </button>
+                            <Link
+                                to={NOTE_ROUTE}
+                                params={{ id: selectedNode.id }}
+                                aria-label={`Open ${selectedNode.title || 'Untitled'}`}
+                                className="focus-ring-soft inline-flex h-8 w-8 items-center justify-center rounded-[10px] text-fg-secondary outline-none transition-colors hover:bg-hover-subtle hover:text-fg-default"
+                            >
+                                <Icon.ArrowRight className="h-4 w-4" aria-hidden="true" />
+                            </Link>
+                        </div>
                     </div>
                 ) : (
-                    <Text as="p" variant="meta" tone="secondary">
+                    <Text as="p" variant="meta" tone="secondary" className="line-clamp-2">
                         {graphNodes[0]?.title
                             ? `Select a node to preview links. Most linked: ${graphNodes[0].title}`
                             : 'Select a node to preview links.'}


### PR DESCRIPTION
## :dart: Goal
- Improve the graph page mobile experience without removing the accessible graph explorer list.
- Separate graph touch interactions from list scrolling so mobile users can interact with each mode more predictably.

## :hammer_and_wrench: Core Changes
- Add mobile-only Graph/List tabs while preserving the desktop graph + explorer two-column layout.
- Align graph canvas and explorer panel heights across mobile, tablet, and desktop breakpoints.
- Keep inactive mobile panels mounted with visibility-based hiding to reduce canvas and virtual list measurement churn.
- Simplify the selected-node summary so the virtualized list viewport stays stable.

## :brain: Key Decisions
- Mobile prioritizes clear interaction modes over showing graph and list at the same time.
- The accessible explorer list remains available as the List tab instead of being removed.
- Inactive panels use visibility/inert behavior instead of display-none hiding to avoid virtualizer scroll resets and canvas zero-size measurements.
- Selected-node details are compacted to avoid changing the list viewport height on every selection.

## :test_tube: Verification Guide
### How to verify
1. Run `pnpm --filter @ocean-brain/client type-check`.
2. Run `pnpm --filter @ocean-brain/client lint`.
3. Run `pnpm --filter @ocean-brain/client test:ci -- Graph`.
4. Open the graph page on a mobile-width viewport and switch between Graph and List tabs.
5. Select graph/list nodes and confirm the list scroll area remains stable.

### Expected result
- Type-check, lint, and graph test commands pass.
- Mobile shows Graph/List tabs, while desktop keeps the two-column layout.
- Switching tabs does not feel like a remount/reset of the list or canvas.
- Selecting nodes does not cause the list viewport height to jump.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)
- [x] Release impact label applied: `release: patch`
