### PR TITLE
🐛 Fix MCP compatibility version test

### DIFF
--- a/packages/server/src/modules/app-version.test.ts
+++ b/packages/server/src/modules/app-version.test.ts
@@ -33,9 +33,24 @@ test('resolveOceanBrainVersion prefers package metadata over environment overrid
     }
 });
 
-test('resolveMcpCompatibilityVersion reads package compatibility metadata separately from app version', () => {
-    assert.equal(resolveMcpCompatibilityVersion(), '0.8.0');
-    assert.notEqual(resolveMcpCompatibilityVersion(), resolveOceanBrainVersion());
+test('resolveMcpCompatibilityVersion reads explicit package compatibility metadata', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ocean-brain-version-'));
+    const packageJsonPath = path.join(tempDir, 'package.json');
+
+    try {
+        fs.writeFileSync(
+            packageJsonPath,
+            JSON.stringify({
+                version: '9.9.9',
+                oceanBrain: { mcpCompatibilityVersion: '0.8.0' },
+            }),
+        );
+
+        assert.equal(resolveMcpCompatibilityVersion(), '0.8.0');
+        assert.equal(resolveMcpCompatibilityVersionFromPaths([packageJsonPath]), '0.8.0');
+    } finally {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    }
 });
 
 test('resolveMcpCompatibilityVersion requires explicit compatibility metadata', () => {


### PR DESCRIPTION
## :dart: Goal
- Keep the MCP compatibility version test valid when the app release version intentionally matches the MCP compatibility version.
- Unblock the v0.8.0 release PR without adding release changes to the version bump PR.

## :hammer_and_wrench: Core Changes
- Replace the runtime `notEqual` assertion between app version and MCP compatibility version.
- Verify explicit MCP compatibility metadata with a temporary package manifest whose app version differs from the compatibility version.

## :brain: Key Decisions
- App version and MCP compatibility version are independent fields, but they are allowed to have the same value at a release boundary such as `0.8.0`.
- The release bump PR should remain version-only, so this test correction is handled separately.

## :test_tube: Verification Guide
### How to verify
1. Run `pnpm --filter @ocean-brain/server test -- src/modules/app-version.test.ts`.
2. Run `pnpm --filter @ocean-brain/server type-check`.
3. Run `pnpm --filter @ocean-brain/server lint`.

### Expected result
- The app-version tests pass even when package `version` and `oceanBrain.mcpCompatibilityVersion` both resolve to `0.8.0`.
- Server type-check and lint pass.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)
- [x] Release impact label applied: `release: patch`
