### PR TITLE
🐛 Fix CLI smoke login assertion

### DIFF
--- a/scripts/ci/smoke-cli-npx.mjs
+++ b/scripts/ci/smoke-cli-npx.mjs
@@ -235,6 +235,22 @@ async function assertProtectedHomeRedirectsToLogin() {
     }
 }
 
+export function assertLoginPageHtml(html) {
+    const expectedFragments = [
+        'Ocean Brain',
+        '<form method="post" action="/login">',
+        'name="password"',
+        'type="password"',
+        'Sign in'
+    ];
+
+    for (const expectedText of expectedFragments) {
+        if (!html.includes(expectedText)) {
+            throw new Error(`/login response missing expected content: ${expectedText}`);
+        }
+    }
+}
+
 async function assertLoginPageLoads() {
     const response = await fetch(`${rootUrl}/login?next=%2F`, {
         redirect: 'manual',
@@ -245,16 +261,7 @@ async function assertLoginPageLoads() {
         throw new Error(`/login returned HTTP ${response.status} instead of 200`);
     }
 
-    const html = await response.text();
-    for (const expectedText of [
-        'Ocean Brain',
-        'Enter the workspace password to continue',
-        '<form method="post" action="/login">'
-    ]) {
-        if (!html.includes(expectedText)) {
-            throw new Error(`/login response missing expected content: ${expectedText}`);
-        }
-    }
+    assertLoginPageHtml(await response.text());
 }
 
 async function assertAuthSession(expected) {

--- a/scripts/ci/smoke-cli-npx.test.mjs
+++ b/scripts/ci/smoke-cli-npx.test.mjs
@@ -4,6 +4,7 @@ import { EventEmitter } from 'node:events';
 
 import {
     AUTH_SESSION_PATH,
+    assertLoginPageHtml,
     buildSmokeScenarios,
     expectAuthFailure,
     extractLocalAssetPaths,
@@ -75,6 +76,21 @@ test('extractLocalAssetPaths returns only local Vite assets from the client shel
         `),
         ['/assets/index.css', '/assets/index.js']
     );
+});
+
+
+test('assertLoginPageHtml accepts the minimal password login shell', () => {
+    assert.doesNotThrow(() => assertLoginPageHtml(`
+        <main>
+            <div class="brand"><img src="/icon.png" alt="" aria-hidden="true" />Ocean Brain</div>
+            <h1 class="sr-only">Sign in</h1>
+            <form method="post" action="/login">
+                <label for="password">Password</label>
+                <input id="password" name="password" type="password" />
+                <button type="submit">Sign in</button>
+            </form>
+        </main>
+    `));
 });
 
 test('expectAuthFailure reads the latest stderr through the provided getter', async () => {


### PR DESCRIPTION
## :dart: Goal
- Keep CLI smoke aligned with the minimal password login page shipped in v0.8.0.
- Unblock the release PR by removing stale expectations for login helper copy that is no longer part of the login page contract.

## :hammer_and_wrench: Core Changes
- Update the npx smoke login assertion to verify stable functional structure instead of removed helper text.
- Add unit coverage for the minimal login shell expected by the smoke test.

## :brain: Key Decisions
- CLI smoke should verify that the login route is usable, not enforce deleted copy.
- This is a CI smoke assertion fix only.
- No release-impact label is applied because this does not change runtime product behavior; it only updates release validation to match the already-merged login UI.

## :test_tube: Verification Guide
### How to verify
1. Run `node --test scripts/ci/smoke-cli-npx.test.mjs`.
2. Let GitHub Actions run `CI` and `CLI SMOKE` on the release PR after this lands.

### Expected result
- The smoke helper tests pass.
- CLI smoke verifies the login route/form/password input/button without depending on deleted helper copy.

## :white_check_mark: Checklist
- [x] Tests completed
- [x] Documentation updated (if needed)
- [x] No release-impact label intentionally applied for CI-only test assertion maintenance