### PR TITLE
⚡ Speed up client test CI

### DIFF
--- a/docs/process/DEPLOYMENT_RELEASE_STRATEGY.md
+++ b/docs/process/DEPLOYMENT_RELEASE_STRATEGY.md
@@ -1,6 +1,6 @@
 # Ocean Brain Deployment and Release Strategy
 
-Updated: 2026-04-06
+Updated: 2026-07-03
 
 ## 1. Current Deployment Channels
 1. npm distribution
@@ -112,6 +112,7 @@ git push origin v0.3.1
 5. Review the release PR
 - Confirm the expected tag is `v<version>`.
 - Confirm exactly one release impact label is applied: `release: patch`, `release: minor`, or `release: major`.
+- Do not use `release: no-impact` for release PRs because release PRs intentionally publish artifacts.
 - Confirm the release PR contains the verification plan.
 - Confirm `oceanBrain.mcpCompatibilityVersion` changed only when MCP compatibility is intentionally broken.
 
@@ -146,6 +147,20 @@ gh run list --workflow RELEASE.yml --limit 5
 - Open the created release page after `verify-docker` creates it.
 - For patch releases, start from GitHub generated notes and preserve the PR-linked bullet format.
 - For minor and major releases, treat auto-generated notes as a draft and replace the body with the final note before sharing the release externally.
+
+## 6-1. No-Impact PRs
+No-impact PRs are allowed for repository operations that should not be included in a versioned npm or Docker release.
+
+Use `release: no-impact` when the change has no effect on released artifacts, runtime behavior, user-visible product behavior, public APIs, CLI/MCP contracts, or release notes.
+
+Typical examples:
+- CI speedups, CI-only workflow tuning, and test runner configuration.
+- Local development environment changes, editor/tooling setup, and contributor-only scripts.
+- Local demo-only changes that are not shipped as the default product behavior.
+- Documentation/process updates that do not describe a released product change.
+- Test-only refactors that do not change product code or release artifacts.
+
+Do not use `release: no-impact` when a change affects packaged CLI files, server/client runtime behavior, Docker/npm artifacts, public contracts, migrations, or user-visible behavior. Pick `release: patch`, `release: minor`, or `release: major` instead.
 
 ## 7. Recovery Guide
 Use this section when the version bump PR is merged but the release did not start cleanly.

--- a/docs/process/DEV_CONVENTION.md
+++ b/docs/process/DEV_CONVENTION.md
@@ -1,6 +1,6 @@
 # Ocean Brain Dev Convention
 
-Updated: 2026-06-05
+Updated: 2026-07-03
 
 ## 1. Base Environment
 - Node.js: `22`
@@ -30,7 +30,7 @@ Updated: 2026-06-05
    - Body sections: write each section as a Markdown H2 heading using the exact shortcode labels, for example `## :dart: Goal`
    - Required section labels: `:dart: Goal`, `:hammer_and_wrench: Core Changes`, `:brain: Key Decisions`, `:test_tube: Verification Guide`, `:white_check_mark: Checklist` (shortcode only)
    - Commit format: `<emoji> <subject>` (Unicode emoji only)
-   - Release impact label: exactly one of `release: major`, `release: minor`, or `release: patch`
+   - Release impact label: exactly one of `release: major`, `release: minor`, `release: patch`, or `release: no-impact`
 
 ## 5. Server and Release Linked Rules
 - Server start script includes `prisma migrate deploy`.

--- a/docs/process/GIT_CONVENTION.md
+++ b/docs/process/GIT_CONVENTION.md
@@ -1,6 +1,6 @@
 # Ocean Brain Git Convention
 
-Updated: 2026-06-15
+Updated: 2026-07-03
 
 ## 1. Scope
 - This document defines commit and PR conventions for the Ocean Brain repository.
@@ -74,20 +74,24 @@ Use these shortcode labels exactly:
 1. CI checks (`lint`, `type-check`, `build`) pass
 2. Local validation for the changed scope is complete
 3. Any docs/scripts/env changes are documented in PR body
-4. Exactly one release impact label is applied: `release: major`, `release: minor`, or `release: patch`, unless the maintainer explicitly declares the PR as no-release-impact operational work
+4. Exactly one release impact label is applied: `release: major`, `release: minor`, `release: patch`, or `release: no-impact`
 5. Release-impacting changes include version/tag plan
 
 ### 3-5. Release Impact Labels
-Every release-impacting PR must have exactly one release impact label before review/merge. Pick the highest applicable impact. Maintainer-declared no-release-impact operational PRs may intentionally omit the label.
+Every PR must have exactly one release impact label before review/merge. Pick the highest applicable impact.
 
 - `release: major`: breaking change, migration requirement, removed/renamed public behavior, or incompatible API/CLI/config change
 - `release: minor`: backward-compatible feature, new endpoint/tool/command, new user-visible capability, or backward-compatible output enrichment
-- `release: patch`: backward-compatible bug fix, documentation-only change, tests, refactor, maintenance, or performance improvement without a new capability
+- `release: patch`: backward-compatible bug fix, documentation-only change, tests, refactor, maintenance, or performance improvement that should be included in release notes
+- `release: no-impact`: operational or repository-only changes that do not affect released npm/Docker artifacts, runtime behavior, user-visible product behavior, public APIs, CLI/MCP contracts, or release notes
 
 Examples:
 - Preserving Markdown hard breaks: `release: patch`
 - Adding `[[title]](note:id)` reference Markdown support: `release: minor`
 - Removing or changing an existing MCP/CLI contract incompatibly: `release: major`
+- CI test speedups, CI-only workflow tuning, and test runner configuration with no released artifact behavior change: `release: no-impact`
+- Local demo-only changes that are not shipped as the default product behavior: `release: no-impact`
+- Local development environment, documentation process, editor/tooling, or repository maintenance changes with no runtime/release effect: `release: no-impact`
 
 ### 3-6. Release-Impact PR
 Changes in the files below are treated as release-impacting.
@@ -115,7 +119,7 @@ Before sharing a PR URL, confirm all of the following:
 3. PR body heading emojis must use shortcode form (`:dart:`, `:hammer_and_wrench:`, etc.).
 4. `Verification Guide` contains concrete commands and expected results.
 5. The `Checklist` state is intentionally set (not left ambiguous).
-6. Exactly one release impact label is applied: `release: major`, `release: minor`, or `release: patch`, or the PR body explicitly states that the maintainer declared it no-release-impact.
+6. Exactly one release impact label is applied: `release: major`, `release: minor`, `release: patch`, or `release: no-impact`.
 
 ## 4. PR Template Path
 - Use `.github/PULL_REQUEST_TEMPLATE.md` as the official PR template.

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -10,7 +10,7 @@
         "format": "biome check --write .",
         "preview": "vite preview",
         "test": "vitest",
-        "test:ci": "vitest run --coverage --maxWorkers 1",
+        "test:ci": "vitest run --coverage",
         "type-check": "tsc --noEmit"
     },
     "dependencies": {

--- a/packages/client/src/apis/note.api.spec.ts
+++ b/packages/client/src/apis/note.api.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import {
     fetchNoteSnapshot,
     fetchNoteSnapshots,

--- a/packages/client/src/apis/server-cache.api.spec.ts
+++ b/packages/client/src/apis/server-cache.api.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { getServerCache, setServerCache } from '~/apis/server-cache.api';
 import { graphQuery } from '~/modules/graph-query';
 

--- a/packages/client/src/components/layout/SiteLayout/SidebarSearch.spec.tsx
+++ b/packages/client/src/components/layout/SiteLayout/SidebarSearch.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { fetchNotes } from '~/apis/note.api';
@@ -17,8 +17,7 @@ vi.mock('~/apis/note.api', () => ({ fetchNotes: vi.fn() }));
 
 describe('<SidebarSearch />', () => {
     it('renders debounced note suggestions and labelled controls', async () => {
-        const user = userEvent.setup();
-
+        vi.useFakeTimers();
         vi.mocked(fetchNotes).mockResolvedValue({
             type: 'success',
             allNotes: {
@@ -33,19 +32,22 @@ describe('<SidebarSearch />', () => {
 
         render(<SidebarSearch />);
 
-        await user.type(screen.getByRole('textbox'), 'alpha');
+        fireEvent.change(screen.getByRole('textbox'), { target: { value: 'alpha' } });
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(501);
+            await Promise.resolve();
+        });
 
         expect(screen.getByRole('button', { name: 'Search notes' })).toBeInTheDocument();
         expect(screen.getByRole('button', { name: 'Clear search' })).toBeInTheDocument();
 
-        await waitFor(() => {
-            expect(fetchNotes).toHaveBeenCalledWith({
-                query: 'alpha',
-                limit: 5,
-            });
+        expect(fetchNotes).toHaveBeenCalledWith({
+            query: 'alpha',
+            limit: 5,
         });
 
-        expect(await screen.findByText('Alpha note')).toBeInTheDocument();
+        expect(screen.getByText('Alpha note')).toBeInTheDocument();
     });
 
     it('navigates to the search route on submit', async () => {

--- a/packages/client/src/modules/blocknote-markdown.spec.ts
+++ b/packages/client/src/modules/blocknote-markdown.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from 'vitest';
 import { type MarkdownBlock, prepareBlocksForMarkdown, restoreTagPlaceholdersInMarkdown } from './blocknote-markdown';
 

--- a/packages/client/src/modules/route-search.spec.ts
+++ b/packages/client/src/modules/route-search.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { afterEach, vi } from 'vitest';
 
 import {

--- a/packages/client/src/modules/server-events.spec.ts
+++ b/packages/client/src/modules/server-events.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it, vi } from 'vitest';
 import { parseServerEvent, publishServerEvent, subscribeServerEvent } from './server-events';
 

--- a/packages/client/src/modules/time.spec.ts
+++ b/packages/client/src/modules/time.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from 'vitest';
 import { getRecentTimeSinceRefreshDelay, recentTimeSince, timeSince } from './time';
 

--- a/packages/client/src/modules/view-dashboard.spec.ts
+++ b/packages/client/src/modules/view-dashboard.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import {
     buildViewSectionInput,
     EMPTY_VIEWS_WORKSPACE,

--- a/packages/client/src/pages/Note.external-change.spec.tsx
+++ b/packages/client/src/pages/Note.external-change.spec.tsx
@@ -1,6 +1,5 @@
 import { QueryClientProvider } from '@tanstack/react-query';
-import { act, render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { StrictMode, Suspense } from 'react';
 import { createNote as createNoteApi, fetchNote, fetchNotePropertyKeys, updateNote } from '~/apis/note.api';
 import { ToastProvider } from '~/components/ui';
@@ -181,7 +180,6 @@ describe('<NoteContent /> external change handling', () => {
     });
 
     it('does not reopen the external-change modal when a stale detail refetch resolves after a local save', async () => {
-        const user = userEvent.setup();
         const initialNote = createNote({
             title: 'Accepted remote title',
             updatedAt: '1779700002000',
@@ -210,9 +208,8 @@ describe('<NoteContent /> external change handling', () => {
         });
 
         const titleInput = screen.getByPlaceholderText('Title');
-        await user.clear(titleInput);
-        await user.type(titleInput, 'Local title');
-        await user.click(screen.getByRole('button', { name: 'Save' }));
+        fireEvent.change(titleInput, { target: { value: 'Local title' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
         await waitFor(() => expect(updateNote).toHaveBeenCalledTimes(1));
 
@@ -231,7 +228,6 @@ describe('<NoteContent /> external change handling', () => {
     });
 
     it('ignores an older note value after reloading latest and saving a newer local edit', async () => {
-        const user = userEvent.setup();
         const remoteNote = createNote({
             title: 'Remote title',
             updatedAt: '1779700002000',
@@ -250,9 +246,8 @@ describe('<NoteContent /> external change handling', () => {
         });
 
         const titleInput = screen.getByPlaceholderText('Title');
-        await user.clear(titleInput);
-        await user.type(titleInput, 'Local title');
-        await user.click(screen.getByRole('button', { name: 'Save' }));
+        fireEvent.change(titleInput, { target: { value: 'Local title' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
         await waitFor(() => expect(updateNote).toHaveBeenCalledTimes(1));
 
@@ -267,7 +262,6 @@ describe('<NoteContent /> external change handling', () => {
     });
 
     it('does not block editing once an external update is already loaded', async () => {
-        const user = userEvent.setup();
         const initialNote = createNote({
             title: 'Initial title',
             updatedAt: '1779700001000',
@@ -312,9 +306,8 @@ describe('<NoteContent /> external change handling', () => {
         });
 
         const titleInput = screen.getByPlaceholderText('Title');
-        await user.clear(titleInput);
-        await user.type(titleInput, 'Local title');
-        await user.click(screen.getByRole('button', { name: 'Save' }));
+        fireEvent.change(titleInput, { target: { value: 'Local title' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
         await waitFor(() => expect(updateNote).toHaveBeenCalledTimes(1));
         expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
@@ -345,7 +338,6 @@ describe('<NoteContent /> external change handling', () => {
     });
 
     it('keeps local editor content after saving local content edits', async () => {
-        const user = userEvent.setup();
         const initialNote = createNote({
             content: createContent('Initial body'),
             updatedAt: '1779700001000',
@@ -364,16 +356,14 @@ describe('<NoteContent /> external change handling', () => {
             updateNote: savedNote,
         });
 
-        await user.clear(editor);
-        await user.type(editor, 'Local body');
-        await user.click(screen.getByRole('button', { name: 'Save' }));
+        fireEvent.change(editor, { target: { value: 'Local body' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
         await waitFor(() => expect(updateNote).toHaveBeenCalledTimes(1));
         expect(screen.getByLabelText('Editor')).toHaveValue('Local body');
     });
 
     it('flushes pending changes before allowing in-app navigation', async () => {
-        const user = userEvent.setup();
         const initialNote = createNote({
             title: 'Initial title',
             content: createContent('Initial body'),
@@ -387,8 +377,7 @@ describe('<NoteContent /> external change handling', () => {
         renderNote(initialNote);
 
         const titleInput = await screen.findByPlaceholderText('Title');
-        await user.clear(titleInput);
-        await user.type(titleInput, 'Route-safe title');
+        fireEvent.change(titleInput, { target: { value: 'Route-safe title' } });
 
         expect(screen.getByRole('status')).toHaveTextContent('Saving...');
 
@@ -420,7 +409,6 @@ describe('<NoteContent /> external change handling', () => {
     });
 
     it('blocks in-app navigation when the pending save fails', async () => {
-        const user = userEvent.setup();
         const initialNote = createNote({
             title: 'Initial title',
             updatedAt: '1779700001000',
@@ -429,8 +417,7 @@ describe('<NoteContent /> external change handling', () => {
         renderNote(initialNote);
 
         const titleInput = await screen.findByPlaceholderText('Title');
-        await user.clear(titleInput);
-        await user.type(titleInput, 'Unsaved title');
+        fireEvent.change(titleInput, { target: { value: 'Unsaved title' } });
 
         vi.mocked(updateNote).mockResolvedValue({
             type: 'error',
@@ -458,7 +445,6 @@ describe('<NoteContent /> external change handling', () => {
     });
 
     it('shows recovery actions after a save failure and retries the local draft', async () => {
-        const user = userEvent.setup();
         const initialNote = createNote({
             title: 'Initial title',
             updatedAt: '1779700001000',
@@ -487,9 +473,8 @@ describe('<NoteContent /> external change handling', () => {
         renderNote(initialNote);
 
         const titleInput = await screen.findByPlaceholderText('Title');
-        await user.clear(titleInput);
-        await user.type(titleInput, 'Recovered title');
-        await user.click(screen.getByRole('button', { name: 'Save' }));
+        fireEvent.change(titleInput, { target: { value: 'Recovered title' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
         expect(await screen.findByText(/Save failed. Your latest draft is still available here/)).toBeInTheDocument();
 
@@ -499,7 +484,7 @@ describe('<NoteContent /> external change handling', () => {
 
         expect(storedDraft.title).toBe('Recovered title');
 
-        await user.click(screen.getByRole('button', { name: 'Retry save' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Retry save' }));
 
         await waitFor(() => expect(updateNote).toHaveBeenCalledTimes(2));
         await waitFor(() => {
@@ -512,7 +497,6 @@ describe('<NoteContent /> external change handling', () => {
     });
 
     it('saves a failed draft as a new note without retrying the failed original save', async () => {
-        const user = userEvent.setup();
         const initialNote = createNote({
             title: 'Initial title',
             content: createContent('Initial body'),
@@ -539,13 +523,12 @@ describe('<NoteContent /> external change handling', () => {
         renderNote(initialNote);
 
         const titleInput = await screen.findByPlaceholderText('Title');
-        await user.clear(titleInput);
-        await user.type(titleInput, 'Recovered title');
-        await user.click(screen.getByRole('button', { name: 'Save' }));
+        fireEvent.change(titleInput, { target: { value: 'Recovered title' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
         expect(await screen.findByText(/Save failed. Your latest draft is still available here/)).toBeInTheDocument();
 
-        await user.click(screen.getByRole('button', { name: 'Save as new note' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Save as new note' }));
 
         expect(createNoteApi).toHaveBeenCalledWith({
             title: 'Recovered title',
@@ -553,7 +536,9 @@ describe('<NoteContent /> external change handling', () => {
             layout: 'wide',
         });
         expect(updateNote).toHaveBeenCalledTimes(1);
-        expect(window.localStorage.getItem(getDraftStorageKey(initialNote.id))).toBeNull();
+        await waitFor(() => {
+            expect(window.localStorage.getItem(getDraftStorageKey(initialNote.id))).toBeNull();
+        });
         expect(mockNavigate).toHaveBeenCalledWith({
             to: '/$id',
             params: { id: 'new-note-id' },
@@ -561,7 +546,6 @@ describe('<NoteContent /> external change handling', () => {
     });
 
     it('restores a saved browser draft into the editor', async () => {
-        const user = userEvent.setup();
         const initialNote = createNote({
             title: 'Initial title',
             content: createContent('Initial body'),
@@ -588,7 +572,7 @@ describe('<NoteContent /> external change handling', () => {
 
         expect(await screen.findByText(/A draft from/)).toBeInTheDocument();
 
-        await user.click(screen.getByRole('button', { name: 'Restore draft' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Restore draft' }));
 
         expect(screen.getByPlaceholderText('Title')).toHaveValue('Browser draft title');
         expect(screen.getByLabelText('Editor')).toHaveValue('Browser draft body');

--- a/packages/client/src/pages/graph-theme.spec.ts
+++ b/packages/client/src/pages/graph-theme.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from 'vitest';
 
 import { getGraphLabelFont, getGraphLinkColor, getGraphNodeFill, getGraphTheme } from './graph-theme';

--- a/packages/client/src/test/setup.ts
+++ b/packages/client/src/test/setup.ts
@@ -5,19 +5,24 @@ afterEach(() => {
     cleanup();
     vi.clearAllMocks();
     vi.useRealTimers();
-    window.history.pushState({}, '', '/');
+
+    if (typeof window !== 'undefined') {
+        window.history.pushState({}, '', '/');
+    }
 });
 
-Object.defineProperty(window, 'matchMedia', {
-    writable: true,
-    value: vi.fn().mockImplementation((query: string) => ({
-        matches: false,
-        media: query,
-        onchange: null,
-        addListener: vi.fn(),
-        removeListener: vi.fn(),
-        addEventListener: vi.fn(),
-        removeEventListener: vi.fn(),
-        dispatchEvent: vi.fn(),
-    })),
-});
+if (typeof window !== 'undefined') {
+    Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        value: vi.fn().mockImplementation((query: string) => ({
+            matches: false,
+            media: query,
+            onchange: null,
+            addListener: vi.fn(),
+            removeListener: vi.fn(),
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+            dispatchEvent: vi.fn(),
+        })),
+    });
+}


### PR DESCRIPTION
## :dart: Goal
Speed up PR test feedback by removing unnecessary client test serialization and reducing avoidable frontend test setup cost.

## :hammer_and_wrench: Core Changes
- Remove the client `test:ci` `--maxWorkers 1` restriction so independent Vitest files can run in parallel.
- Move pure client unit specs to the Node test environment where DOM APIs are not required.
- Guard shared client test setup so it can run under both jsdom and Node environments.
- Document the `release: no-impact` label for CI, demo-only, development-environment, and other non-release-affecting changes.
- Replace the real debounce wait in `SidebarSearch` with fake timers.
- Simplify `Note.external-change` value changes where the protected contract is save/conflict behavior, not per-key typing behavior.

## :brain: Key Decisions
- Kept user-event based interaction tests where keyboard/click behavior itself is the contract.
- Kept `StrictMode` coverage for the note external-change page test.
- Left larger page-test restructuring for a separate change because the current PR already reduces CI time with low-risk test-only changes.
- Classified this PR as `release: no-impact` because it changes CI/test operations and process docs without changing released runtime behavior.

## :test_tube: Verification Guide
- `pnpm test:ci` should pass.
- `pnpm --filter @ocean-brain/client lint` should pass.
- `pnpm check:encoding` should pass.
- Local timing improved from about `97.36s` to about `21.82s` for `pnpm test:ci` on the same machine.

## :white_check_mark: Checklist
- [x] Release impact label applied: `release: no-impact`
- [x] Local validation passed: `pnpm test:ci`
- [x] Local validation passed: `pnpm --filter @ocean-brain/client lint`
- [x] Local validation passed: `pnpm check:encoding`
- [x] PR title follows `<emoji> <subject>` with an English verb
- [x] Release impact: `release: no-impact`
