### PR TITLE
🐛 Reset note detail scroll on route changes

### DIFF
--- a/packages/client/src/components/shared/RestoreParentScroll.spec.tsx
+++ b/packages/client/src/components/shared/RestoreParentScroll.spec.tsx
@@ -1,0 +1,86 @@
+import { fireEvent, render } from '@testing-library/react';
+import { vi } from 'vitest';
+
+import RestoreParentScroll from './RestoreParentScroll';
+
+const useLocationMock = vi.fn();
+
+vi.mock('@tanstack/react-router', () => ({
+    useLocation: (options: { select: (location: { pathname: string }) => string }) => useLocationMock(options),
+}));
+
+describe('<RestoreParentScroll />', () => {
+    beforeEach(() => {
+        useLocationMock.mockReset();
+        vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+            callback(0);
+            return 0;
+        });
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('resets the parent scroll when the next route has no saved position', () => {
+        let pathname = '/';
+        useLocationMock.mockImplementation((options: { select: (location: { pathname: string }) => string }) =>
+            options.select({ pathname }),
+        );
+
+        const { container, rerender } = render(
+            <div>
+                <RestoreParentScroll />
+            </div>,
+        );
+        const scrollContainer = container.firstElementChild as HTMLDivElement;
+
+        scrollContainer.scrollTop = 240;
+        fireEvent.scroll(scrollContainer);
+
+        pathname = '/notes/1';
+        rerender(
+            <div>
+                <RestoreParentScroll />
+            </div>,
+        );
+
+        expect(scrollContainer.scrollTop).toBe(0);
+    });
+
+    it('restores the saved parent scroll when returning to a route', () => {
+        let pathname = '/';
+        useLocationMock.mockImplementation((options: { select: (location: { pathname: string }) => string }) =>
+            options.select({ pathname }),
+        );
+
+        const { container, rerender } = render(
+            <div>
+                <RestoreParentScroll />
+            </div>,
+        );
+        const scrollContainer = container.firstElementChild as HTMLDivElement;
+
+        scrollContainer.scrollTop = 240;
+        fireEvent.scroll(scrollContainer);
+
+        pathname = '/notes/1';
+        rerender(
+            <div>
+                <RestoreParentScroll />
+            </div>,
+        );
+
+        scrollContainer.scrollTop = 80;
+        fireEvent.scroll(scrollContainer);
+
+        pathname = '/';
+        rerender(
+            <div>
+                <RestoreParentScroll />
+            </div>,
+        );
+
+        expect(scrollContainer.scrollTop).toBe(240);
+    });
+});

--- a/packages/client/src/components/shared/RestoreParentScroll.tsx
+++ b/packages/client/src/components/shared/RestoreParentScroll.tsx
@@ -41,10 +41,7 @@ export default function RestoreParentScroll() {
                 }
             });
 
-            const scrollTop = memo.get(pathname);
-            if (scrollTop) {
-                parentElement.scrollTop = scrollTop;
-            }
+            parentElement.scrollTop = memo.get(pathname) ?? 0;
 
             parentElement.addEventListener('scroll', handleScroll);
 


### PR DESCRIPTION
## :dart: Goal
- Prevent detail pages from inheriting the previous list scroll position when navigating from a scrolled note list.
- Keep route-specific scroll restoration for paths that already have a saved position.

## :hammer_and_wrench: Core Changes
- Reset the parent scroll container to the top when the next route has no saved scroll position.
- Added coverage for resetting new routes and restoring previously saved routes.

## :brain: Key Decisions
- Kept the existing path-based scroll memory behavior.
- Changed only the missing fallback behavior so new routes start at the top instead of reusing the current container position.

## :test_tube: Verification Guide
### How to verify
1. Run `pnpm --filter @ocean-brain/client lint`.
2. Run `pnpm --filter @ocean-brain/client type-check`.
3. Run `pnpm --filter @ocean-brain/client test -- RestoreParentScroll.spec.tsx --run`.

### Expected result
- Lint passes.
- Type-check passes.
- Scroll restoration tests pass.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)