### PR TITLE
🐛 Omit local images from document exports

### DIFF
--- a/packages/client/src/modules/note-export.spec.ts
+++ b/packages/client/src/modules/note-export.spec.ts
@@ -34,13 +34,37 @@ describe('note-export', () => {
 
     it('omits local image assets from document-only markdown exports', () => {
         const markdown = createMarkdownDocumentExport(
-            'Before\n![Local](/assets/images/2026/4/15/photo.png)\n![External](https://example.com/external.png)',
+            [
+                'Before',
+                '![Local](/assets/images/2026/4/15/photo.png)',
+                '![(image) sample building photo.png](/assets/images/2024/8/13/1723517460089.png)',
+                '![[[[]]] ((()))](/assets/images/nested/alt.png)',
+                '![Title](/assets/images/with-title.png "Local title")',
+                '![Paren URL](/assets/images/path/image(foo).png)',
+                '![Angle URL](</assets/images/path/image(bar).png> "Angle title")',
+                '![External](https://example.com/external.png)',
+                '![External Paren](https://example.com/image(foo).png "External title")',
+            ].join('\n'),
             { id: '123', title: 'Hello' },
         );
 
-        expect(markdown).toContain('<!-- Local Ocean Brain image omitted from document-only export. -->');
+        expect(markdown).toBe(
+            [
+                'Before',
+                '',
+                '',
+                '',
+                '',
+                '',
+                '',
+                '![External](https://example.com/external.png)',
+                '![External Paren](https://example.com/image(foo).png "External title")',
+            ].join('\n'),
+        );
         expect(markdown).not.toContain('/assets/images/');
+        expect(markdown).not.toContain('![(image) sample building photo.png]');
         expect(markdown).toContain('![External](https://example.com/external.png)');
+        expect(markdown).toContain('![External Paren](https://example.com/image(foo).png "External title")');
     });
 
     it('exports local image assets into a markdown zip and rewrites markdown image paths', async () => {
@@ -73,7 +97,9 @@ describe('note-export', () => {
             { id: '123', title: 'Hello' },
         );
 
-        expect(html).toContain('<!-- Local Ocean Brain image omitted from document-only export. -->');
+        expect(html).toBe(
+            '<figure><figcaption>Local photo</figcaption></figure><img src="https://example.com/external.png" alt="External">',
+        );
         expect(html).not.toContain('/assets/images/');
         expect(html).toContain('<figcaption>Local photo</figcaption>');
         expect(html).toContain('src="https://example.com/external.png"');
@@ -85,7 +111,7 @@ describe('note-export', () => {
             { id: '123', title: 'Hello' },
         );
 
-        expect(html).toContain('<!-- Local Ocean Brain image omitted from document-only export. -->');
+        expect(html).toBe('<p data-copy="<img src=\'/assets/images/not-real.png\'>">Text</p>');
         expect(html).not.toContain('src=/assets/images/a/unquoted.png');
         expect(html).toContain('data-copy="<img src=\'/assets/images/not-real.png\'>"');
     });

--- a/packages/client/src/modules/note-export.ts
+++ b/packages/client/src/modules/note-export.ts
@@ -24,7 +24,6 @@ interface MarkdownDocumentExportOptions {
 
 const YAML_SPECIAL_CHAR_PATTERN = /[:{}[\],&*#?|<>=!%@`-]/;
 const LOCAL_IMAGE_ASSET_PREFIX = '/assets/images/';
-const LOCAL_IMAGE_OMITTED_COMMENT = '<!-- Local Ocean Brain image omitted from document-only export. -->';
 
 const normalizeTitleForFilename = (title: string) => {
     const normalized = title
@@ -337,32 +336,52 @@ const applyTextReplacements = (
 };
 
 const findMarkdownImageTags = (markdown: string) => {
-    const imagePattern = /!\[[^\]\n]*\]\([^)]+?\)/g;
     const ranges: Array<{
         end: number;
         source: { end: number; start: number; value: string };
         start: number;
     }> = [];
+    let searchIndex = 0;
 
-    for (const match of markdown.matchAll(imagePattern)) {
-        if (match.index === undefined) {
+    while (searchIndex < markdown.length) {
+        const start = markdown.indexOf('![', searchIndex);
+
+        if (start === -1) {
+            break;
+        }
+
+        let cursor = start + 2;
+        let altDepth = 1;
+
+        while (cursor < markdown.length && altDepth > 0 && markdown[cursor] !== '\n') {
+            if (markdown[cursor] === '\\') {
+                cursor += 2;
+                continue;
+            }
+
+            if (markdown[cursor] === '[') {
+                altDepth += 1;
+            } else if (markdown[cursor] === ']') {
+                altDepth -= 1;
+            }
+
+            cursor += 1;
+        }
+
+        if (altDepth !== 0 || markdown[cursor] !== '(') {
+            searchIndex = start + 2;
             continue;
         }
 
-        const fullMatch = match[0];
-        const openParenIndex = fullMatch.indexOf('(');
-        const closeParenIndex = fullMatch.lastIndexOf(')');
+        const sourceStartWithWhitespace = cursor + 1;
+        let sourceStart = sourceStartWithWhitespace;
 
-        if (openParenIndex < 0 || closeParenIndex < 0 || closeParenIndex <= openParenIndex) {
-            continue;
-        }
-
-        let sourceStart = openParenIndex + 1;
-        while (sourceStart < closeParenIndex && /\s/.test(fullMatch[sourceStart])) {
+        while (sourceStart < markdown.length && markdown[sourceStart] !== '\n' && /\s/.test(markdown[sourceStart])) {
             sourceStart += 1;
         }
 
-        if (sourceStart >= closeParenIndex) {
+        if (sourceStart >= markdown.length || markdown[sourceStart] === '\n') {
+            searchIndex = start + 2;
             continue;
         }
 
@@ -370,34 +389,105 @@ const findMarkdownImageTags = (markdown: string) => {
         let sourceValueStart = sourceStart;
         let sourceValueEnd = sourceStart;
 
-        if (fullMatch[sourceStart] === '<') {
-            const angleEnd = fullMatch.indexOf('>', sourceStart + 1);
+        if (markdown[sourceStart] === '<') {
+            cursor = sourceStart + 1;
 
-            if (angleEnd === -1 || angleEnd > closeParenIndex) {
+            while (cursor < markdown.length && markdown[cursor] !== '>' && markdown[cursor] !== '\n') {
+                cursor += markdown[cursor] === '\\' ? 2 : 1;
+            }
+
+            if (markdown[cursor] !== '>') {
+                searchIndex = start + 2;
                 continue;
             }
 
-            sourceEnd = angleEnd + 1;
+            sourceEnd = cursor + 1;
             sourceValueStart = sourceStart + 1;
-            sourceValueEnd = angleEnd;
+            sourceValueEnd = cursor;
         } else {
-            while (sourceEnd < closeParenIndex && !/\s/.test(fullMatch[sourceEnd])) {
-                sourceEnd += 1;
+            let parenDepth = 0;
+            cursor = sourceStart;
+
+            while (cursor < markdown.length && markdown[cursor] !== '\n') {
+                const character = markdown[cursor];
+
+                if (character === '\\') {
+                    cursor += 2;
+                    continue;
+                }
+
+                if (/\s/.test(character) && parenDepth === 0) {
+                    break;
+                }
+
+                if (character === '(') {
+                    parenDepth += 1;
+                } else if (character === ')') {
+                    if (parenDepth === 0) {
+                        break;
+                    }
+
+                    parenDepth -= 1;
+                }
+
+                cursor += 1;
             }
 
+            sourceEnd = cursor;
             sourceValueStart = sourceStart;
             sourceValueEnd = sourceEnd;
         }
 
+        if (sourceValueEnd <= sourceValueStart) {
+            searchIndex = start + 2;
+            continue;
+        }
+
+        cursor = sourceEnd;
+
+        while (cursor < markdown.length && markdown[cursor] !== '\n' && /\s/.test(markdown[cursor])) {
+            cursor += 1;
+        }
+
+        if (markdown[cursor] === '"' || markdown[cursor] === "'") {
+            const quote = markdown[cursor];
+            cursor += 1;
+
+            while (cursor < markdown.length && markdown[cursor] !== '\n') {
+                if (markdown[cursor] === '\\') {
+                    cursor += 2;
+                    continue;
+                }
+
+                if (markdown[cursor] === quote) {
+                    cursor += 1;
+                    break;
+                }
+
+                cursor += 1;
+            }
+        }
+
+        while (cursor < markdown.length && markdown[cursor] !== '\n' && /\s/.test(markdown[cursor])) {
+            cursor += 1;
+        }
+
+        if (markdown[cursor] !== ')') {
+            searchIndex = start + 2;
+            continue;
+        }
+
         ranges.push({
-            end: match.index + fullMatch.length,
+            end: cursor + 1,
             source: {
-                end: match.index + sourceEnd,
-                start: match.index + sourceStart,
-                value: fullMatch.slice(sourceValueStart, sourceValueEnd),
+                end: sourceEnd,
+                start: sourceStartWithWhitespace,
+                value: markdown.slice(sourceValueStart, sourceValueEnd),
             },
-            start: match.index,
+            start,
         });
+
+        searchIndex = cursor + 1;
     }
 
     return ranges;
@@ -444,7 +534,7 @@ export const createMarkdownDocumentExport = (
         .map((imageTag) => ({
             end: imageTag.end,
             start: imageTag.start,
-            value: LOCAL_IMAGE_OMITTED_COMMENT,
+            value: '',
         }));
 
     return applyTextReplacements(markdownExport, replacements);
@@ -473,7 +563,7 @@ export const createHtmlDocumentExport = (
         .map((imageTag) => ({
             end: imageTag.end,
             start: imageTag.start,
-            value: LOCAL_IMAGE_OMITTED_COMMENT,
+            value: '',
         }));
 
     return applyHtmlReplacements(htmlExport, replacements);

--- a/packages/client/src/pages/Note.tsx
+++ b/packages/client/src/pages/Note.tsx
@@ -38,6 +38,7 @@ import useNoteMutate from '~/hooks/resource/useNoteMutate';
 import { useNoteSaveController } from '~/hooks/useNoteSaveController';
 import type { Note, NoteLayout, NoteProperty, NotePropertyValueType } from '~/models/note.model';
 import { replaceFixedPlaceholder } from '~/modules/fixed-placeholder';
+import { createMarkdownDocumentExport } from '~/modules/note-export';
 import { queryKeys } from '~/modules/query-key-factory';
 import { publishClientNoteUpdatedEvent, subscribeServerEvent } from '~/modules/server-events';
 import { getRecentTimeSinceRefreshDelay, recentTimeSince } from '~/modules/time';
@@ -960,7 +961,7 @@ export function NoteContent({ id }: NoteContentProps) {
         }
 
         try {
-            await navigator.clipboard.writeText(markdown);
+            await navigator.clipboard.writeText(createMarkdownDocumentExport(markdown, getExportMetadata()));
             toast('Copied note as Markdown.');
         } catch {
             toast('Failed to copy Markdown.');


### PR DESCRIPTION
## :dart: Goal
- Prevent document-only Markdown exports and copied Markdown from exposing local image asset paths.
- Remove noisy omitted-image comments from document-only exports.

## :hammer_and_wrench: Core Changes
- Omit local `/assets/images/` Markdown images from document-only Markdown output.
- Omit local image tags from document-only HTML output without inserting comments.
- Apply the same local image filtering to the Copy Markdown action.
- Harden Markdown image scanning for nested brackets, parenthesized URLs, angle URLs, and optional titles.

## :brain: Key Decisions
- Keep external images and external URLs unchanged.
- Keep ZIP exports as the path for preserving local image assets.
- Avoid exposing internal local asset paths when assets are not bundled.

## :test_tube: Verification Guide
### How to verify
1. Run `pnpm --filter @ocean-brain/client test -- note-export.spec.ts --run`.
2. Run `pnpm --filter @ocean-brain/client lint`.
3. Run `pnpm --filter @ocean-brain/client type-check`.

### Expected result
- Document-only Markdown/HTML exports omit local images and local asset paths.
- External images remain in the exported document.
- All commands pass.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)