### PR TITLE
🐛 Refresh stale login pages before submit

### DIFF
--- a/packages/server/src/features/auth/http/login-page.html
+++ b/packages/server/src/features/auth/http/login-page.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="ocean-brain-session-generation" content="OCEAN_BRAIN_SESSION_GENERATION" />
     <title>Ocean Brain Sign In</title>
     <style>
         :root {
@@ -201,5 +202,63 @@
             </form>
         </section>
     </main>
+    <script>
+        (() => {
+            const generationMeta = document.querySelector('meta[name="ocean-brain-session-generation"]');
+            const pageGeneration = generationMeta?.getAttribute('content');
+            const generationHeader = 'X-Ocean-Brain-Session-Generation';
+            const sessionEndpoint = '/api/auth/session';
+            let checkPromise;
+            let submitting = false;
+
+            const checkForStaleLoginPage = async () => {
+                if (!pageGeneration) {
+                    return false;
+                }
+
+                checkPromise ??= fetch(sessionEndpoint, {
+                    cache: 'no-store',
+                    credentials: 'same-origin',
+                })
+                    .then((response) => {
+                        const currentGeneration = response.headers.get(generationHeader);
+                        const isStale = Boolean(currentGeneration && currentGeneration !== pageGeneration);
+
+                        if (isStale) {
+                            window.location.reload();
+                        }
+
+                        return isStale;
+                    })
+                    .catch(() => false)
+                    .finally(() => {
+                        checkPromise = undefined;
+                    });
+
+                return checkPromise;
+            };
+
+            void checkForStaleLoginPage();
+            window.addEventListener('pageshow', () => {
+                void checkForStaleLoginPage();
+            });
+
+            document.querySelector('form')?.addEventListener('submit', async (event) => {
+                if (submitting) {
+                    return;
+                }
+
+                event.preventDefault();
+
+                const isStale = await checkForStaleLoginPage();
+                if (isStale) {
+                    return;
+                }
+
+                submitting = true;
+                event.currentTarget.submit();
+            });
+        })();
+    </script>
 </body>
 </html>

--- a/packages/server/src/features/auth/http/login-page.ts
+++ b/packages/server/src/features/auth/http/login-page.ts
@@ -4,6 +4,7 @@ declare const __LOGIN_PAGE_TEMPLATE__: string | undefined;
 
 const LOGIN_ERROR_TOKEN = '<!-- OCEAN_BRAIN_LOGIN_ERROR -->';
 const NEXT_PATH_TOKEN = 'OCEAN_BRAIN_NEXT_PATH';
+const SESSION_GENERATION_TOKEN = 'OCEAN_BRAIN_SESSION_GENERATION';
 
 const readLoginPageTemplate = () => {
     if (typeof __LOGIN_PAGE_TEMPLATE__ === 'string') {
@@ -27,6 +28,7 @@ interface LoginPageParams {
     nextPath: string;
     errorMessage?: string;
     csrfToken?: string;
+    sessionGeneration?: string;
 }
 
 const renderLoginError = (errorMessage?: string) => {
@@ -45,15 +47,22 @@ const renderCsrfInput = (csrfToken?: string) => {
     return `<input type="hidden" name="_csrf" value="${escapeHtml(csrfToken)}" />`;
 };
 
-const renderLoginTemplate = (values: { errorBlock: string; nextPath: string; csrfInput: string }) => {
+const renderLoginTemplate = (values: {
+    errorBlock: string;
+    nextPath: string;
+    csrfInput: string;
+    sessionGeneration: string;
+}) => {
     return LOGIN_PAGE_TEMPLATE.replace(LOGIN_ERROR_TOKEN, values.errorBlock)
+        .replace(SESSION_GENERATION_TOKEN, values.sessionGeneration)
         .replace(NEXT_PATH_TOKEN, values.nextPath)
         .replace('<!-- OCEAN_BRAIN_CSRF_INPUT -->', values.csrfInput);
 };
 
-export const renderLoginPage = ({ nextPath, errorMessage, csrfToken }: LoginPageParams) =>
+export const renderLoginPage = ({ nextPath, errorMessage, csrfToken, sessionGeneration }: LoginPageParams) =>
     renderLoginTemplate({
         errorBlock: renderLoginError(errorMessage),
         nextPath: escapeHtml(nextPath),
         csrfInput: renderCsrfInput(csrfToken),
+        sessionGeneration: escapeHtml(sessionGeneration ?? ''),
     });

--- a/packages/server/src/features/auth/http/pages.test.ts
+++ b/packages/server/src/features/auth/http/pages.test.ts
@@ -80,6 +80,11 @@ const extractCsrfTokenFromHtml = (html: string) => {
     return match?.[1];
 };
 
+const extractSessionGenerationFromHtml = (html: string) => {
+    const match = html.match(/name="ocean-brain-session-generation" content="([^"]*)"/);
+    return match?.[1];
+};
+
 const extractCsrfTokenFromCookie = (cookie?: string) => {
     const token = cookie
         ?.split(';')
@@ -90,7 +95,13 @@ const extractCsrfTokenFromCookie = (cookie?: string) => {
     return token ? decodeURIComponent(token) : undefined;
 };
 
-const formRequest = async (baseUrl: string, path: string, body: Record<string, string>, cookie?: string) => {
+const formRequest = async (
+    baseUrl: string,
+    path: string,
+    body: Record<string, string>,
+    cookie?: string,
+    options: { includeCsrfHeader?: boolean } = {},
+) => {
     const csrfToken = extractCsrfTokenFromCookie(cookie);
     const response = await fetch(`${baseUrl}${path}`, {
         method: 'POST',
@@ -98,7 +109,7 @@ const formRequest = async (baseUrl: string, path: string, body: Record<string, s
         headers: {
             'Content-Type': 'application/x-www-form-urlencoded',
             ...(cookie ? { Cookie: cookie } : {}),
-            ...(csrfToken ? { 'X-XSRF-TOKEN': csrfToken } : {}),
+            ...(options.includeCsrfHeader !== false && csrfToken ? { 'X-XSRF-TOKEN': csrfToken } : {}),
         },
         body: new URLSearchParams(body).toString(),
     });
@@ -143,15 +154,19 @@ test('password mode blocks client routes until the server-side login form succee
     const loginPageHtml = await loginPage.text();
     const loginCookie = toCookieHeader(getSetCookies(loginPage.headers));
     const csrfToken = extractCsrfTokenFromHtml(loginPageHtml);
+    const pageSessionGeneration = extractSessionGenerationFromHtml(loginPageHtml);
 
     assert.equal(loginPage.status, 200);
+    assert.equal(loginPage.headers.get('cache-control'), 'no-store');
     assert.match(loginPageHtml, /Ocean Brain/);
     assert.doesNotMatch(loginPageHtml, /Enter the workspace password to continue/);
     assert.doesNotMatch(loginPageHtml, /This session must be authenticated/);
     assert.match(loginPageHtml, /<form method="post" action="\/login">/);
     assert.match(loginPageHtml, /name="_csrf"/);
     assert.match(loginPageHtml, /name="next" value="\/notes"/);
+    assert.match(loginPageHtml, /X-Ocean-Brain-Session-Generation/);
     assert.ok(csrfToken);
+    assert.ok(pageSessionGeneration);
 
     const invalidLogin = await formRequest(
         baseUrl,
@@ -166,6 +181,15 @@ test('password mode blocks client routes until the server-side login form succee
 
     assert.equal(invalidLogin.status, 401);
     assert.match(invalidLogin.text, /Invalid password/);
+    assert.match(invalidLogin.text, /name="ocean-brain-session-generation"/);
+
+    const preSubmitSession = await fetch(`${baseUrl}/api/auth/session`, {
+        headers: invalidLogin.cookie ? { Cookie: invalidLogin.cookie } : undefined,
+    });
+    const preSubmitCookie = mergeCookieHeaders(
+        invalidLogin.cookie,
+        toCookieHeader(getSetCookies(preSubmitSession.headers)),
+    );
 
     const validLogin = await formRequest(
         baseUrl,
@@ -175,7 +199,8 @@ test('password mode blocks client routes until the server-side login form succee
             password: 'secret',
             _csrf: csrfToken,
         },
-        invalidLogin.cookie,
+        preSubmitCookie,
+        { includeCsrfHeader: false },
     );
 
     assert.equal(validLogin.status, 303);
@@ -273,15 +298,26 @@ test('password login page redirects stale CSRF submissions to a fresh login page
     const authConfig = createPasswordAuthConfig();
     const firstServer = await startServer(t, authConfig);
     const loginPage = await fetch(`${firstServer.baseUrl}/login?next=%2Fnotes`);
-    const csrfToken = extractCsrfTokenFromHtml(await loginPage.text());
+    const loginPageHtml = await loginPage.text();
+    const csrfToken = extractCsrfTokenFromHtml(loginPageHtml);
+    const pageSessionGeneration = extractSessionGenerationFromHtml(loginPageHtml);
     const loginCookie = toCookieHeader(getSetCookies(loginPage.headers));
 
     assert.ok(csrfToken);
+    assert.ok(pageSessionGeneration);
     assert.ok(loginCookie);
 
     await firstServer.close();
 
     const secondServer = await startServer(t, authConfig);
+    const sessionStatus = await fetch(`${secondServer.baseUrl}/api/auth/session`, {
+        headers: { Cookie: loginCookie },
+    });
+    const currentSessionGeneration = sessionStatus.headers.get('x-ocean-brain-session-generation');
+
+    assert.ok(currentSessionGeneration);
+    assert.equal(currentSessionGeneration, pageSessionGeneration);
+
     const response = await formRequest(
         secondServer.baseUrl,
         '/login',

--- a/packages/server/src/features/auth/http/pages.ts
+++ b/packages/server/src/features/auth/http/pages.ts
@@ -3,23 +3,36 @@ import type { Controller } from '~/types/index.js';
 import {
     compareSharedSecret,
     destroySession,
+    getSessionGeneration,
     refreshCsrfToken,
     regenerateSession,
     sanitizeRedirectPath,
 } from '../service.js';
 import { renderLoginPage } from './login-page.js';
 
+const setLoginPageHeaders = (res: Parameters<Controller>[1]) => {
+    res.set('Cache-Control', 'no-store');
+};
+
 export const createLoginPageHandler = (authConfig: AuthConfig): Controller => {
     return async (req, res) => {
         if (authConfig.mode !== 'password' || req.session?.authenticated) {
+            setLoginPageHeaders(res);
             res.redirect(303, sanitizeRedirectPath(req.query.next));
             return;
         }
 
         const nextPath = sanitizeRedirectPath(req.query.next);
+        setLoginPageHeaders(res);
         res.status(200)
             .type('html')
-            .send(renderLoginPage({ nextPath, csrfToken: res.locals._csrf }))
+            .send(
+                renderLoginPage({
+                    nextPath,
+                    csrfToken: res.locals._csrf,
+                    sessionGeneration: getSessionGeneration(),
+                }),
+            )
             .end();
     };
 };
@@ -29,6 +42,7 @@ export const createLoginPageSubmitHandler = (authConfig: AuthConfig): Controller
         const nextPath = sanitizeRedirectPath(req.body?.next);
 
         if (authConfig.mode !== 'password' || !authConfig.password) {
+            setLoginPageHeaders(res);
             res.redirect(303, nextPath);
             return;
         }
@@ -36,6 +50,7 @@ export const createLoginPageSubmitHandler = (authConfig: AuthConfig): Controller
         const password = typeof req.body?.password === 'string' ? req.body.password : '';
 
         if (!password || !compareSharedSecret(authConfig.password, password)) {
+            setLoginPageHeaders(res);
             res.status(401)
                 .type('html')
                 .send(
@@ -43,6 +58,7 @@ export const createLoginPageSubmitHandler = (authConfig: AuthConfig): Controller
                         nextPath,
                         errorMessage: 'Invalid password',
                         csrfToken: res.locals._csrf,
+                        sessionGeneration: getSessionGeneration(),
                     }),
                 )
                 .end();
@@ -53,6 +69,7 @@ export const createLoginPageSubmitHandler = (authConfig: AuthConfig): Controller
         req.session.authenticated = true;
         refreshCsrfToken(req);
 
+        setLoginPageHeaders(res);
         res.redirect(303, nextPath);
     };
 };
@@ -61,10 +78,12 @@ export const createLogoutPageHandler = (authConfig: AuthConfig): Controller => {
     return async (req, res) => {
         if (authConfig.mode === 'password') {
             await destroySession(req);
+            setLoginPageHeaders(res);
             res.redirect(303, '/login');
             return;
         }
 
+        setLoginPageHeaders(res);
         res.redirect(303, '/');
     };
 };

--- a/packages/server/src/features/auth/service.ts
+++ b/packages/server/src/features/auth/service.ts
@@ -9,6 +9,8 @@ import { createAppError } from '~/modules/error-handler.js';
 export const AUTH_SESSION_GENERATION_HEADER = 'X-Ocean-Brain-Session-Generation';
 const AUTH_SESSION_GENERATION = crypto.randomUUID();
 
+export const getSessionGeneration = () => AUTH_SESSION_GENERATION;
+
 export const createPasswordHash = async (password: string) => {
     const salt = crypto.randomBytes(16).toString('hex');
     const hash = crypto.pbkdf2Sync(password, salt, 1000, 64, 'sha512').toString('hex');
@@ -27,7 +29,7 @@ export const buildSessionResponse = (authConfig: AuthConfig, req: Request) =>
     buildAuthSessionResponse(authConfig, Boolean(req.session?.authenticated));
 
 export const setSessionStatusHeaders = (res: Response) => {
-    res.set(AUTH_SESSION_GENERATION_HEADER, AUTH_SESSION_GENERATION);
+    res.set(AUTH_SESSION_GENERATION_HEADER, getSessionGeneration());
     res.set('Cache-Control', 'no-store');
 };
 


### PR DESCRIPTION
## :dart: Goal
- Prevent stale server-owned login pages from making users submit the same password twice after a server restart or session generation change.
- Keep the login flow aligned with the existing full-page refresh behavior for new server generations.

## :hammer_and_wrench: Core Changes
- Embed the current auth session generation into the server-rendered login page.
- Make the login page check the current session generation on load, page restore, and immediately before form submit.
- Reload the login page before submitting if the page generation is stale.
- Mark login page responses as `no-store` to avoid reusing stale login HTML.
- Extend auth page tests for generation metadata, pre-submit session checks, and stale CSRF handling.

## :brain: Key Decisions
- Chose a full page reload instead of silently replacing only the CSRF token so the browser always uses the newest login HTML and server state.
- Kept the existing CSRF failure redirect behavior as a fallback for non-JavaScript or race-condition cases.
- Reused the existing session generation header instead of adding a new server version endpoint.

## :test_tube: Verification Guide
### How to verify
1. `pnpm --filter @ocean-brain/server exec tsx --tsconfig tsconfig.json --test src/features/auth/http/pages.test.ts`
2. `pnpm --filter @ocean-brain/server lint`
3. `pnpm --filter @ocean-brain/server type-check`
4. `pnpm build`
5. `pnpm test:ci`

### Expected result
- Commands 1-4 pass.
- `pnpm test:ci` currently fails in `packages/server/test/blocknote.test.ts` hard-break related cases, outside this auth change; auth page tests pass.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed for changed auth scope
- [x] Documentation updated (if needed): not needed
