### PR TITLE
🐛 Fix first login form submission

### DIFF
--- a/packages/server/src/features/auth/http/login-page.html
+++ b/packages/server/src/features/auth/http/login-page.html
@@ -208,6 +208,7 @@
             const pageGeneration = generationMeta?.getAttribute('content');
             const generationHeader = 'X-Ocean-Brain-Session-Generation';
             const sessionEndpoint = '/api/auth/session';
+            const form = document.querySelector('form');
             let checkPromise;
             let submitting = false;
 
@@ -243,20 +244,21 @@
                 void checkForStaleLoginPage();
             });
 
-            document.querySelector('form')?.addEventListener('submit', async (event) => {
+            form?.addEventListener('submit', async (event) => {
+                event.preventDefault();
+
                 if (submitting) {
                     return;
                 }
 
-                event.preventDefault();
+                submitting = true;
 
                 const isStale = await checkForStaleLoginPage();
                 if (isStale) {
                     return;
                 }
 
-                submitting = true;
-                event.currentTarget.submit();
+                form.submit();
             });
         })();
     </script>

--- a/packages/server/test/login-page-browser.test.ts
+++ b/packages/server/test/login-page-browser.test.ts
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { JSDOM } from 'jsdom';
+import { renderLoginPage } from '~/features/auth/http/login-page.js';
+
+const waitForBrowserTasks = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+test('login page submits the form on the first submit event', async (t) => {
+    let nativeSubmitCount = 0;
+    const html = renderLoginPage({
+        nextPath: '/notes',
+        csrfToken: 'csrf-token',
+        sessionGeneration: 'generation-1',
+    });
+    const dom = new JSDOM(html, {
+        url: 'http://localhost/login',
+        runScripts: 'dangerously',
+        beforeParse: (window) => {
+            Object.defineProperty(window, 'fetch', {
+                configurable: true,
+                value: async () =>
+                    new Response(null, {
+                        headers: {
+                            'X-Ocean-Brain-Session-Generation': 'generation-1',
+                        },
+                    }),
+            });
+            Object.defineProperty(window.HTMLFormElement.prototype, 'submit', {
+                configurable: true,
+                value: () => {
+                    nativeSubmitCount += 1;
+                },
+            });
+        },
+    });
+    t.after(() => dom.window.close());
+    await waitForBrowserTasks();
+
+    const form = dom.window.document.querySelector('form');
+    const submitButton = dom.window.document.querySelector('button[type="submit"]');
+
+    assert.ok(form);
+    assert.ok(submitButton);
+
+    const submitEvent = new dom.window.SubmitEvent('submit', {
+        bubbles: true,
+        cancelable: true,
+        submitter: submitButton,
+    });
+
+    form.dispatchEvent(submitEvent);
+    await waitForBrowserTasks();
+
+    assert.equal(submitEvent.defaultPrevented, true);
+    assert.equal(nativeSubmitCount, 1);
+});


### PR DESCRIPTION
## :dart: Goal
- Make the password login form submit on the first click.
- Prevent duplicate submissions while the session-generation check is pending.

## :hammer_and_wrench: Core Changes
- Capture the login form before the asynchronous submit handler runs.
- Prevent every intercepted submit before checking the in-flight submission guard.
- Mark the submission as active before awaiting the session-generation check.
- Add a DOM regression test that executes the real inline login script and verifies one-click native submission.

## :brain: Key Decisions
- Kept the stale-login-page generation check and CSRF flow unchanged.
- Used the native form submit method after the asynchronous guard to avoid recursively firing the submit listener.
- Placed the regression test in the server test directory so the existing CI glob executes it.
- Release impact: release: patch.

## :test_tube: Verification Guide
### How to verify
1. Run `pnpm check:encoding`.
2. Run `pnpm lint`.
3. Run `pnpm test:ci`.
4. Run `pnpm type-check`.
5. Run `pnpm build`.
6. Open the development login page, enter a password, and click Sign in once.

### Expected result
- All standard checks pass.
- Server CI reports 76 passing tests.
- A single click sends one POST request to /login.
- Repeated clicks during the generation check do not bypass or duplicate submission.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Build completed
- [x] Browser flow verified
- [x] Documentation updated (not needed; expected login behavior is restored)