### PR TITLE
✅ Allow home query parameters in E2E

### DIFF
--- a/tests/e2e/auth-shell.spec.ts
+++ b/tests/e2e/auth-shell.spec.ts
@@ -16,7 +16,7 @@ test('unauthenticated users see the login page and authenticated users load the 
     await page.getByLabel('Password').fill('e2e-password');
     await page.getByRole('button', { name: 'Sign in' }).click();
 
-    await expect(page).toHaveURL('/');
+    await expect(page).toHaveURL((url) => url.pathname === '/');
     await expect(page.locator('#root')).not.toBeEmpty();
 
     expect(pageErrors).toEqual([]);


### PR DESCRIPTION
## :dart: Goal
- Restore reliable release E2E validation after the home route began normalizing default search parameters.
- Keep the login test focused on reaching the authenticated home route rather than an exact query string.

## :hammer_and_wrench: Core Changes
- Assert the authenticated URL pathname is `/`.
- Allow the router to append its canonical default home search parameters.

## :brain: Key Decisions
- Kept the assertion strict about the destination path.
- Did not change runtime routing or login behavior.
- Release impact: release: no-impact.

## :test_tube: Verification Guide
### How to verify
1. Run `pnpm check:encoding`.
2. Run `pnpm lint`.
3. Run `pnpm type-check`.
4. Run `pnpm build`.
5. Run `pnpm test:e2e`.

### Expected result
- All commands pass.
- The authenticated browser reaches the `/` pathname.
- Canonical home query parameters do not fail the login E2E test.

## :white_check_mark: Checklist
- [x] Encoding check completed
- [x] Lint completed
- [x] Type-check completed
- [x] Build completed
- [x] E2E completed
- [x] Release impact label applied: `release: no-impact`