### PR TITLE
📝 Streamline npm and Docker setup documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The editor comes first. Capture a note in the browser, connect it to other notes
 
 Ocean Brain works well for project decisions, research trails, meeting notes, learning notes, and ideas that are not finished yet.
 
-[Try the live demo](https://demo-ocean-brain.baejino.com/) · [Run Ocean Brain](#run-ocean-brain)
+[Try the live demo](https://demo-ocean-brain.baejino.com/) · [Quick start](#quick-start)
 
 The demo keeps workspace edits in your browser. It does not include server-backed features such as note snapshots or MCP access.
 
@@ -23,156 +23,43 @@ The demo keeps workspace edits in your browser. It does not include server-backe
 
 Notes can be copied as Markdown or downloaded as Markdown or HTML. Local image assets can be bundled with an export when the document needs to stand on its own.
 
-## Run Ocean Brain
+## Quick start
 
-One Ocean Brain instance is one shared workspace. Password mode protects the whole instance with a single shared password; it does not provide individual accounts, roles, or per-note permissions.
+These commands enable password mode and bind Ocean Brain to your own machine. Choose a strong password; each example generates a session secret for the current run.
 
-Ocean Brain will not start until you explicitly choose password mode or open mode. The two modes cannot be enabled together.
+### npx
 
-### Private local trial
-
-With Node.js 22 installed, the shortest path to a private local trial is `npx`. Open mode has no login, so keep it bound to your own machine:
+With Node.js 22 installed:
 
 ```bash
-HOST=127.0.0.1 \
-PORT=6683 \
-npx ocean-brain serve --allow-insecure-no-auth
-```
-
-Open <http://localhost:6683>. Notes and uploaded images are stored under `~/.ocean-brain` and remain there across restarts.
-
-### Password mode with npx
-
-Password mode needs both a workspace password and a separate session secret. Generate the session secret once, keep it private, and reuse it across restarts.
-
-```bash
-HOST=127.0.0.1 \
-PORT=6683 \
 OCEAN_BRAIN_PASSWORD='choose-a-strong-password' \
-OCEAN_BRAIN_SESSION_SECRET='paste-a-long-random-secret-here' \
+OCEAN_BRAIN_SESSION_SECRET="$(openssl rand -hex 32)" \
+HOST=127.0.0.1 \
+PORT=6683 \
 npx ocean-brain serve
 ```
 
-For example, `openssl rand -hex 32` generates a suitable random session secret.
+Open <http://localhost:6683>. Notes and images persist under `~/.ocean-brain`.
+
+For a stable session secret, storage settings, open mode, and the complete `serve` and `mcp` command reference, see the [npm CLI guide](./packages/cli/README.md).
 
 ### Docker
 
-The Docker example uses password mode, persists the database and images on the host, and publishes the app on loopback only.
-
 ```bash
-docker run -d \
-  --name ocean-brain \
-  --restart unless-stopped \
+docker run --rm \
   -e OCEAN_BRAIN_PASSWORD='choose-a-strong-password' \
-  -e OCEAN_BRAIN_SESSION_SECRET='paste-a-long-random-secret-here' \
-  -v "$PWD/data:/data" \
-  -v "$PWD/assets:/assets" \
+  -e OCEAN_BRAIN_SESSION_SECRET="$(openssl rand -hex 32)" \
   -p 127.0.0.1:6683:6683 \
   baealex/ocean-brain:latest
 ```
 
-`latest` is convenient for evaluation. For an instance you intend to keep, use an exact tag from [GitHub Releases](https://github.com/baealex/ocean-brain/releases), written as `baealex/ocean-brain:<version>`.
+Open <http://localhost:6683>. This trial is disposable when the container stops.
 
-Before exposing Ocean Brain beyond the host machine:
-
-- Keep password mode enabled.
-- Put the instance behind HTTPS.
-- Change the loopback bind only when your network or reverse proxy requires it.
-- Back up the database and images before upgrading.
-
-In password mode, uploaded image URLs are protected by the same authenticated session as the workspace.
-
-### Runtime settings
-
-| Setting | Purpose |
-|---|---|
-| `OCEAN_BRAIN_PASSWORD` | Shared password for the workspace |
-| `OCEAN_BRAIN_SESSION_SECRET` | Long, random secret used to protect login sessions |
-| `OCEAN_BRAIN_ALLOW_INSECURE_NO_AUTH=true` | Explicitly enable open mode; do not combine with a password |
-| `OCEAN_BRAIN_DATA_DIR` | Override the default npx data directory and its `db.sqlite3` path |
-| `OCEAN_BRAIN_IMAGE_DIR` | Override the uploaded image directory |
-| `DATABASE_URL` | Override the SQLite file URL; this takes precedence over `OCEAN_BRAIN_DATA_DIR` for the database path |
-| `HOST`, `PORT`, `--host`, `--port` | Change the bind address and port; environment values take precedence and defaults are `0.0.0.0` and `6683` |
-
-## Data and recovery
-
-Ocean Brain stores note data in SQLite and uploaded images separately on disk. Back up both locations together.
-
-| Run method | SQLite database | Uploaded images |
-|---|---|---|
-| `npx` | `~/.ocean-brain/data/db.sqlite3` | `~/.ocean-brain/assets/images` |
-| Docker example above | `./data/db.sqlite3` | `./assets/images` |
-
-For a simple, consistent backup, stop Ocean Brain and copy both the database and image directory. Restore them while the instance is stopped, then start it again.
-
-Ocean Brain also has recovery paths for everyday mistakes:
-
-- Deleted notes remain in Trash for 30 days.
-- Note snapshots are retained for up to 7 days, with at most 10 snapshots per note.
-
-Trash, snapshots, and individual note exports are useful recovery tools, but they are not full-instance backups.
-
-## Connect an MCP client
-
-Ocean Brain can expose the workspace to [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) clients. The MCP tools can search and read notes, query tags and properties, create notes, make targeted Markdown or metadata edits, and move notes to Trash.
-
-1. Open `Settings > MCP` and turn MCP access on.
-2. Select **Issue token**. If a token already exists, the button reads **Rotate token**.
-3. Copy the token while it is visible and save it in a local file.
-4. Choose Codex, Claude, or JSON in the setup panel and copy the generated configuration.
-
-An equivalent `.mcp.json` entry looks like this:
-
-```json
-{
-  "mcpServers": {
-    "ocean-brain": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "ocean-brain",
-        "mcp",
-        "--server",
-        "http://localhost:6683",
-        "--token-file",
-        "/absolute/path/to/ocean-brain-mcp-token.txt"
-      ]
-    }
-  }
-}
-```
-
-Set `--server` to the Ocean Brain URL reachable from the machine running the MCP client; replace `localhost` when the instance is remote or behind a proxy.
-
-Ocean Brain keeps one active MCP token. Rotating or revoking it immediately invalidates the previous token. `--token-file` is preferred over placing the token directly in client configuration.
-
-For a long-lived setup, pin the MCP CLI to a version compatible with the server by replacing `ocean-brain` in the command with `ocean-brain@<version>`.
+For a stable session secret, persistent volumes, open mode, exact version tags, and backups, see the [Docker guide](./docs/DOCKER.md).
 
 ## Development
 
-The repository uses Node.js `22`, pnpm `10.25.0`, and a `packages/*` workspace.
-
-```bash
-pnpm install
-
-OCEAN_BRAIN_PASSWORD='development-password' \
-OCEAN_BRAIN_SESSION_SECRET='development-session-secret' \
-pnpm dev
-```
-
-The client normally runs at <http://localhost:5173> and the server at <http://localhost:6683>. Use the npm package or Docker image when you want a packaged instance; the source commands above are for development.
-
-Before opening a pull request, run the checks for the changed scope:
-
-```bash
-pnpm check:encoding
-pnpm lint
-pnpm test:ci
-pnpm type-check
-pnpm build
-```
-
-The repository-specific workflow is documented in [DEV_CONVENTION.md](./docs/process/DEV_CONVENTION.md) and [GIT_CONVENTION.md](./docs/process/GIT_CONVENTION.md).
+Source development uses Node.js `22`, pnpm `10.25.0`, and a `packages/*` workspace. See [DEV_CONVENTION.md](./docs/process/DEV_CONVENTION.md) and [GIT_CONVENTION.md](./docs/process/GIT_CONVENTION.md) before making changes.
 
 ## License
 

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -1,0 +1,71 @@
+<!--
+Docker Hub Overview source.
+
+Suggested Docker Hub short description:
+Self-hosted writing space for connected notes.
+
+Keep the product overview in README.md. This file owns Docker image usage:
+authentication, tags, container startup, networking, mounts, and backups.
+-->
+
+<img src="https://raw.githubusercontent.com/baealex/ocean-brain/main/packages/client/public/icon.png" alt="Ocean Brain logo: a brain resting on ocean waves" width="112" />
+
+# Ocean Brain
+
+**A self-hosted writing space for connected notes, packaged for Docker.**
+
+One container runs the complete Ocean Brain web app and server.
+
+![Ocean Brain workspace showing a connected note with typed properties, inline references, and automatic backlinks](https://raw.githubusercontent.com/baealex/ocean-brain/main/docs/assets/ocean-brain-workspace.png)
+
+[Product overview](https://github.com/baealex/ocean-brain#readme) · [Releases](https://github.com/baealex/ocean-brain/releases) · [Source](https://github.com/baealex/ocean-brain)
+
+## Start a password-protected workspace
+
+Generate a session secret once, keep it private, and reuse it when recreating the container:
+
+```bash
+openssl rand -hex 32
+```
+
+```bash
+docker run -d \
+  --name ocean-brain \
+  --restart unless-stopped \
+  -e OCEAN_BRAIN_PASSWORD='choose-a-strong-password' \
+  -e OCEAN_BRAIN_SESSION_SECRET='paste-the-generated-session-secret-here' \
+  -v "$PWD/data:/data" \
+  -v "$PWD/assets:/assets" \
+  -p 127.0.0.1:6683:6683 \
+  baealex/ocean-brain:latest
+```
+
+Open <http://localhost:6683>.
+
+`latest` is convenient for evaluation. For a workspace you intend to keep, choose an exact version from [GitHub Releases](https://github.com/baealex/ocean-brain/releases) and use `baealex/ocean-brain:<version>`. Docker tags omit the release tag's leading `v`.
+
+The example publishes Ocean Brain on loopback only. Before exposing it beyond the host machine, keep password mode enabled, place the instance behind HTTPS, and change the bind address only when your network or reverse proxy requires it. The container refuses to start unless password mode or open mode is selected explicitly.
+
+## Local-only open mode
+
+Open mode has no login. Use it only on your own machine, keep the loopback port binding, and do not combine it with the password variables.
+
+```bash
+docker run --rm \
+  -e OCEAN_BRAIN_ALLOW_INSECURE_NO_AUTH=true \
+  -v "$PWD/data:/data" \
+  -v "$PWD/assets:/assets" \
+  -p 127.0.0.1:6683:6683 \
+  baealex/ocean-brain:latest
+```
+
+## Persistent paths
+
+| Content | Container path | Host path above |
+|---|---|---|
+| SQLite database | `/data/db.sqlite3` | `./data/db.sqlite3` |
+| Uploaded images | `/assets/images` | `./assets/images` |
+
+Stop the container and back up `./data` and `./assets` together before changing versions. Restore both while the container remains stopped. Trash, note snapshots, and individual exports are useful recovery tools, but they do not replace a full backup.
+
+The image is published for `linux/amd64` and `linux/arm64`.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,113 @@
+<!--
+npm package README for the public ocean-brain CLI.
+
+Keep the product overview in the repository README. This file owns the public
+`serve` and `mcp` command interface, including npx auth and storage behavior.
+-->
+
+# ocean-brain CLI
+
+The npm distribution for [Ocean Brain](https://github.com/baealex/ocean-brain). It provides two commands:
+
+- `ocean-brain serve` runs the packaged Ocean Brain web app and server.
+- `ocean-brain mcp` connects an MCP client to a running Ocean Brain instance over stdio.
+
+For the product overview and screenshots, see the [Ocean Brain project](https://github.com/baealex/ocean-brain#readme).
+
+## Requirements
+
+Use Node.js 22. A global installation is not required; the examples below use `npx`.
+
+## `serve`
+
+`serve` is the default command, so `npx ocean-brain` and `npx ocean-brain serve` are equivalent.
+
+For a password-protected workspace, set both the shared workspace password and a separate session secret:
+
+```bash
+OCEAN_BRAIN_PASSWORD='choose-a-strong-password' \
+OCEAN_BRAIN_SESSION_SECRET='paste-a-long-random-secret-here' \
+npx -y ocean-brain serve --host 127.0.0.1
+```
+
+Open <http://localhost:6683>. Generate the session secret once—for example with `openssl rand -hex 32`—keep it private, and reuse it across restarts. Startup fails unless password mode or open mode is selected explicitly; do not enable both.
+
+One running instance is one shared workspace. Password mode protects the entire instance with one shared password; it does not provide individual accounts, roles, or per-note permissions. If you bind beyond localhost, keep password mode enabled and place Ocean Brain behind HTTPS.
+
+### Local-only open mode
+
+Open mode has no login. Use it only on your own machine and keep the loopback binding:
+
+```bash
+npx -y ocean-brain serve \
+  --host 127.0.0.1 \
+  --allow-insecure-no-auth
+```
+
+### Options and environment
+
+| Setting | Behavior |
+|---|---|
+| `-H, --host <host>` | Bind address; defaults to `0.0.0.0` |
+| `-p, --port <port>` | Listen port; defaults to `6683` |
+| `--allow-insecure-no-auth` | Explicitly enable open mode |
+| `HOST`, `PORT` | Override their corresponding CLI options |
+| `OCEAN_BRAIN_PASSWORD` | Shared password for password mode |
+| `OCEAN_BRAIN_SESSION_SECRET` | Session secret required in password mode |
+| `OCEAN_BRAIN_ALLOW_INSECURE_NO_AUTH=true` | Environment equivalent of the open-mode flag |
+| `OCEAN_BRAIN_DATA_DIR` | Data directory; defaults to `~/.ocean-brain/data` |
+| `OCEAN_BRAIN_IMAGE_DIR` | Uploaded-image directory; defaults to `~/.ocean-brain/assets/images` |
+| `DATABASE_URL` | SQLite file URL; takes precedence over the database path derived from the data directory |
+
+By default, notes are stored in `~/.ocean-brain/data/db.sqlite3` and uploaded images in `~/.ocean-brain/assets/images`. The CLI creates the directories and applies bundled database migrations at startup. Stop Ocean Brain and back up both paths together; restore them while the server remains stopped.
+
+Deleted notes remain in Trash for 30 days. Note snapshots are retained for up to 7 days, with at most 10 snapshots per note. These recovery tools and individual exports do not replace a full backup.
+
+For a long-lived installation, replace `ocean-brain` in the commands with an exact version such as `ocean-brain@X.Y.Z`.
+
+## `mcp`
+
+The `mcp` command starts a stdio MCP server that forwards tool calls to an existing Ocean Brain instance. It does not start the web app.
+
+The MCP tools can search and read notes, query tags and properties, create notes, make targeted Markdown or metadata edits, and move notes to Trash.
+
+First enable MCP access under `Settings > MCP`, issue a token, and save it to a local file. Then configure the MCP client, for example:
+
+```json
+{
+  "mcpServers": {
+    "ocean-brain": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "ocean-brain",
+        "mcp",
+        "--server",
+        "http://localhost:6683",
+        "--token-file",
+        "/absolute/path/to/ocean-brain-mcp-token.txt"
+      ]
+    }
+  }
+}
+```
+
+Set `--server` to the Ocean Brain URL reachable from the machine running the MCP client. Replace `localhost` when the instance is remote or behind a proxy.
+
+### Options
+
+| Option | Behavior |
+|---|---|
+| `-s, --server <url>` | Ocean Brain server URL; defaults to `http://localhost:6683` |
+| `--token-file <path>` | Read the bearer token from a file; takes precedence over `--token` |
+| `--token <token>` | Direct bearer-token fallback |
+
+Prefer `--token-file` so the token is not stored directly in client configuration. Ocean Brain keeps one active MCP token; rotating or revoking it immediately invalidates the previous token. For a long-lived MCP setup, pin an npm package version compatible with the requirement shown in `Settings > MCP`.
+
+## Links
+
+- [Product documentation](https://github.com/baealex/ocean-brain#readme)
+- [Releases](https://github.com/baealex/ocean-brain/releases)
+- [Source code](https://github.com/baealex/ocean-brain)
+- [Issues](https://github.com/baealex/ocean-brain/issues)
+- [MIT License](https://github.com/baealex/ocean-brain/blob/main/LICENSE)


### PR DESCRIPTION
## :dart: Goal

- Keep the repository README focused on Ocean Brain's product identity and a safe first run.
- Give npm and Docker users platform-specific guidance where they discover each distribution.

## :hammer_and_wrench: Core Changes

- Reduce the root setup section to password-protected npx and Docker quick starts.
- Add an npm package README covering `serve`, `mcp`, authentication, storage, and recovery.
- Add a Docker Hub Overview source covering authentication, tags, networking, persistent paths, and backups.
- Link each root quick start directly to its matching distribution guide.

## :brain: Key Decisions

- Keep the root README as the concise product entry point instead of duplicating all operational details there.
- Make password mode the recommended quick start while keeping open mode secondary and loopback-only.
- Keep Docker Hub Overview updates manual because this documentation changes infrequently.

## :test_tube: Verification Guide

### How to verify

1. Run `pnpm check:encoding` and `pnpm lint`.
2. Run `pnpm test:ci`, `pnpm type-check`, and `pnpm build`.
3. Run `pnpm --dir packages/cli pack --dry-run --json` and confirm the file list contains `README.md`.
4. Compare `serve --help` and `mcp --help` with the npm guide, then render the root README and open both distribution links.

### Expected result

- Encoding, lint, all tests, type-check, build, and diff checks pass.
- The npm tarball includes its package README, and the documented CLI flags match the public command help.
- Both root quick starts use password mode and open the matching npm CLI or Docker guide for details.

## :white_check_mark: Checklist

- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)
