### PR TITLE
♻️ Refactor note editor save coordination

### DIFF
--- a/packages/client/src/components/note/NoteEditorHeader.tsx
+++ b/packages/client/src/components/note/NoteEditorHeader.tsx
@@ -1,0 +1,128 @@
+import type { RefObject } from 'react';
+import * as Icon from '~/components/icon';
+import { Button, Dropdown } from '~/components/shared';
+import { MoreButton, Text } from '~/components/ui';
+import type { NoteSaveStatus } from '~/hooks/useNoteSaveController';
+import NoteSaveStatusIndicator from './NoteSaveStatusIndicator';
+
+interface NoteEditorHeaderProps {
+    title: string;
+    titleRef: RefObject<HTMLInputElement | null>;
+    isPinned: boolean;
+    createdAt: string;
+    saveStatus: NoteSaveStatus;
+    savedAt: string;
+    savedVersion: string;
+    saveConfirmationRevision: number;
+    onTitleChange: (title: string) => void;
+    onCopyMarkdown: () => void;
+    onDownloadDocument: () => void;
+    onTogglePinned: () => void;
+    onChangeLayout: () => void;
+    onCloneNote: () => void;
+    onRestoreVersion: () => void;
+    onDelete: () => void;
+    onSave: () => void;
+}
+
+export default function NoteEditorHeader({
+    title,
+    titleRef,
+    isPinned,
+    createdAt,
+    saveStatus,
+    savedAt,
+    savedVersion,
+    saveConfirmationRevision,
+    onTitleChange,
+    onCopyMarkdown,
+    onDownloadDocument,
+    onTogglePinned,
+    onChangeLayout,
+    onCloneNote,
+    onRestoreVersion,
+    onDelete,
+    onSave,
+}: NoteEditorHeaderProps) {
+    return (
+        <div className="surface-floating sticky top-20 z-[1001] mb-7 px-5 pt-4 pb-3.5">
+            <div className="flex flex-col gap-3.5">
+                <div className="flex items-start justify-between gap-5">
+                    <div className="min-w-0 flex-1 pt-0.5">
+                        <Text
+                            as="div"
+                            variant="micro"
+                            weight="semibold"
+                            tracking="widest"
+                            transform="uppercase"
+                            tone="tertiary"
+                            className="mb-1.5"
+                        >
+                            Thought in progress
+                        </Text>
+                        <input
+                            ref={titleRef}
+                            aria-label="Note title"
+                            placeholder="Title"
+                            className="text-heading sm:text-display w-full bg-transparent font-semibold leading-[1.25] tracking-[-0.02em] outline-none"
+                            type="text"
+                            value={title}
+                            onChange={(event) => onTitleChange(event.target.value)}
+                        />
+                    </div>
+                    <div className="flex shrink-0 items-center gap-2">
+                        <Dropdown
+                            button={<MoreButton label="Note actions" size="lg" />}
+                            items={[
+                                { name: 'Copy Markdown', onClick: onCopyMarkdown },
+                                { name: 'Download document', onClick: onDownloadDocument },
+                                { type: 'separator', key: 'export-separator' },
+                                { name: isPinned ? 'Unpin' : 'Pin', onClick: onTogglePinned },
+                                { name: 'Change layout', onClick: onChangeLayout },
+                                { type: 'separator' },
+                                { name: 'Clone this note', onClick: onCloneNote },
+                                { name: 'Restore previous version', onClick: onRestoreVersion },
+                                { type: 'separator' },
+                                { name: 'Delete', onClick: onDelete },
+                            ]}
+                        />
+                        <Button
+                            size="sm"
+                            variant="subtle"
+                            isLoading={saveStatus === 'saving'}
+                            disabled={saveStatus === 'conflict'}
+                            onClick={onSave}
+                        >
+                            Save
+                        </Button>
+                    </div>
+                </div>
+                <div className="flex flex-wrap items-center gap-x-2.5 gap-y-1.5 border-t border-border-subtle/80 pt-3">
+                    {isPinned && (
+                        <Text
+                            as="span"
+                            variant="label"
+                            weight="medium"
+                            tone="secondary"
+                            className="inline-flex items-center gap-1.5"
+                        >
+                            <Icon.Pin className="h-3 w-3" weight="fill" />
+                            Pinned
+                        </Text>
+                    )}
+                    {isPinned && <span className="h-1 w-1 rounded-full bg-border-secondary" />}
+                    <NoteSaveStatusIndicator
+                        status={saveStatus}
+                        savedAt={savedAt}
+                        savedVersion={savedVersion}
+                        confirmationRevision={saveConfirmationRevision}
+                    />
+                    <span className="h-1 w-1 rounded-full bg-border-secondary" />
+                    <Text as="span" variant="micro" weight="medium" tone="tertiary">
+                        Created {createdAt}
+                    </Text>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/packages/client/src/components/note/NotePropertiesPanel.spec.tsx
+++ b/packages/client/src/components/note/NotePropertiesPanel.spec.tsx
@@ -1,12 +1,12 @@
 import { QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import type { ReactNode } from 'react';
+import { createRef, type ReactNode, type Ref } from 'react';
 import { fetchNotePropertyKeys, updateNoteProperties } from '~/apis/note.api';
 import { ToastProvider } from '~/components/ui';
 import type { NoteProperty } from '~/models/note.model';
 import { createTestQueryClient } from '~/test/test-utils';
-import NotePropertiesPanel from './NotePropertiesPanel';
+import NotePropertiesPanel, { type NotePropertiesPanelRef } from './NotePropertiesPanel';
 
 vi.mock('@tanstack/react-router', () => ({
     Link: ({ children }: { children: ReactNode }) => <a href="/settings/properties">{children}</a>,
@@ -27,7 +27,20 @@ const createProperty = (overrides: Partial<NoteProperty> = {}): NoteProperty => 
     ...overrides,
 });
 
-const renderPanel = (properties: NoteProperty[], onSaved = vi.fn()) => {
+const createDeferred = <T,>() => {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((nextResolve) => {
+        resolve = nextResolve;
+    });
+
+    return { promise, resolve };
+};
+
+const renderPanel = (
+    properties: NoteProperty[],
+    onSaved = vi.fn(),
+    options: { onPendingChange?: (pending: boolean) => void; ref?: Ref<NotePropertiesPanelRef> } = {},
+) => {
     const queryClient = createTestQueryClient();
 
     vi.mocked(fetchNotePropertyKeys).mockResolvedValue({
@@ -49,10 +62,12 @@ const renderPanel = (properties: NoteProperty[], onSaved = vi.fn()) => {
         <QueryClientProvider client={queryClient}>
             <ToastProvider>
                 <NotePropertiesPanel
+                    ref={options.ref}
                     noteId="note-1"
                     properties={properties}
                     expectedUpdatedAt="1779700000000"
                     editSessionId="edit-session-1"
+                    onPendingChange={options.onPendingChange}
                     onSaved={onSaved}
                 />
             </ToastProvider>
@@ -129,5 +144,61 @@ describe('<NotePropertiesPanel />', () => {
             'https://example.com/docs',
         );
         expect(screen.queryByRole('link', { name: 'Open Script' })).not.toBeInTheDocument();
+    });
+
+    it('flushes a pending property edit through its session boundary', async () => {
+        const user = userEvent.setup();
+        const property = createProperty();
+        const panelRef = createRef<NotePropertiesPanelRef>();
+        const onPendingChange = vi.fn();
+        vi.mocked(updateNoteProperties).mockResolvedValue({
+            type: 'success',
+            updateNoteProperties: {
+                id: 'note-1',
+                updatedAt: '1779700001000',
+                properties: [createProperty({ value: 'Flushed summary', updatedAt: '1779700001000' })],
+            },
+        });
+        renderPanel([property], vi.fn(), { ref: panelRef, onPendingChange });
+
+        const valueInput = await screen.findByRole('textbox', { name: 'Property value' });
+        await user.clear(valueInput);
+        await user.type(valueInput, 'Flushed summary');
+        await waitFor(() => expect(onPendingChange).toHaveBeenLastCalledWith(true));
+
+        const result = await panelRef.current?.flushPendingSave();
+
+        expect(result).toBe('saved');
+        expect(updateNoteProperties).toHaveBeenCalledTimes(1);
+        await waitFor(() => expect(onPendingChange).toHaveBeenLastCalledWith(false));
+    });
+
+    it('ignores a delayed property response after pending changes are discarded', async () => {
+        const user = userEvent.setup();
+        const property = createProperty();
+        const panelRef = createRef<NotePropertiesPanelRef>();
+        const onSaved = vi.fn();
+        const delayedSave = createDeferred<Awaited<ReturnType<typeof updateNoteProperties>>>();
+        vi.mocked(updateNoteProperties).mockReturnValue(delayedSave.promise);
+        renderPanel([property], onSaved, { ref: panelRef });
+
+        const valueInput = await screen.findByRole('textbox', { name: 'Property value' });
+        await user.clear(valueInput);
+        await user.type(valueInput, 'Discarded summary');
+        const flushPromise = panelRef.current?.flushPendingSave();
+        await waitFor(() => expect(updateNoteProperties).toHaveBeenCalledOnce());
+
+        panelRef.current?.discardPendingChanges();
+        delayedSave.resolve({
+            type: 'success',
+            updateNoteProperties: {
+                id: 'note-1',
+                updatedAt: '1779700001000',
+                properties: [createProperty({ value: 'Discarded summary', updatedAt: '1779700001000' })],
+            },
+        });
+        await flushPromise;
+
+        expect(onSaved).not.toHaveBeenCalled();
     });
 });

--- a/packages/client/src/components/note/NotePropertiesPanel.tsx
+++ b/packages/client/src/components/note/NotePropertiesPanel.tsx
@@ -1,7 +1,12 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
-import { useCallback, useEffect, useRef, useState } from 'react';
-import { fetchNotePropertyKeys, type NotePropertyKeySummary, updateNoteProperties } from '~/apis/note.api';
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react';
+import {
+    fetchNotePropertyKeys,
+    type NotePropertyKeySummary,
+    type UpdateNotePropertiesRequestData,
+    updateNoteProperties,
+} from '~/apis/note.api';
 import * as Icon from '~/components/icon';
 import { AuxiliaryPanel, Button } from '~/components/shared';
 import {
@@ -124,23 +129,40 @@ const getPropertyRowsPatchDraft = (
 const getPropertyRowsPatchSignature = (rows: EditableNotePropertyRow[], deletedKeys: string[] = []) =>
     JSON.stringify(getPropertyRowsPatchDraft(rows, deletedKeys));
 
+export type NotePropertySaveResult = 'idle' | 'saved' | 'error';
+
+export interface NotePropertiesPanelRef {
+    flushPendingSave: (options?: { expectedUpdatedAt?: string }) => Promise<NotePropertySaveResult>;
+    invalidateInFlightSave: () => void;
+    discardPendingChanges: () => void;
+}
+
 interface NotePropertiesPanelProps {
     noteId: string;
     properties?: NoteProperty[];
     expectedUpdatedAt: string;
     editSessionId: string;
     disabled?: boolean;
-    onSaved: (note: Pick<Note, 'id' | 'updatedAt' | 'properties'>) => void;
+    saveProperties?: (
+        input: UpdateNotePropertiesRequestData,
+    ) => Promise<Awaited<ReturnType<typeof updateNoteProperties>> | undefined>;
+    onPendingChange?: (hasPendingChanges: boolean) => void;
+    onSaved: (note: Pick<Note, 'id' | 'updatedAt' | 'properties'>) => void | Promise<void>;
 }
 
-const NotePropertiesPanel = ({
-    noteId,
-    properties = [],
-    expectedUpdatedAt,
-    editSessionId,
-    disabled,
-    onSaved,
-}: NotePropertiesPanelProps) => {
+const NotePropertiesPanel = forwardRef<NotePropertiesPanelRef, NotePropertiesPanelProps>(function NotePropertiesPanel(
+    {
+        noteId,
+        properties = [],
+        expectedUpdatedAt,
+        editSessionId,
+        disabled,
+        saveProperties = updateNoteProperties,
+        onPendingChange,
+        onSaved,
+    },
+    ref,
+) {
     const toast = useToast();
     const queryClient = useQueryClient();
     const [rows, setRows] = useState<EditableNotePropertyRow[]>(() => getNormalizedRows(properties));
@@ -152,7 +174,9 @@ const NotePropertiesPanel = ({
     const savedSignatureRef = useRef(getPropertyRowsPatchSignature(rows));
     const autoSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const isAutoSavingRef = useRef(false);
+    const inFlightSavePromiseRef = useRef<Promise<NotePropertySaveResult> | null>(null);
     const hasQueuedAutoSaveRef = useRef(false);
+    const saveGenerationRef = useRef(0);
 
     const propertyKeysQuery = useQuery({
         queryKey: queryKeys.notes.propertyKeys({ limit: 50 }),
@@ -193,63 +217,139 @@ const NotePropertiesPanel = ({
         (propertyKey) => !rows.some((row) => row.key === propertyKey.key),
     );
     const hasPropertyDefinitions = propertyKeySummaries.length > 0;
+    const hasPendingChanges = getPropertyRowsPatchSignature(rows, deletedKeys) !== savedSignatureRef.current;
 
-    const saveCurrentRows = useCallback(async () => {
-        const signature = getPropertyRowsPatchSignature(rowsRef.current, deletedKeysRef.current);
-
-        if (disabled || signature === savedSignatureRef.current) {
-            return;
-        }
-
-        if (isAutoSavingRef.current) {
-            hasQueuedAutoSaveRef.current = true;
-            return;
-        }
-
-        const patch = getPropertyRowsPatchDraft(rowsRef.current, deletedKeysRef.current);
-
-        if (patch.set.length === 0 && patch.deleteKeys.length === 0) {
-            return;
-        }
-
-        isAutoSavingRef.current = true;
-        hasQueuedAutoSaveRef.current = false;
-        setAutoSaveStatus('saving');
-
-        try {
-            const response = await updateNoteProperties({
-                id: noteId,
-                set: patch.set,
-                deleteKeys: patch.deleteKeys,
-                editSessionId,
-                expectedUpdatedAt: expectedUpdatedAtRef.current,
-            });
-
-            if (response.type === 'error') {
-                setAutoSaveStatus('error');
-                toast(response.errors[0]?.message ?? 'Failed to save properties.');
-                return;
+    const saveCurrentRows = useCallback(
+        async ({
+            ignoreDisabled = false,
+            expectedUpdatedAt: expectedUpdatedAtOverride,
+        }: {
+            ignoreDisabled?: boolean;
+            expectedUpdatedAt?: string;
+        } = {}): Promise<NotePropertySaveResult> => {
+            if (autoSaveTimerRef.current) {
+                clearTimeout(autoSaveTimerRef.current);
+                autoSaveTimerRef.current = null;
             }
 
-            expectedUpdatedAtRef.current = response.updateNoteProperties.updatedAt;
-            savedSignatureRef.current = getPropertyRowsPatchSignature(
-                getNormalizedRows(response.updateNoteProperties.properties ?? []),
-            );
-            onSaved(response.updateNoteProperties);
-            void queryClient.invalidateQueries({ queryKey: queryKeys.notes.propertyKeysAll(), exact: false });
-            setAutoSaveStatus('saved');
-        } catch {
-            setAutoSaveStatus('error');
-            toast('Failed to save properties.');
-        } finally {
-            isAutoSavingRef.current = false;
+            if (inFlightSavePromiseRef.current) {
+                hasQueuedAutoSaveRef.current = true;
+                const result = await inFlightSavePromiseRef.current;
+
+                if (result === 'error') {
+                    return result;
+                }
+
+                return saveCurrentRows({ ignoreDisabled });
+            }
+
+            const signature = getPropertyRowsPatchSignature(rowsRef.current, deletedKeysRef.current);
+
+            if ((!ignoreDisabled && disabled) || signature === savedSignatureRef.current) {
+                return 'idle';
+            }
+
+            const patch = getPropertyRowsPatchDraft(rowsRef.current, deletedKeysRef.current);
+
+            if (patch.set.length === 0 && patch.deleteKeys.length === 0) {
+                return 'idle';
+            }
+
+            isAutoSavingRef.current = true;
+            hasQueuedAutoSaveRef.current = false;
+            setAutoSaveStatus('saving');
+            const saveGeneration = saveGenerationRef.current;
+
+            const savePromise = (async (): Promise<NotePropertySaveResult> => {
+                try {
+                    const response = await saveProperties({
+                        id: noteId,
+                        set: patch.set,
+                        deleteKeys: patch.deleteKeys,
+                        editSessionId,
+                        expectedUpdatedAt: expectedUpdatedAtOverride ?? expectedUpdatedAtRef.current,
+                    });
+
+                    if (!response || saveGeneration !== saveGenerationRef.current) {
+                        setAutoSaveStatus('idle');
+                        return 'idle';
+                    }
+
+                    if (response.type === 'error') {
+                        setAutoSaveStatus('error');
+                        toast(response.errors[0]?.message ?? 'Failed to save properties.');
+                        return 'error';
+                    }
+
+                    expectedUpdatedAtRef.current = response.updateNoteProperties.updatedAt;
+                    savedSignatureRef.current = getPropertyRowsPatchSignature(
+                        getNormalizedRows(response.updateNoteProperties.properties ?? []),
+                    );
+                    await onSaved(response.updateNoteProperties);
+                    void queryClient.invalidateQueries({ queryKey: queryKeys.notes.propertyKeysAll(), exact: false });
+                    setAutoSaveStatus('saved');
+                    return 'saved';
+                } catch {
+                    setAutoSaveStatus('error');
+                    toast('Failed to save properties.');
+                    return 'error';
+                } finally {
+                    isAutoSavingRef.current = false;
+                }
+            })();
+
+            inFlightSavePromiseRef.current = savePromise;
+            const result = await savePromise;
+
+            if (inFlightSavePromiseRef.current === savePromise) {
+                inFlightSavePromiseRef.current = null;
+            }
 
             if (hasQueuedAutoSaveRef.current) {
                 hasQueuedAutoSaveRef.current = false;
-                void saveCurrentRows();
+                const queuedResult = await saveCurrentRows({
+                    ignoreDisabled,
+                });
+
+                return queuedResult === 'idle' ? result : queuedResult;
             }
-        }
-    }, [disabled, editSessionId, noteId, onSaved, queryClient, toast]);
+
+            return result;
+        },
+        [disabled, editSessionId, noteId, onSaved, queryClient, saveProperties, toast],
+    );
+
+    useImperativeHandle(
+        ref,
+        () => ({
+            flushPendingSave: ({ expectedUpdatedAt: nextExpectedUpdatedAt } = {}) =>
+                saveCurrentRows({ ignoreDisabled: true, expectedUpdatedAt: nextExpectedUpdatedAt }),
+            invalidateInFlightSave: () => {
+                saveGenerationRef.current += 1;
+
+                if (autoSaveTimerRef.current) {
+                    clearTimeout(autoSaveTimerRef.current);
+                    autoSaveTimerRef.current = null;
+                }
+            },
+            discardPendingChanges: () => {
+                saveGenerationRef.current += 1;
+                hasQueuedAutoSaveRef.current = false;
+                savedSignatureRef.current = getPropertyRowsPatchSignature(rowsRef.current, deletedKeysRef.current);
+                setAutoSaveStatus('idle');
+
+                if (autoSaveTimerRef.current) {
+                    clearTimeout(autoSaveTimerRef.current);
+                    autoSaveTimerRef.current = null;
+                }
+            },
+        }),
+        [saveCurrentRows],
+    );
+
+    useEffect(() => {
+        onPendingChange?.(hasPendingChanges || autoSaveStatus === 'saving');
+    }, [autoSaveStatus, hasPendingChanges, onPendingChange]);
 
     useEffect(() => {
         if (autoSaveTimerRef.current) {
@@ -533,6 +633,6 @@ const NotePropertiesPanel = ({
             </div>
         </AuxiliaryPanel>
     );
-};
+});
 
 export default NotePropertiesPanel;

--- a/packages/client/src/components/note/NoteRecoveryCallouts.tsx
+++ b/packages/client/src/components/note/NoteRecoveryCallouts.tsx
@@ -1,0 +1,81 @@
+import { Button, Callout } from '~/components/shared';
+
+interface NoteRecoveryCalloutsProps {
+    localDraftCreatedAt: string | null;
+    hasSaveError: boolean;
+    onRestoreDraft: () => void;
+    onDiscardDraft: () => void;
+    onRetrySave: () => void;
+    onSaveAsNewNote: () => void;
+}
+
+export default function NoteRecoveryCallouts({
+    localDraftCreatedAt,
+    hasSaveError,
+    onRestoreDraft,
+    onDiscardDraft,
+    onRetrySave,
+    onSaveAsNewNote,
+}: NoteRecoveryCalloutsProps) {
+    return (
+        <>
+            {localDraftCreatedAt && (
+                <Callout tone="danger" className="mb-6">
+                    <div className="flex w-full flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                        <span>A draft from {localDraftCreatedAt} is saved only in this browser.</span>
+                        <div className="flex flex-wrap gap-2">
+                            <Button
+                                type="button"
+                                size="sm"
+                                variant="subtle"
+                                className="self-start"
+                                onClick={onRestoreDraft}
+                            >
+                                Restore draft
+                            </Button>
+                            <Button
+                                type="button"
+                                size="sm"
+                                variant="ghost"
+                                className="self-start"
+                                onClick={onDiscardDraft}
+                            >
+                                Discard
+                            </Button>
+                        </div>
+                    </div>
+                </Callout>
+            )}
+
+            {hasSaveError && (
+                <Callout tone="danger" className="mb-6">
+                    <div className="flex w-full flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                        <span>
+                            Save failed. Your latest draft is still available here. Retry before leaving this note.
+                        </span>
+                        <div className="flex flex-wrap gap-2">
+                            <Button
+                                type="button"
+                                size="sm"
+                                variant="subtle"
+                                className="self-start"
+                                onClick={onRetrySave}
+                            >
+                                Retry save
+                            </Button>
+                            <Button
+                                type="button"
+                                size="sm"
+                                variant="ghost"
+                                className="self-start"
+                                onClick={onSaveAsNewNote}
+                            >
+                                Save as new note
+                            </Button>
+                        </div>
+                    </div>
+                </Callout>
+            )}
+        </>
+    );
+}

--- a/packages/client/src/components/note/NoteSaveStatusIndicator.tsx
+++ b/packages/client/src/components/note/NoteSaveStatusIndicator.tsx
@@ -1,0 +1,98 @@
+import classNames from 'classnames';
+import { useEffect, useState } from 'react';
+import * as Icon from '~/components/icon';
+import { Text } from '~/components/ui';
+import type { NoteSaveStatus } from '~/hooks/useNoteSaveController';
+import { toNoteVersionTime } from '~/modules/note-version';
+import { getRecentTimeSinceRefreshDelay, recentTimeSince } from '~/modules/time';
+
+const SAVE_CONFIRMATION_DURATION_MS = 2200;
+
+interface NoteSaveStatusIndicatorProps {
+    status: NoteSaveStatus;
+    savedAt: string;
+    savedVersion: string;
+    confirmationRevision: number;
+}
+
+export default function NoteSaveStatusIndicator({
+    status,
+    savedAt,
+    savedVersion,
+    confirmationRevision,
+}: NoteSaveStatusIndicatorProps) {
+    const [relativeNow, setRelativeNow] = useState(() => Date.now());
+    const [showSavedConfirmation, setShowSavedConfirmation] = useState(false);
+
+    useEffect(() => {
+        if (status !== 'saved') {
+            return;
+        }
+
+        const timer = window.setTimeout(
+            () => setRelativeNow(Date.now()),
+            getRecentTimeSinceRefreshDelay(toNoteVersionTime(savedVersion), relativeNow),
+        );
+
+        return () => window.clearTimeout(timer);
+    }, [relativeNow, savedVersion, status]);
+
+    useEffect(() => {
+        if (confirmationRevision === 0) {
+            return;
+        }
+
+        setShowSavedConfirmation(true);
+        const timer = window.setTimeout(() => setShowSavedConfirmation(false), SAVE_CONFIRMATION_DURATION_MS);
+
+        return () => window.clearTimeout(timer);
+    }, [confirmationRevision]);
+
+    const isRecentSaveVisible = status === 'saved' && showSavedConfirmation;
+    const statusText =
+        status === 'pending'
+            ? 'Saving...'
+            : status === 'saving'
+              ? 'Saving now...'
+              : status === 'error'
+                ? 'Save failed. Try again.'
+                : status === 'conflict'
+                  ? 'Save paused: changed elsewhere'
+                  : `Saved ${recentTimeSince(toNoteVersionTime(savedVersion), relativeNow)}`;
+    const indicatorClassName = classNames(
+        'inline-flex items-center gap-2 transition-colors',
+        status === 'saved' && !isRecentSaveVisible && 'text-fg-secondary',
+        isRecentSaveVisible && 'text-accent-success',
+        (status === 'pending' || status === 'saving') && 'text-fg-default',
+        (status === 'error' || status === 'conflict') && 'text-fg-error',
+    );
+    const progressRingClassName = classNames(
+        'save-progress-ring flex h-4 w-4 shrink-0 items-center justify-center rounded-full',
+        (status === 'pending' || status === 'saving') && 'save-progress-ring-active',
+        status === 'saved' && isRecentSaveVisible && 'save-progress-ring-complete',
+        (status === 'error' || status === 'conflict') && 'save-progress-ring-error',
+    );
+    const icon =
+        status === 'error' || status === 'conflict' ? (
+            <Icon.WarningCircle className="h-3.5 w-3.5" weight="fill" />
+        ) : (
+            <span className={progressRingClassName} aria-hidden>
+                <span className="h-2 w-2 rounded-full bg-elevated" />
+            </span>
+        );
+
+    return (
+        <Text
+            as="span"
+            variant="label"
+            weight="medium"
+            className={indicatorClassName}
+            role="status"
+            aria-live="polite"
+            title={savedAt}
+        >
+            {icon}
+            {statusText}
+        </Text>
+    );
+}

--- a/packages/client/src/components/note/RestoreSnapshotModal.tsx
+++ b/packages/client/src/components/note/RestoreSnapshotModal.tsx
@@ -12,6 +12,7 @@ interface RestoreSnapshotModalProps {
     isOpen: boolean;
     noteId: string;
     onClose: () => void;
+    restoreSnapshot?: (id: string) => Promise<Awaited<ReturnType<typeof restoreNoteSnapshot>> | undefined>;
     onRestored?: (note: Pick<Note, 'id' | 'updatedAt'>) => void;
 }
 
@@ -31,7 +32,13 @@ const formatSnapshotLabel = (label?: string, entrypoint?: string) => {
     return 'Web browser';
 };
 
-export default function RestoreSnapshotModal({ isOpen, noteId, onClose, onRestored }: RestoreSnapshotModalProps) {
+export default function RestoreSnapshotModal({
+    isOpen,
+    noteId,
+    onClose,
+    restoreSnapshot = restoreNoteSnapshot,
+    onRestored,
+}: RestoreSnapshotModalProps) {
     const toast = useToast();
     const queryClient = useQueryClient();
     const [selectedSnapshotId, setSelectedSnapshotId] = useState<string | null>(null);
@@ -51,8 +58,12 @@ export default function RestoreSnapshotModal({ isOpen, noteId, onClose, onRestor
     });
 
     const restoreMutation = useMutation({
-        mutationFn: restoreNoteSnapshot,
+        mutationFn: restoreSnapshot,
         onSuccess: async (response) => {
+            if (!response) {
+                return;
+            }
+
             if (response.type === 'error') {
                 toast(response.errors[0].message);
                 return;

--- a/packages/client/src/components/note/index.ts
+++ b/packages/client/src/components/note/index.ts
@@ -1,8 +1,10 @@
 export { default as LayoutModal } from './LayoutModal';
+export { default as NoteEditorHeader } from './NoteEditorHeader';
 export { default as NoteExportModal } from './NoteExportModal';
 export { default as NoteExternalChangeModal } from './NoteExternalChangeModal';
 export { default as NoteListCard } from './NoteListCard';
 export { default as NoteListItem } from './NoteListItem';
 export { default as NotePropertiesPanel } from './NotePropertiesPanel';
+export { default as NoteRecoveryCallouts } from './NoteRecoveryCallouts';
 export { default as NoteReferenceWarningModal } from './NoteReferenceWarningModal';
 export { default as RestoreSnapshotModal } from './RestoreSnapshotModal';

--- a/packages/client/src/hooks/useNoteEditorSession.ts
+++ b/packages/client/src/hooks/useNoteEditorSession.ts
@@ -1,0 +1,716 @@
+import { useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
+import dayjs from 'dayjs';
+import { nanoid } from 'nanoid';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+    createNote,
+    fetchNote,
+    pinNote,
+    restoreNoteSnapshot,
+    type UpdateNotePropertiesRequestData,
+    updateNote,
+    updateNoteProperties,
+} from '~/apis/note.api';
+import type { NotePropertiesPanelRef } from '~/components/note/NotePropertiesPanel';
+import type { EditorRef } from '~/components/shared/Editor';
+import type { Note, NoteLayout } from '~/models/note.model';
+import { replaceFixedPlaceholder } from '~/modules/fixed-placeholder';
+import { createMarkdownDocumentExport } from '~/modules/note-export';
+import {
+    classifyExternalNoteEvent,
+    type ExternalNoteChange,
+    isBlockingExternalNoteChange,
+} from '~/modules/note-external-change';
+import { compareNoteVersions, toNoteVersionTime } from '~/modules/note-version';
+import { queryKeys } from '~/modules/query-key-factory';
+import { publishClientNoteUpdatedEvent, subscribeServerEvent } from '~/modules/server-events';
+import { useNoteNavigationGuard } from './useNoteNavigationGuard';
+import { useNoteSaveController } from './useNoteSaveController';
+import { useNoteWriteCoordinator } from './useNoteWriteCoordinator';
+
+const NOTE_UPDATE_CONFLICT_CODE = 'NOTE_UPDATE_CONFLICT';
+
+type NoteDetailCache = Pick<Note, 'title' | 'content' | 'pinned' | 'layout' | 'createdAt' | 'updatedAt' | 'properties'>;
+type Notify = (message: string) => void;
+type NavigateToNote = (noteId: string) => void | Promise<void>;
+
+interface UseNoteEditorSessionParams {
+    noteId: string;
+    navigateToNote: NavigateToNote;
+    notify: Notify;
+}
+
+const formatNoteTime = (value: string) => {
+    const timestamp = toNoteVersionTime(value);
+
+    return dayjs(timestamp ?? Number(value)).format('YYYY-MM-DD HH:mm:ss');
+};
+
+const getConflictUpdatedAt = (details: unknown) => {
+    return (details as { extensions?: { currentUpdatedAt?: string } })?.extensions?.currentUpdatedAt;
+};
+
+export function useNoteEditorSession({ noteId, navigateToNote, notify }: UseNoteEditorSessionParams) {
+    const queryClient = useQueryClient();
+    const editorRef = useRef<EditorRef>(null);
+    const titleRef = useRef<HTMLInputElement>(null);
+    const [initialEditSessionId] = useState(nanoid);
+    const editSessionIdRef = useRef(initialEditSessionId);
+    const propertyPanelRef = useRef<NotePropertiesPanelRef>(null);
+    const layoutConflictRef = useRef<NoteLayout | null>(null);
+    const allowNextNavigationRef = useRef(false);
+    const sessionGenerationRef = useRef(0);
+
+    const noteQuery = useSuspenseQuery({
+        queryKey: queryKeys.notes.detail(noteId),
+        queryFn: async () => {
+            const response = await fetchNote(noteId);
+
+            if (response.type === 'error') {
+                throw response;
+            }
+
+            return response.note;
+        },
+        gcTime: 0,
+    });
+    const note = noteQuery.data;
+    const refetchNote = noteQuery.refetch;
+    const serverVersionRef = useRef(note.updatedAt);
+    const appliedNoteVersionRef = useRef(note.updatedAt);
+
+    const [title, setTitle] = useState(note.title);
+    const [isPinned, setIsPinned] = useState(note.pinned);
+    const [layout, setLayoutState] = useState<NoteLayout>(note.layout || 'wide');
+    const layoutRef = useRef(layout);
+    const [externalNoteChange, setExternalNoteChange] = useState<ExternalNoteChange | null>(null);
+    const [editorContentOverride, setEditorContentOverride] = useState<string | null>(null);
+    const [editorRevision, setEditorRevision] = useState(0);
+    const [lastSavedAt, setLastSavedAt] = useState(() => formatNoteTime(note.updatedAt));
+    const [lastSavedVersion, setLastSavedVersion] = useState(note.updatedAt);
+    const [saveConfirmationRevision, setSaveConfirmationRevision] = useState(0);
+    const [hasPendingPropertyChanges, setHasPendingPropertyChanges] = useState(false);
+    const hasPendingPropertyChangesRef = useRef(false);
+    const {
+        execute: executeWrite,
+        invalidatePending: invalidatePendingWrites,
+        drain: drainWrites,
+        isBusy: isWriteBusy,
+        hasPendingWrites,
+    } = useNoteWriteCoordinator();
+
+    const setLayout = useCallback((nextLayout: NoteLayout) => {
+        layoutRef.current = nextLayout;
+        setLayoutState(nextLayout);
+    }, []);
+
+    const commitAcceptedVersion = useCallback((updatedAt: string, options: { confirmSave?: boolean } = {}) => {
+        serverVersionRef.current = updatedAt;
+        appliedNoteVersionRef.current = updatedAt;
+        setLastSavedAt(formatNoteTime(updatedAt));
+        setLastSavedVersion(updatedAt);
+
+        if (options.confirmSave) {
+            setSaveConfirmationRevision((revision) => revision + 1);
+        }
+    }, []);
+
+    const applyAcceptedWrite = useCallback(
+        async ({
+            updatedAt,
+            patch,
+            confirmSave = true,
+        }: {
+            updatedAt: string;
+            patch: Partial<NoteDetailCache>;
+            confirmSave?: boolean;
+        }) => {
+            const noteDetailQueryKey = queryKeys.notes.detail(noteId);
+            const sessionGeneration = sessionGenerationRef.current;
+
+            await queryClient.cancelQueries({
+                queryKey: noteDetailQueryKey,
+                exact: true,
+            });
+
+            if (sessionGeneration !== sessionGenerationRef.current) {
+                return false;
+            }
+
+            commitAcceptedVersion(updatedAt, { confirmSave });
+            queryClient.setQueryData<NoteDetailCache>(noteDetailQueryKey, (current) =>
+                current
+                    ? {
+                          ...current,
+                          ...patch,
+                          updatedAt,
+                      }
+                    : current,
+            );
+            publishClientNoteUpdatedEvent({
+                noteId,
+                updatedAt,
+                editSessionId: editSessionIdRef.current,
+            });
+            return true;
+        },
+        [commitAcceptedVersion, noteId, queryClient],
+    );
+
+    const handlePropertyPendingChange = useCallback((hasPendingChanges: boolean) => {
+        hasPendingPropertyChangesRef.current = hasPendingChanges;
+        setHasPendingPropertyChanges(hasPendingChanges);
+    }, []);
+
+    const flushPendingProperties = useCallback(() => {
+        return (
+            propertyPanelRef.current?.flushPendingSave({
+                expectedUpdatedAt: serverVersionRef.current,
+            }) ?? Promise.resolve<'idle'>('idle')
+        );
+    }, []);
+
+    const saveController = useNoteSaveController({
+        noteId,
+        initialContent: note.content,
+        initialUpdatedAt: note.updatedAt,
+        editSessionIdRef,
+        serverVersionRef,
+        executeWrite,
+        getContent: () => editorRef.current?.getContent(),
+        beforeSave: flushPendingProperties,
+        hasExternalPendingChanges: () => hasPendingPropertyChangesRef.current || hasPendingWrites(),
+        onSaved: (updatedAt) => {
+            layoutConflictRef.current = null;
+            commitAcceptedVersion(updatedAt, { confirmSave: true });
+        },
+        onConflict: (updatedAt) => {
+            setExternalNoteChange({
+                type: 'updated',
+                updatedAt,
+                source: 'unknown',
+            });
+            notify('This note changed elsewhere. Choose how to resolve the draft.');
+        },
+        onError: notify,
+    });
+    const {
+        saveStatus,
+        localDraft,
+        serverUpdatedAtRef,
+        hasUnsavedChanges,
+        buildDraft,
+        queueSave,
+        flushPendingSave,
+        restoreLocalDraft,
+        discardLocalDraft,
+        clearDrafts,
+        resolveConflict,
+        pauseForConflict,
+        getPendingDraft,
+    } = saveController;
+    const hasSessionUnsavedChanges = hasUnsavedChanges || hasPendingPropertyChanges || isWriteBusy;
+
+    const flushPendingSessionWrites = useCallback(
+        async (options?: Parameters<typeof flushPendingSave>[0]) => {
+            const result = await flushPendingSave(options);
+
+            if (result === 'error' || result === 'conflict') {
+                return result;
+            }
+
+            await drainWrites();
+            return result;
+        },
+        [drainWrites, flushPendingSave],
+    );
+
+    const saveProperties = useCallback(
+        (input: UpdateNotePropertiesRequestData) =>
+            executeWrite(async () => {
+                const response = await updateNoteProperties({
+                    ...input,
+                    expectedUpdatedAt: serverVersionRef.current,
+                });
+
+                if (response.type === 'success') {
+                    await applyAcceptedWrite({
+                        updatedAt: response.updateNoteProperties.updatedAt,
+                        patch: { properties: response.updateNoteProperties.properties },
+                    });
+                }
+
+                return response;
+            }),
+        [applyAcceptedWrite, executeWrite],
+    );
+
+    useNoteNavigationGuard({
+        allowNextNavigationRef,
+        hasExternalPendingChanges: hasPendingPropertyChanges || isWriteBusy,
+        saveStatus,
+        flushPendingChanges: flushPendingSessionWrites,
+        notify,
+    });
+
+    useEffect(() => {
+        if (hasSessionUnsavedChanges) {
+            if (
+                note.updatedAt !== serverUpdatedAtRef.current &&
+                (compareNoteVersions(note.updatedAt, serverUpdatedAtRef.current) ?? 0) > 0
+            ) {
+                pauseForConflict(note.updatedAt);
+            }
+
+            return;
+        }
+
+        const appliedNoteVersion = appliedNoteVersionRef.current;
+
+        if (
+            appliedNoteVersion &&
+            note.updatedAt !== appliedNoteVersion &&
+            (compareNoteVersions(note.updatedAt, appliedNoteVersion) ?? 0) < 0
+        ) {
+            return;
+        }
+
+        setIsPinned(note.pinned);
+        setLayout(note.layout || 'wide');
+        setTitle(note.title);
+
+        if (appliedNoteVersion !== note.updatedAt) {
+            const currentEditorContent = editorRef.current?.getContent();
+
+            commitAcceptedVersion(note.updatedAt);
+
+            if (currentEditorContent === undefined || currentEditorContent !== note.content) {
+                setEditorContentOverride(null);
+                setEditorRevision((revision) => revision + 1);
+            }
+        }
+    }, [
+        commitAcceptedVersion,
+        hasSessionUnsavedChanges,
+        note.content,
+        note.layout,
+        note.pinned,
+        note.title,
+        note.updatedAt,
+        pauseForConflict,
+        serverUpdatedAtRef,
+    ]);
+
+    useEffect(() => {
+        if (
+            externalNoteChange?.type !== 'updated' ||
+            saveStatus === 'conflict' ||
+            externalNoteChange.updatedAt !== note.updatedAt
+        ) {
+            return;
+        }
+
+        commitAcceptedVersion(note.updatedAt);
+        setExternalNoteChange(null);
+    }, [commitAcceptedVersion, externalNoteChange, note.updatedAt, saveStatus]);
+
+    useEffect(() => {
+        return subscribeServerEvent((event) => {
+            const decision = classifyExternalNoteEvent({
+                event,
+                noteId,
+                editSessionId: editSessionIdRef.current,
+                loadedUpdatedAt: note.updatedAt,
+                acceptedUpdatedAt: serverUpdatedAtRef.current,
+                hasUnsavedChanges: hasSessionUnsavedChanges,
+            });
+
+            if (decision.type === 'ignore') {
+                return;
+            }
+
+            if (decision.shouldPauseSave && decision.change.type === 'updated') {
+                pauseForConflict(decision.change.updatedAt);
+            }
+
+            setExternalNoteChange(decision.change);
+        });
+    }, [hasSessionUnsavedChanges, note.updatedAt, noteId, pauseForConflict, serverUpdatedAtRef]);
+
+    const handleContentChange = useCallback(() => {
+        queueSave(buildDraft(title));
+    }, [buildDraft, queueSave, title]);
+
+    const handleTitleChange = useCallback(
+        (nextTitle: string) => {
+            setTitle(nextTitle);
+            queueSave(buildDraft(nextTitle));
+        },
+        [buildDraft, queueSave],
+    );
+
+    const handleManualSave = useCallback(() => {
+        queueSave(buildDraft(title), { immediate: true });
+    }, [buildDraft, queueSave, title]);
+
+    const handleLayoutSave = useCallback(
+        async (newLayout: NoteLayout) => {
+            if (hasUnsavedChanges) {
+                setLayout(newLayout);
+                queueSave(buildDraft(title, { layout: newLayout }), { immediate: true });
+                notify('Layout will be saved with your draft.');
+                return;
+            }
+
+            const flushResult = await flushPendingSave();
+
+            if (flushResult === 'error' || flushResult === 'conflict') {
+                return;
+            }
+
+            await executeWrite(async () => {
+                const response = await updateNote({
+                    id: noteId,
+                    layout: newLayout,
+                    editSessionId: editSessionIdRef.current,
+                    expectedUpdatedAt: serverUpdatedAtRef.current,
+                });
+
+                if (response.type === 'error') {
+                    if (response.errors[0].code === NOTE_UPDATE_CONFLICT_CODE) {
+                        layoutConflictRef.current = newLayout;
+                        setLayout(newLayout);
+                        pauseForConflict(
+                            getConflictUpdatedAt(response.errors[0].details) ?? serverUpdatedAtRef.current,
+                        );
+                    }
+
+                    notify(response.errors[0].message);
+                    return;
+                }
+
+                const didCommit = await applyAcceptedWrite({
+                    updatedAt: response.updateNote.updatedAt,
+                    patch: { layout: newLayout },
+                });
+
+                if (!didCommit) {
+                    return;
+                }
+
+                layoutConflictRef.current = null;
+                setLayout(newLayout);
+                notify('Layout has been updated.');
+            });
+        },
+        [
+            applyAcceptedWrite,
+            buildDraft,
+            executeWrite,
+            flushPendingSave,
+            hasUnsavedChanges,
+            noteId,
+            notify,
+            pauseForConflict,
+            queueSave,
+            serverUpdatedAtRef,
+            title,
+        ],
+    );
+
+    const handleTogglePinned = useCallback(async () => {
+        const flushResult = await flushPendingSave();
+
+        if (flushResult === 'error' || flushResult === 'conflict') {
+            return;
+        }
+
+        const nextPinned = !isPinned;
+        await executeWrite(async () => {
+            const response = await pinNote(noteId, nextPinned);
+
+            if (response.type === 'error') {
+                notify(response.errors[0].message);
+                return;
+            }
+
+            const didCommit = await applyAcceptedWrite({
+                updatedAt: response.pinNote.updatedAt,
+                patch: { pinned: nextPinned },
+                confirmSave: false,
+            });
+
+            if (!didCommit) {
+                return;
+            }
+
+            setIsPinned(nextPinned);
+            await Promise.all([
+                queryClient.invalidateQueries({ queryKey: queryKeys.notes.listAll(), exact: false }),
+                queryClient.invalidateQueries({ queryKey: queryKeys.notes.tagListAll(), exact: false }),
+                queryClient.invalidateQueries({ queryKey: queryKeys.notes.pinned(), exact: true }),
+            ]);
+        });
+    }, [applyAcceptedWrite, executeWrite, flushPendingSave, isPinned, noteId, notify, queryClient]);
+
+    const getExportMetadata = useCallback(
+        () => ({
+            id: noteId,
+            title,
+            createdAt: note.createdAt,
+            updatedAt: serverUpdatedAtRef.current || note.updatedAt,
+        }),
+        [note.createdAt, note.updatedAt, noteId, serverUpdatedAtRef, title],
+    );
+
+    const handleCopyMarkdown = useCallback(async () => {
+        const markdown = editorRef.current?.getMarkdown();
+
+        if (markdown === undefined) {
+            notify('Markdown is not ready yet.');
+            return;
+        }
+
+        try {
+            await navigator.clipboard.writeText(createMarkdownDocumentExport(markdown, getExportMetadata()));
+            notify('Copied note as Markdown.');
+        } catch {
+            notify('Failed to copy Markdown.');
+        }
+    }, [getExportMetadata, notify]);
+
+    const handleReloadExternalChange = useCallback(async () => {
+        propertyPanelRef.current?.invalidateInFlightSave();
+        invalidatePendingWrites();
+        await drainWrites();
+        sessionGenerationRef.current += 1;
+        const response = await refetchNote();
+
+        if (response.error || !response.data) {
+            notify('Failed to reload the latest note state.');
+            return;
+        }
+
+        propertyPanelRef.current?.discardPendingChanges();
+        clearDrafts();
+        layoutConflictRef.current = null;
+        commitAcceptedVersion(response.data.updatedAt);
+        setTitle(response.data.title);
+        setLayout(response.data.layout || 'wide');
+        setEditorContentOverride(null);
+        setEditorRevision((revision) => revision + 1);
+        setExternalNoteChange(null);
+    }, [clearDrafts, commitAcceptedVersion, drainWrites, invalidatePendingWrites, notify, refetchNote]);
+
+    const handleOverwriteConflict = useCallback(async () => {
+        const pendingDraft = getPendingDraft();
+
+        if (pendingDraft) {
+            layoutConflictRef.current = null;
+            setExternalNoteChange(null);
+            await flushPendingSave({ ignoreConflict: true });
+            return;
+        }
+
+        const layoutConflict = layoutConflictRef.current;
+
+        if (!layoutConflict) {
+            setExternalNoteChange(null);
+            await flushPendingSave({ ignoreConflict: true });
+            return;
+        }
+
+        await executeWrite(async () => {
+            const response = await updateNote({
+                id: noteId,
+                layout: layoutConflict,
+                editSessionId: editSessionIdRef.current,
+                force: true,
+            });
+
+            if (response.type === 'error') {
+                notify(response.errors[0].message);
+                return;
+            }
+
+            const didCommit = await applyAcceptedWrite({
+                updatedAt: response.updateNote.updatedAt,
+                patch: { layout: layoutConflict },
+            });
+
+            if (!didCommit) {
+                return;
+            }
+
+            layoutConflictRef.current = null;
+            resolveConflict();
+            setExternalNoteChange(null);
+            setLayout(layoutConflict);
+        });
+    }, [applyAcceptedWrite, executeWrite, flushPendingSave, getPendingDraft, noteId, notify, resolveConflict]);
+
+    const handleClonePendingDraft = useCallback(async () => {
+        const draft = getPendingDraft();
+
+        if (!draft) {
+            return;
+        }
+
+        const propertySaveResult = await flushPendingProperties();
+
+        if (propertySaveResult === 'error') {
+            return;
+        }
+
+        const response = await createNote({
+            title: replaceFixedPlaceholder(draft.title || 'untitled'),
+            content: replaceFixedPlaceholder(draft.content),
+            layout: draft.layout ?? layout,
+        });
+
+        if (response.type === 'error') {
+            notify(response.errors[0].message);
+            return;
+        }
+
+        allowNextNavigationRef.current = true;
+        layoutConflictRef.current = null;
+        setExternalNoteChange(null);
+        clearDrafts();
+
+        void Promise.resolve(navigateToNote(response.createNote.id)).finally(() => {
+            allowNextNavigationRef.current = false;
+        });
+    }, [clearDrafts, flushPendingProperties, getPendingDraft, layout, navigateToNote, notify]);
+
+    const handleRestoreLocalDraft = useCallback(() => {
+        if (!localDraft) {
+            return;
+        }
+
+        setTitle(localDraft.title);
+
+        if (localDraft.layout) {
+            setLayout(localDraft.layout);
+        }
+
+        setEditorContentOverride(localDraft.content);
+        setEditorRevision((revision) => revision + 1);
+        restoreLocalDraft(localDraft);
+    }, [localDraft, restoreLocalDraft]);
+
+    const handlePropertiesSaved = useCallback(() => undefined, []);
+
+    const handleRestoreSnapshot = useCallback(
+        async (snapshotId: string) => {
+            propertyPanelRef.current?.invalidateInFlightSave();
+            invalidatePendingWrites();
+            await drainWrites();
+            sessionGenerationRef.current += 1;
+            return executeWrite(async () => {
+                const response = await restoreNoteSnapshot(snapshotId);
+
+                if (response.type === 'error') {
+                    return response;
+                }
+
+                const restoredNote = response.restoreNoteSnapshot;
+                const didCommit = await applyAcceptedWrite({
+                    updatedAt: restoredNote.updatedAt,
+                    patch: {
+                        title: restoredNote.title,
+                        content: restoredNote.content,
+                        layout: restoredNote.layout,
+                        pinned: restoredNote.pinned,
+                    },
+                });
+
+                if (!didCommit) {
+                    return response;
+                }
+
+                editSessionIdRef.current = nanoid();
+                propertyPanelRef.current?.discardPendingChanges();
+                clearDrafts();
+                layoutConflictRef.current = null;
+                setExternalNoteChange(null);
+                setTitle(restoredNote.title);
+                setLayout(restoredNote.layout || 'wide');
+                setIsPinned(restoredNote.pinned);
+                setEditorContentOverride(restoredNote.content);
+                setEditorRevision((revision) => revision + 1);
+                return response;
+            });
+        },
+        [applyAcceptedWrite, clearDrafts, drainWrites, executeWrite, invalidatePendingWrites],
+    );
+
+    const isConflictedExternalUpdate = saveStatus === 'conflict' && externalNoteChange?.type === 'updated';
+    const conflictDraft = isConflictedExternalUpdate ? getPendingDraft() : null;
+
+    return {
+        document: {
+            title,
+            titleRef,
+            isPinned,
+            layout,
+            getLayout: () => layoutRef.current,
+            properties: note.properties,
+            createdAt: formatNoteTime(note.createdAt),
+            onTitleChange: handleTitleChange,
+            onLayoutSave: handleLayoutSave,
+            onTogglePinned: handleTogglePinned,
+        },
+        editor: {
+            ref: editorRef,
+            key: `${noteId}:${editorRevision}`,
+            content: editorContentOverride ?? note.content,
+            getContent: () => editorRef.current?.getContent() ?? '',
+            getHtml: () => editorRef.current?.getHtml(),
+            getMarkdown: () => editorRef.current?.getMarkdown(),
+            onChange: handleContentChange,
+        },
+        save: {
+            status: saveStatus,
+            lastSavedAt,
+            lastSavedVersion,
+            confirmationRevision: saveConfirmationRevision,
+            onManualSave: handleManualSave,
+            flushPendingChanges: flushPendingSessionWrites,
+        },
+        recovery: {
+            localDraftCreatedAt: localDraft ? dayjs(localDraft.createdAt).format('YYYY-MM-DD HH:mm:ss') : null,
+            onRestoreLocalDraft: handleRestoreLocalDraft,
+            onDiscardLocalDraft: discardLocalDraft,
+            onClonePendingDraft: handleClonePendingDraft,
+        },
+        externalChange: {
+            value: externalNoteChange,
+            isConflict: isConflictedExternalUpdate,
+            hasConflictDraft: conflictDraft !== null,
+            isBlocking: isBlockingExternalNoteChange({
+                change: externalNoteChange,
+                isConflict: isConflictedExternalUpdate,
+                loadedUpdatedAt: note.updatedAt,
+            }),
+            isReloading: noteQuery.isRefetching,
+            onReload: handleReloadExternalChange,
+            onOverwrite: handleOverwriteConflict,
+        },
+        properties: {
+            ref: propertyPanelRef,
+            expectedUpdatedAt: serverUpdatedAtRef.current,
+            editSessionId: editSessionIdRef.current,
+            saveProperties,
+            onPendingChange: handlePropertyPendingChange,
+            onSaved: handlePropertiesSaved,
+        },
+        exportDocument: {
+            metadata: getExportMetadata(),
+            onCopyMarkdown: handleCopyMarkdown,
+        },
+        snapshots: {
+            restore: handleRestoreSnapshot,
+        },
+    };
+}

--- a/packages/client/src/hooks/useNoteNavigationGuard.ts
+++ b/packages/client/src/hooks/useNoteNavigationGuard.ts
@@ -1,0 +1,47 @@
+import { useBlocker } from '@tanstack/react-router';
+import type { MutableRefObject } from 'react';
+import { useCallback } from 'react';
+import type { NoteSaveFlushResult, NoteSaveStatus } from './useNoteSaveController';
+
+interface UseNoteNavigationGuardParams {
+    allowNextNavigationRef: MutableRefObject<boolean>;
+    hasExternalPendingChanges: boolean;
+    saveStatus: NoteSaveStatus;
+    flushPendingChanges: () => Promise<NoteSaveFlushResult>;
+    notify: (message: string) => void;
+}
+
+export function useNoteNavigationGuard({
+    allowNextNavigationRef,
+    hasExternalPendingChanges,
+    saveStatus,
+    flushPendingChanges,
+    notify,
+}: UseNoteNavigationGuardParams) {
+    const shouldBlockNavigation = useCallback(async () => {
+        if (allowNextNavigationRef.current) {
+            allowNextNavigationRef.current = false;
+            return false;
+        }
+
+        if (saveStatus === 'conflict') {
+            notify('Resolve the note conflict before leaving.');
+            return true;
+        }
+
+        const result = await flushPendingChanges();
+
+        if (result === 'error') {
+            notify('Save failed. Stay on this note and try again.');
+            return true;
+        }
+
+        return result === 'conflict';
+    }, [allowNextNavigationRef, flushPendingChanges, notify, saveStatus]);
+
+    useBlocker({
+        disabled: saveStatus === 'saved' && !hasExternalPendingChanges,
+        enableBeforeUnload: false,
+        shouldBlockFn: shouldBlockNavigation,
+    });
+}

--- a/packages/client/src/hooks/useNoteSaveController.spec.tsx
+++ b/packages/client/src/hooks/useNoteSaveController.spec.tsx
@@ -402,4 +402,112 @@ describe('useNoteSaveController', () => {
         expect(onError).toHaveBeenCalledWith('Failed to save note.');
         expect(storedDraft.title).toBe('Rejected draft');
     });
+
+    it('ignores a delayed save response after drafts are cleared', async () => {
+        const queryClient = createQueryClient();
+        const delayedSave = createDeferred<Awaited<ReturnType<typeof updateNote>>>();
+        const onSaved = vi.fn();
+        const serverVersionRef = { current: '1770000000000' };
+        queryClient.setQueryData(queryKeys.notes.detail('7'), {
+            title: 'Remote title',
+            content: 'remote content',
+            pinned: false,
+            layout: 'wide',
+            createdAt: '1769999999000',
+            updatedAt: '1770000002000',
+        });
+        vi.mocked(updateNote).mockReturnValue(delayedSave.promise);
+        const { result } = renderHook(
+            () =>
+                useNoteSaveController({
+                    noteId: '7',
+                    initialContent: 'initial',
+                    initialUpdatedAt: '1770000000000',
+                    editSessionIdRef: { current: 'session-1' },
+                    serverVersionRef,
+                    getContent: () => 'local content',
+                    onSaved,
+                    onConflict: vi.fn(),
+                    onError: vi.fn(),
+                }),
+            { wrapper: createWrapper(queryClient) },
+        );
+
+        act(() => {
+            result.current.queueSave(result.current.buildDraft('Local title'), { immediate: true });
+        });
+        await waitFor(() => expect(updateNote).toHaveBeenCalledTimes(1));
+        act(() => {
+            result.current.clearDrafts();
+            serverVersionRef.current = '1770000002000';
+        });
+
+        await act(async () => {
+            delayedSave.resolve({
+                type: 'success',
+                updateNote: {
+                    id: '7',
+                    title: 'Local title',
+                    updatedAt: '1770000001000',
+                },
+            } as never);
+            await delayedSave.promise;
+        });
+
+        expect(onSaved).not.toHaveBeenCalled();
+        expect(queryClient.getQueryData(queryKeys.notes.detail('7'))).toMatchObject({
+            title: 'Remote title',
+            content: 'remote content',
+            updatedAt: '1770000002000',
+        });
+        expect(result.current.saveStatus).toBe('saved');
+        expect(serverVersionRef.current).toBe('1770000002000');
+        expect(window.localStorage.getItem(getDraftStorageKey('7'))).toBeNull();
+    });
+
+    it('runs prerequisite writes before reading the expected note version', async () => {
+        const serverVersionRef = { current: '1770000000000' };
+        const beforeSave = vi.fn(async () => {
+            serverVersionRef.current = '1770000001000';
+            return 'saved' as const;
+        });
+        vi.mocked(updateNote).mockResolvedValue({
+            type: 'success',
+            updateNote: {
+                id: '7',
+                title: 'Draft title',
+                updatedAt: '1770000002000',
+            },
+        } as never);
+        const { result } = renderHook(
+            () =>
+                useNoteSaveController({
+                    noteId: '7',
+                    initialContent: 'initial',
+                    initialUpdatedAt: '1770000000000',
+                    editSessionIdRef: { current: 'session-1' },
+                    serverVersionRef,
+                    beforeSave,
+                    getContent: () => 'content',
+                    onSaved: vi.fn(),
+                    onConflict: vi.fn(),
+                    onError: vi.fn(),
+                }),
+            { wrapper: createWrapper() },
+        );
+
+        await act(async () => {
+            result.current.queueSave(result.current.buildDraft('Draft title'));
+            await result.current.flushPendingSave();
+        });
+
+        expect(beforeSave).toHaveBeenCalledOnce();
+        expect(updateNote).toHaveBeenCalledWith({
+            id: '7',
+            title: 'Draft title',
+            content: 'content',
+            editSessionId: 'session-1',
+            expectedUpdatedAt: '1770000001000',
+        });
+    });
 });

--- a/packages/client/src/hooks/useNoteSaveController.ts
+++ b/packages/client/src/hooks/useNoteSaveController.ts
@@ -11,19 +11,23 @@ import {
 } from '~/modules/note-draft-storage';
 import { queryKeys } from '~/modules/query-key-factory';
 import { publishClientNoteUpdatedEvent } from '~/modules/server-events';
+import type { NoteWriteExecutor } from './useNoteWriteCoordinator';
 
 const NOTE_AUTOSAVE_DELAY_MS = 1000;
 const NOTE_UPDATE_CONFLICT_CODE = 'NOTE_UPDATE_CONFLICT';
 
 export type NoteSaveStatus = 'saved' | 'pending' | 'saving' | 'error' | 'conflict';
 export type NoteSaveFlushResult = 'idle' | 'saved' | 'error' | 'conflict';
-
 interface UseNoteSaveControllerParams {
     noteId: string;
     initialContent: string;
     initialUpdatedAt: string;
     editSessionIdRef: MutableRefObject<string>;
     getContent: () => string | undefined;
+    beforeSave?: () => Promise<'idle' | 'saved' | 'error'>;
+    hasExternalPendingChanges?: () => boolean;
+    serverVersionRef?: MutableRefObject<string>;
+    executeWrite?: NoteWriteExecutor;
     onSaved: (updatedAt: string) => void;
     onConflict: (updatedAt: string) => void;
     onError: (message: string) => void;
@@ -41,6 +45,10 @@ export function useNoteSaveController({
     initialUpdatedAt,
     editSessionIdRef,
     getContent,
+    beforeSave,
+    hasExternalPendingChanges,
+    serverVersionRef,
+    executeWrite,
     onSaved,
     onConflict,
     onError,
@@ -51,12 +59,17 @@ export function useNoteSaveController({
     const inFlightSaveRef = useRef(false);
     const inFlightSavePromiseRef = useRef<Promise<NoteSaveFlushResult> | null>(null);
     const flushAfterInFlightRef = useRef(false);
-    const serverUpdatedAtRef = useRef(initialUpdatedAt);
+    const internalServerUpdatedAtRef = useRef(initialUpdatedAt);
+    const serverUpdatedAtRef = serverVersionRef ?? internalServerUpdatedAtRef;
+    const saveGenerationRef = useRef(0);
     const isSaveConflictRef = useRef(false);
     const isAliveRef = useRef(true);
     const onSavedRef = useRef(onSaved);
     const onConflictRef = useRef(onConflict);
     const onErrorRef = useRef(onError);
+    const beforeSaveRef = useRef(beforeSave);
+    const hasExternalPendingChangesRef = useRef(hasExternalPendingChanges);
+    const executeWriteRef = useRef(executeWrite);
 
     const [saveStatus, setSaveStatus] = useState<NoteSaveStatus>('saved');
     const [localDraft, setLocalDraft] = useState<NoteSaveDraft | null>(null);
@@ -111,14 +124,15 @@ export function useNoteSaveController({
                 return inFlightSavePromiseRef.current ?? 'idle';
             }
 
-            const draft = pendingDraftRef.current;
+            const hasPendingDraft = pendingDraftRef.current !== null;
+            const hasExternalPendingChanges = hasExternalPendingChangesRef.current?.() ?? false;
 
-            if (!draft) {
+            if (!hasPendingDraft && !hasExternalPendingChanges) {
                 flushAfterInFlightRef.current = false;
                 return 'idle';
             }
 
-            pendingDraftRef.current = null;
+            const saveGeneration = saveGenerationRef.current;
             flushAfterInFlightRef.current = false;
             clearSaveTimer();
             inFlightSaveRef.current = true;
@@ -128,143 +142,211 @@ export function useNoteSaveController({
             }
 
             const savePromise = (async (): Promise<NoteSaveFlushResult> => {
-                let response: Awaited<ReturnType<typeof updateNote>>;
+                const prerequisiteResult = (await beforeSaveRef.current?.()) ?? 'idle';
 
-                try {
-                    response = await updateNote({
-                        id: noteId,
-                        title: draft.title,
-                        content: draft.content,
-                        ...(draft.layout ? { layout: draft.layout } : {}),
-                        editSessionId: editSessionIdRef.current,
-                        ...(ignoreConflict ? { force: true } : { expectedUpdatedAt: draft.baseUpdatedAt }),
-                    });
-                } catch {
-                    response = {
-                        type: 'error',
-                        category: 'network',
-                        errors: [
-                            {
-                                code: 'NETWORK_ERROR',
-                                message: 'Failed to save note.',
-                            },
-                        ],
-                    };
+                if (saveGeneration !== saveGenerationRef.current) {
+                    return 'idle';
                 }
 
-                inFlightSaveRef.current = false;
-                inFlightSavePromiseRef.current = null;
+                if (prerequisiteResult === 'error') {
+                    inFlightSaveRef.current = false;
+                    inFlightSavePromiseRef.current = null;
 
-                if (response.type === 'error') {
-                    if (!pendingDraftRef.current) {
-                        pendingDraftRef.current = draft;
-                    }
-
-                    persistCurrentPendingDraft();
-
-                    const error = response.errors[0];
-
-                    if (error.code === NOTE_UPDATE_CONFLICT_CODE && !ignoreConflict) {
-                        const currentUpdatedAt = (error.details as { extensions?: { currentUpdatedAt?: string } })
-                            ?.extensions?.currentUpdatedAt;
-                        isSaveConflictRef.current = true;
-
-                        if (!silent && isAliveRef.current) {
-                            setMountedSaveStatus('conflict');
-                            onConflictRef.current(currentUpdatedAt ?? serverUpdatedAtRef.current);
-                        }
-
-                        return 'conflict';
-                    }
-
-                    if (!silent && isAliveRef.current) {
+                    if (pendingDraftRef.current) {
                         setMountedSaveStatus('error');
-                        onErrorRef.current(error.message);
+                    } else {
+                        setMountedSaveStatus('saved');
                     }
 
                     return 'error';
                 }
 
-                isSaveConflictRef.current = false;
-                serverUpdatedAtRef.current = response.updateNote.updatedAt;
-                const shouldNotifySave = !silent && isAliveRef.current;
-                const noteDetailQueryKey = queryKeys.notes.detail(noteId);
+                const draft = pendingDraftRef.current;
 
-                await queryClient.cancelQueries({
-                    queryKey: noteDetailQueryKey,
-                    exact: true,
-                });
-
-                if (shouldNotifySave) {
-                    onSavedRef.current(response.updateNote.updatedAt);
+                if (!draft) {
+                    inFlightSaveRef.current = false;
+                    inFlightSavePromiseRef.current = null;
+                    setMountedSaveStatus('saved');
+                    return prerequisiteResult;
                 }
 
-                queryClient.setQueryData<NoteDetailCache>(noteDetailQueryKey, (current) => {
-                    if (!current) {
-                        return current;
+                pendingDraftRef.current = null;
+                const runSaveTransaction = async (): Promise<NoteSaveFlushResult> => {
+                    if (saveGeneration !== saveGenerationRef.current) {
+                        return 'idle';
                     }
 
-                    return {
-                        ...current,
-                        title: response.updateNote.title,
-                        content: draft.content,
-                        ...(draft.layout ? { layout: draft.layout } : {}),
+                    let response: Awaited<ReturnType<typeof updateNote>>;
+
+                    try {
+                        response = await updateNote({
+                            id: noteId,
+                            title: draft.title,
+                            content: draft.content,
+                            ...(draft.layout ? { layout: draft.layout } : {}),
+                            editSessionId: editSessionIdRef.current,
+                            ...(ignoreConflict ? { force: true } : { expectedUpdatedAt: serverUpdatedAtRef.current }),
+                        });
+                    } catch {
+                        response = {
+                            type: 'error',
+                            category: 'network',
+                            errors: [
+                                {
+                                    code: 'NETWORK_ERROR',
+                                    message: 'Failed to save note.',
+                                },
+                            ],
+                        };
+                    }
+
+                    if (saveGeneration !== saveGenerationRef.current) {
+                        return 'idle';
+                    }
+
+                    if (response.type === 'error') {
+                        inFlightSaveRef.current = false;
+                        inFlightSavePromiseRef.current = null;
+
+                        if (!pendingDraftRef.current) {
+                            pendingDraftRef.current = draft;
+                        }
+
+                        persistCurrentPendingDraft();
+                        const error = response.errors[0];
+
+                        if (error.code === NOTE_UPDATE_CONFLICT_CODE && !ignoreConflict) {
+                            const currentUpdatedAt = (error.details as { extensions?: { currentUpdatedAt?: string } })
+                                ?.extensions?.currentUpdatedAt;
+                            isSaveConflictRef.current = true;
+
+                            if (!silent && isAliveRef.current) {
+                                setMountedSaveStatus('conflict');
+                                onConflictRef.current(currentUpdatedAt ?? serverUpdatedAtRef.current);
+                            }
+
+                            return 'conflict';
+                        }
+
+                        if (!silent && isAliveRef.current) {
+                            setMountedSaveStatus('error');
+                            onErrorRef.current(error.message);
+                        }
+
+                        return 'error';
+                    }
+
+                    const shouldNotifySave = !silent && isAliveRef.current;
+                    const noteDetailQueryKey = queryKeys.notes.detail(noteId);
+
+                    await queryClient.cancelQueries({
+                        queryKey: noteDetailQueryKey,
+                        exact: true,
+                    });
+
+                    if (saveGeneration !== saveGenerationRef.current) {
+                        return 'idle';
+                    }
+
+                    inFlightSaveRef.current = false;
+                    inFlightSavePromiseRef.current = null;
+                    isSaveConflictRef.current = false;
+                    serverUpdatedAtRef.current = response.updateNote.updatedAt;
+
+                    if (shouldNotifySave) {
+                        onSavedRef.current(response.updateNote.updatedAt);
+                    }
+
+                    queryClient.setQueryData<NoteDetailCache>(noteDetailQueryKey, (current) =>
+                        current
+                            ? {
+                                  ...current,
+                                  title: response.updateNote.title,
+                                  content: draft.content,
+                                  ...(draft.layout ? { layout: draft.layout } : {}),
+                                  updatedAt: response.updateNote.updatedAt,
+                              }
+                            : current,
+                    );
+                    publishClientNoteUpdatedEvent({
+                        noteId,
                         updatedAt: response.updateNote.updatedAt,
-                    };
-                });
-                publishClientNoteUpdatedEvent({
-                    noteId,
-                    updatedAt: response.updateNote.updatedAt,
-                    editSessionId: editSessionIdRef.current,
-                });
-                const nextPendingDraft = pendingDraftRef.current as NoteSaveDraft | null;
+                        editSessionId: editSessionIdRef.current,
+                    });
+                    const nextPendingDraft = pendingDraftRef.current as NoteSaveDraft | null;
 
-                if (nextPendingDraft?.baseUpdatedAt === draft.baseUpdatedAt) {
-                    pendingDraftRef.current = {
-                        ...nextPendingDraft,
-                        baseUpdatedAt: response.updateNote.updatedAt,
-                    };
-                    persistCurrentPendingDraft();
-                } else if (!nextPendingDraft) {
-                    clearLocalNoteDraft(noteId);
-                }
-
-                if (shouldNotifySave) {
-                    if (pendingDraftRef.current) {
-                        setSaveStatus('pending');
-                    } else {
-                        setSaveStatus('saved');
-                        void queryClient.invalidateQueries({
-                            queryKey: queryKeys.notes.listAll(),
-                            exact: false,
-                        });
-                        void queryClient.invalidateQueries({
-                            queryKey: queryKeys.notes.tagListAll(),
-                            exact: false,
-                        });
-                        void queryClient.invalidateQueries({
-                            queryKey: queryKeys.notes.backReferencesAll(),
-                            exact: false,
-                        });
-                        void queryClient.invalidateQueries({
-                            queryKey: queryKeys.notes.graph(),
-                            exact: true,
-                        });
+                    if (nextPendingDraft?.baseUpdatedAt === draft.baseUpdatedAt) {
+                        pendingDraftRef.current = {
+                            ...nextPendingDraft,
+                            baseUpdatedAt: response.updateNote.updatedAt,
+                        };
+                        persistCurrentPendingDraft();
+                    } else if (!nextPendingDraft) {
+                        clearLocalNoteDraft(noteId);
                     }
+
+                    if (shouldNotifySave) {
+                        if (pendingDraftRef.current) {
+                            setSaveStatus('pending');
+                        } else {
+                            setSaveStatus('saved');
+                            void queryClient.invalidateQueries({
+                                queryKey: queryKeys.notes.listAll(),
+                                exact: false,
+                            });
+                            void queryClient.invalidateQueries({
+                                queryKey: queryKeys.notes.tagListAll(),
+                                exact: false,
+                            });
+                            void queryClient.invalidateQueries({
+                                queryKey: queryKeys.notes.backReferencesAll(),
+                                exact: false,
+                            });
+                            void queryClient.invalidateQueries({
+                                queryKey: queryKeys.notes.graph(),
+                                exact: true,
+                            });
+                        }
+                    }
+
+                    return 'saved';
+                };
+                const result = executeWriteRef.current
+                    ? await executeWriteRef.current(runSaveTransaction)
+                    : await runSaveTransaction();
+
+                if (!result) {
+                    if (!pendingDraftRef.current) {
+                        pendingDraftRef.current = draft;
+                    }
+
+                    persistCurrentPendingDraft();
+                    inFlightSaveRef.current = false;
+                    inFlightSavePromiseRef.current = null;
+                    setMountedSaveStatus('pending');
+                    return 'idle';
                 }
 
-                if (pendingDraftRef.current || flushAfterInFlightRef.current) {
+                if (result === 'saved' && (pendingDraftRef.current || flushAfterInFlightRef.current)) {
                     return flushPendingSave({ silent });
                 }
 
-                return 'saved';
+                return result;
             })();
 
             inFlightSavePromiseRef.current = savePromise;
 
             return savePromise;
         },
-        [clearSaveTimer, editSessionIdRef, noteId, persistCurrentPendingDraft, queryClient, setMountedSaveStatus],
+        [
+            clearSaveTimer,
+            editSessionIdRef,
+            noteId,
+            persistCurrentPendingDraft,
+            queryClient,
+            serverUpdatedAtRef,
+            setMountedSaveStatus,
+        ],
     );
 
     const queueSave = useCallback(
@@ -309,8 +391,10 @@ export function useNoteSaveController({
     );
 
     const clearDrafts = useCallback(() => {
+        saveGenerationRef.current += 1;
         clearSaveTimer();
         pendingDraftRef.current = null;
+        inFlightSaveRef.current = false;
         inFlightSavePromiseRef.current = null;
         flushAfterInFlightRef.current = false;
         isSaveConflictRef.current = false;
@@ -345,10 +429,13 @@ export function useNoteSaveController({
     );
 
     useEffect(() => {
+        beforeSaveRef.current = beforeSave;
+        executeWriteRef.current = executeWrite;
+        hasExternalPendingChangesRef.current = hasExternalPendingChanges;
         onConflictRef.current = onConflict;
         onErrorRef.current = onError;
         onSavedRef.current = onSaved;
-    }, [onConflict, onError, onSaved]);
+    }, [beforeSave, executeWrite, hasExternalPendingChanges, onConflict, onError, onSaved]);
 
     useEffect(() => {
         isAliveRef.current = true;
@@ -368,6 +455,7 @@ export function useNoteSaveController({
     }, [initialUpdatedAt]);
 
     useEffect(() => {
+        saveGenerationRef.current += 1;
         pendingDraftRef.current = null;
         inFlightSaveRef.current = false;
         inFlightSavePromiseRef.current = null;
@@ -380,7 +468,12 @@ export function useNoteSaveController({
 
     useEffect(() => {
         const handleBeforeUnload = (event: BeforeUnloadEvent) => {
-            if (!pendingDraftRef.current && !inFlightSaveRef.current && !isSaveConflictRef.current) {
+            if (
+                !pendingDraftRef.current &&
+                !inFlightSaveRef.current &&
+                !isSaveConflictRef.current &&
+                !hasExternalPendingChangesRef.current?.()
+            ) {
                 return;
             }
 

--- a/packages/client/src/hooks/useNoteWriteCoordinator.spec.ts
+++ b/packages/client/src/hooks/useNoteWriteCoordinator.spec.ts
@@ -1,0 +1,108 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useNoteWriteCoordinator } from './useNoteWriteCoordinator';
+
+const createDeferred = <T>() => {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((nextResolve) => {
+        resolve = nextResolve;
+    });
+
+    return { promise, resolve };
+};
+
+describe('useNoteWriteCoordinator', () => {
+    it('runs note writes sequentially in request order', async () => {
+        const firstWrite = createDeferred<string>();
+        const executionOrder: string[] = [];
+        const { result } = renderHook(() => useNoteWriteCoordinator());
+
+        const firstResult = result.current.execute(async () => {
+            executionOrder.push('first:start');
+            const value = await firstWrite.promise;
+            executionOrder.push('first:end');
+            return value;
+        });
+        const secondResult = result.current.execute(async () => {
+            executionOrder.push('second:start');
+            return 'second';
+        });
+
+        await Promise.resolve();
+        expect(executionOrder).toEqual(['first:start']);
+
+        firstWrite.resolve('first');
+
+        await expect(firstResult).resolves.toBe('first');
+        await expect(secondResult).resolves.toBe('second');
+        expect(executionOrder).toEqual(['first:start', 'first:end', 'second:start']);
+    });
+
+    it('continues the queue after a failed write', async () => {
+        const { result } = renderHook(() => useNoteWriteCoordinator());
+
+        const failedResult = result.current.execute(async () => {
+            throw new Error('write failed');
+        });
+        const recoveredResult = result.current.execute(async () => 'recovered');
+
+        await expect(failedResult).rejects.toThrow('write failed');
+        await expect(recoveredResult).resolves.toBe('recovered');
+    });
+
+    it('skips queued writes invalidated before they start', async () => {
+        const firstWrite = createDeferred<void>();
+        const queuedWrite = vi.fn().mockResolvedValue('stale');
+        const { result } = renderHook(() => useNoteWriteCoordinator());
+
+        const firstResult = result.current.execute(() => firstWrite.promise);
+        const queuedResult = result.current.execute(queuedWrite);
+
+        await Promise.resolve();
+        result.current.invalidatePending();
+        firstWrite.resolve();
+
+        await expect(firstResult).resolves.toBeUndefined();
+        await expect(queuedResult).resolves.toBeUndefined();
+        expect(queuedWrite).not.toHaveBeenCalled();
+    });
+
+    it('drains the active transaction before resolving', async () => {
+        const transaction = createDeferred<void>();
+        const { result } = renderHook(() => useNoteWriteCoordinator());
+        let didDrain = false;
+
+        void result.current.execute(() => transaction.promise);
+        const drainResult = result.current.drain().then(() => {
+            didDrain = true;
+        });
+
+        await Promise.resolve();
+        expect(didDrain).toBe(false);
+
+        transaction.resolve();
+        await drainResult;
+
+        expect(didDrain).toBe(true);
+    });
+
+    it('reports queued and active transactions as busy', async () => {
+        const transaction = createDeferred<void>();
+        const { result } = renderHook(() => useNoteWriteCoordinator());
+
+        let transactionResult!: Promise<void | undefined>;
+        act(() => {
+            transactionResult = result.current.execute(() => transaction.promise);
+        });
+
+        expect(result.current.isBusy).toBe(true);
+        expect(result.current.hasPendingWrites()).toBe(true);
+
+        await act(async () => {
+            transaction.resolve();
+            await transactionResult;
+        });
+
+        await waitFor(() => expect(result.current.isBusy).toBe(false));
+        expect(result.current.hasPendingWrites()).toBe(false);
+    });
+});

--- a/packages/client/src/hooks/useNoteWriteCoordinator.ts
+++ b/packages/client/src/hooks/useNoteWriteCoordinator.ts
@@ -1,0 +1,58 @@
+import { useCallback, useMemo, useRef, useState } from 'react';
+
+export type NoteWriteExecutor = <T>(write: () => Promise<T>) => Promise<T | undefined>;
+
+export interface NoteWriteCoordinator {
+    execute: NoteWriteExecutor;
+    invalidatePending: () => void;
+    drain: () => Promise<void>;
+    isBusy: boolean;
+    hasPendingWrites: () => boolean;
+}
+
+export function useNoteWriteCoordinator(): NoteWriteCoordinator {
+    const writeQueueRef = useRef<Promise<void>>(Promise.resolve());
+    const generationRef = useRef(0);
+    const pendingWriteCountRef = useRef(0);
+    const [isBusy, setIsBusy] = useState(false);
+
+    const execute = useCallback(<T>(write: () => Promise<T>) => {
+        pendingWriteCountRef.current += 1;
+        setIsBusy(true);
+        const generation = generationRef.current;
+        const runWrite = () => (generation === generationRef.current ? write() : undefined);
+        const result = writeQueueRef.current.then(runWrite, runWrite);
+        writeQueueRef.current = result.then(
+            () => undefined,
+            () => undefined,
+        );
+        const settleWrite = () => {
+            pendingWriteCountRef.current -= 1;
+
+            if (pendingWriteCountRef.current === 0) {
+                setIsBusy(false);
+            }
+        };
+        void result.then(settleWrite, settleWrite);
+
+        return result;
+    }, []);
+
+    const invalidatePending = useCallback(() => {
+        generationRef.current += 1;
+    }, []);
+
+    const drain = useCallback(() => writeQueueRef.current, []);
+    const hasPendingWrites = useCallback(() => pendingWriteCountRef.current > 0, []);
+
+    return useMemo(
+        () => ({
+            execute,
+            invalidatePending,
+            drain,
+            isBusy,
+            hasPendingWrites,
+        }),
+        [drain, execute, hasPendingWrites, invalidatePending, isBusy],
+    );
+}

--- a/packages/client/src/modules/note-external-change.spec.ts
+++ b/packages/client/src/modules/note-external-change.spec.ts
@@ -1,0 +1,154 @@
+import { classifyExternalNoteEvent, isBlockingExternalNoteChange } from './note-external-change';
+
+const baseInput = {
+    noteId: '7',
+    editSessionId: 'session-1',
+    loadedUpdatedAt: '1770000000000',
+    acceptedUpdatedAt: '1770000000000',
+    hasUnsavedChanges: false,
+};
+
+describe('classifyExternalNoteEvent', () => {
+    it.each([
+        [
+            'an event for a different note',
+            {
+                type: 'mcp.note.updated' as const,
+                source: 'mcp' as const,
+                noteId: '8',
+                updatedAt: '1770000001000',
+            },
+        ],
+        [
+            'a note creation event',
+            {
+                type: 'mcp.note.created' as const,
+                source: 'mcp' as const,
+                noteId: '7',
+                updatedAt: '1770000001000',
+            },
+        ],
+    ])('ignores %s', (_scenario, event) => {
+        expect(classifyExternalNoteEvent({ ...baseInput, event })).toEqual({ type: 'ignore' });
+    });
+
+    it('ignores a web update published by the current edit session', () => {
+        const decision = classifyExternalNoteEvent({
+            ...baseInput,
+            event: {
+                type: 'web.note.updated',
+                source: 'web',
+                noteId: '7',
+                updatedAt: '1770000001000',
+                editSessionId: 'session-1',
+            },
+        });
+
+        expect(decision).toEqual({ type: 'ignore' });
+    });
+
+    it('pauses saving when a different editor updates a dirty note', () => {
+        const decision = classifyExternalNoteEvent({
+            ...baseInput,
+            hasUnsavedChanges: true,
+            event: {
+                type: 'mcp.note.updated',
+                source: 'mcp',
+                noteId: '7',
+                updatedAt: '1770000001000',
+            },
+        });
+
+        expect(decision).toEqual({
+            type: 'notify',
+            change: {
+                type: 'updated',
+                source: 'mcp',
+                updatedAt: '1770000001000',
+            },
+            shouldPauseSave: true,
+        });
+    });
+
+    it('ignores an update that is already loaded or accepted', () => {
+        const event = {
+            type: 'web.note.updated' as const,
+            source: 'web' as const,
+            noteId: '7',
+            updatedAt: '1770000001000',
+            editSessionId: 'session-2',
+        };
+
+        expect(
+            classifyExternalNoteEvent({
+                ...baseInput,
+                loadedUpdatedAt: event.updatedAt,
+                event,
+            }),
+        ).toEqual({ type: 'ignore' });
+        expect(
+            classifyExternalNoteEvent({
+                ...baseInput,
+                acceptedUpdatedAt: event.updatedAt,
+                event,
+            }),
+        ).toEqual({ type: 'ignore' });
+    });
+
+    it('ignores an out-of-order update older than the loaded version', () => {
+        const decision = classifyExternalNoteEvent({
+            ...baseInput,
+            loadedUpdatedAt: '1770000003000',
+            acceptedUpdatedAt: '1770000003000',
+            hasUnsavedChanges: true,
+            event: {
+                type: 'mcp.note.updated',
+                source: 'mcp',
+                noteId: '7',
+                updatedAt: '1770000002000',
+            },
+        });
+
+        expect(decision).toEqual({ type: 'ignore' });
+    });
+
+    it('surfaces deletion independently of local save state', () => {
+        const decision = classifyExternalNoteEvent({
+            ...baseInput,
+            hasUnsavedChanges: true,
+            event: {
+                type: 'mcp.note.deleted',
+                source: 'mcp',
+                noteId: '7',
+            },
+        });
+
+        expect(decision).toEqual({
+            type: 'notify',
+            change: { type: 'deleted', source: 'mcp' },
+            shouldPauseSave: false,
+        });
+    });
+});
+
+describe('isBlockingExternalNoteChange', () => {
+    it('stops blocking after a non-conflicting update is loaded', () => {
+        expect(
+            isBlockingExternalNoteChange({
+                change: { type: 'updated', source: 'web', updatedAt: '1770000001000' },
+                isConflict: false,
+                loadedUpdatedAt: '1770000001000',
+            }),
+        ).toBe(false);
+    });
+
+    it('keeps blocking when the loaded update still conflicts with a draft', () => {
+        expect(
+            isBlockingExternalNoteChange({
+                change: { type: 'updated', source: 'web', updatedAt: '1770000001000' },
+                isConflict: true,
+                loadedUpdatedAt: '1770000001000',
+            }),
+        ).toBe(true);
+    });
+});

--- a/packages/client/src/modules/note-external-change.ts
+++ b/packages/client/src/modules/note-external-change.ts
@@ -1,0 +1,82 @@
+import type { ServerEvent } from '~/modules/server-events';
+import { compareNoteVersions } from './note-version';
+
+export type ExternalNoteChangeSource = 'web' | 'mcp' | 'unknown';
+
+export type ExternalNoteChange =
+    | { type: 'updated'; updatedAt: string; source: ExternalNoteChangeSource }
+    | { type: 'deleted'; source: ExternalNoteChangeSource };
+
+interface ClassifyExternalNoteEventInput {
+    event: ServerEvent;
+    noteId: string;
+    editSessionId: string;
+    loadedUpdatedAt: string;
+    acceptedUpdatedAt: string;
+    hasUnsavedChanges: boolean;
+}
+
+export type ExternalNoteEventDecision =
+    | { type: 'ignore' }
+    | { type: 'notify'; change: ExternalNoteChange; shouldPauseSave: boolean };
+
+export const classifyExternalNoteEvent = ({
+    event,
+    noteId,
+    editSessionId,
+    loadedUpdatedAt,
+    acceptedUpdatedAt,
+    hasUnsavedChanges,
+}: ClassifyExternalNoteEventInput): ExternalNoteEventDecision => {
+    if (event.noteId !== noteId || event.type === 'mcp.note.created') {
+        return { type: 'ignore' };
+    }
+
+    if (event.source === 'web' && event.editSessionId === editSessionId) {
+        return { type: 'ignore' };
+    }
+
+    if (event.type === 'mcp.note.deleted') {
+        return {
+            type: 'notify',
+            change: { type: 'deleted', source: event.source },
+            shouldPauseSave: false,
+        };
+    }
+
+    const comparedWithLoaded = compareNoteVersions(event.updatedAt, loadedUpdatedAt);
+    const comparedWithAccepted = compareNoteVersions(event.updatedAt, acceptedUpdatedAt);
+
+    if (
+        (comparedWithLoaded !== null && comparedWithLoaded <= 0) ||
+        (comparedWithAccepted !== null && comparedWithAccepted <= 0)
+    ) {
+        return { type: 'ignore' };
+    }
+
+    return {
+        type: 'notify',
+        change: {
+            type: 'updated',
+            updatedAt: event.updatedAt,
+            source: event.source,
+        },
+        shouldPauseSave: hasUnsavedChanges,
+    };
+};
+
+export const isBlockingExternalNoteChange = ({
+    change,
+    isConflict,
+    loadedUpdatedAt,
+}: {
+    change: ExternalNoteChange | null;
+    isConflict: boolean;
+    loadedUpdatedAt: string;
+}) => {
+    if (!change) {
+        return false;
+    }
+
+    return !(change.type === 'updated' && !isConflict && change.updatedAt === loadedUpdatedAt);
+};

--- a/packages/client/src/modules/note-version.spec.ts
+++ b/packages/client/src/modules/note-version.spec.ts
@@ -1,0 +1,21 @@
+import { compareNoteVersions, toNoteVersionTime } from './note-version';
+
+describe('note version ordering', () => {
+    it.each([
+        ['1770000000000', 1770000000000],
+        ['2026-02-02T02:40:00.000Z', Date.parse('2026-02-02T02:40:00.000Z')],
+        ['not-a-version', null],
+    ])('parses %s as a comparable timestamp', (version, expected) => {
+        expect(toNoteVersionTime(version)).toBe(expected);
+    });
+
+    it('orders timestamp and ISO versions chronologically', () => {
+        expect(compareNoteVersions('1770000001000', '1770000000000')).toBeGreaterThan(0);
+        expect(compareNoteVersions('2026-02-02T02:40:00.000Z', '2026-02-02T02:40:01.000Z')).toBeLessThan(0);
+    });
+
+    it('only treats identical invalid versions as equal', () => {
+        expect(compareNoteVersions('invalid', 'invalid')).toBe(0);
+        expect(compareNoteVersions('invalid-a', 'invalid-b')).toBeNull();
+    });
+});

--- a/packages/client/src/modules/note-version.ts
+++ b/packages/client/src/modules/note-version.ts
@@ -1,0 +1,16 @@
+export const toNoteVersionTime = (updatedAt: string) => {
+    const timestamp = /^\d+$/.test(updatedAt) ? Number(updatedAt) : Date.parse(updatedAt);
+
+    return Number.isFinite(timestamp) ? timestamp : null;
+};
+
+export const compareNoteVersions = (left: string, right: string) => {
+    const leftTime = toNoteVersionTime(left);
+    const rightTime = toNoteVersionTime(right);
+
+    if (leftTime === null || rightTime === null) {
+        return left === right ? 0 : null;
+    }
+
+    return leftTime === rightTime ? 0 : leftTime < rightTime ? -1 : 1;
+};

--- a/packages/client/src/pages/Note.external-change.spec.tsx
+++ b/packages/client/src/pages/Note.external-change.spec.tsx
@@ -1,7 +1,17 @@
 import { QueryClientProvider } from '@tanstack/react-query';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { StrictMode, Suspense } from 'react';
-import { createNote as createNoteApi, fetchNote, fetchNotePropertyKeys, updateNote } from '~/apis/note.api';
+import {
+    createNote as createNoteApi,
+    fetchNote,
+    fetchNotePropertyKeys,
+    fetchNoteSnapshots,
+    pinNote,
+    restoreNoteSnapshot,
+    updateNote,
+    updateNoteProperties,
+} from '~/apis/note.api';
 import { ToastProvider } from '~/components/ui';
 import type { Note } from '~/models/note.model';
 import { getDraftStorageKey, type NoteSaveDraft } from '~/modules/note-draft-storage';
@@ -35,6 +45,7 @@ vi.mock('~/apis/note.api', () => ({
     createNote: vi.fn(),
     fetchNote: vi.fn(),
     fetchNotePropertyKeys: vi.fn(),
+    pinNote: vi.fn(),
     updateNote: vi.fn(),
     updateNoteProperties: vi.fn(),
     fetchNoteSnapshot: vi.fn(),
@@ -497,6 +508,7 @@ describe('<NoteContent /> external change handling', () => {
     });
 
     it('saves a failed draft as a new note without retrying the failed original save', async () => {
+        const user = userEvent.setup();
         const initialNote = createNote({
             title: 'Initial title',
             content: createContent('Initial body'),
@@ -528,7 +540,7 @@ describe('<NoteContent /> external change handling', () => {
 
         expect(await screen.findByText(/Save failed. Your latest draft is still available here/)).toBeInTheDocument();
 
-        fireEvent.click(screen.getByRole('button', { name: 'Save as new note' }));
+        await user.click(screen.getByRole('button', { name: 'Save as new note' }));
 
         expect(createNoteApi).toHaveBeenCalledWith({
             title: 'Recovered title',
@@ -576,5 +588,291 @@ describe('<NoteContent /> external change handling', () => {
 
         expect(screen.getByPlaceholderText('Title')).toHaveValue('Browser draft title');
         expect(screen.getByLabelText('Editor')).toHaveValue('Browser draft body');
+    });
+
+    it('flushes pending property changes before allowing navigation', async () => {
+        const user = userEvent.setup();
+        const property = {
+            key: 'summary',
+            name: 'Summary',
+            value: 'Initial summary',
+            valueType: 'text' as const,
+            createdAt: '1779700000000',
+            updatedAt: '1779700000000',
+        };
+        const initialNote = createNote({
+            properties: [property],
+            updatedAt: '1779700000000',
+        });
+        vi.mocked(updateNoteProperties).mockResolvedValue({
+            type: 'success',
+            updateNoteProperties: {
+                id: initialNote.id,
+                updatedAt: '1779700001000',
+                properties: [{ ...property, value: 'Navigation-safe summary', updatedAt: '1779700001000' }],
+            },
+        });
+        renderNote(initialNote);
+
+        const propertyInput = await screen.findByRole('textbox', { name: 'Property value' });
+        await user.clear(propertyInput);
+        await user.type(propertyInput, 'Navigation-safe summary');
+        await waitFor(() => {
+            const blockerOptions = mockUseBlocker.mock.calls.at(-1)?.[0] as { disabled: boolean } | undefined;
+            expect(blockerOptions?.disabled).toBe(false);
+        });
+        const blockerOptions = mockUseBlocker.mock.calls.at(-1)?.[0] as
+            | { shouldBlockFn: () => Promise<boolean> }
+            | undefined;
+
+        let shouldBlock = true;
+
+        await act(async () => {
+            shouldBlock = (await blockerOptions?.shouldBlockFn()) ?? true;
+        });
+
+        expect(shouldBlock).toBe(false);
+        expect(updateNoteProperties).toHaveBeenCalledWith({
+            id: initialNote.id,
+            set: [
+                {
+                    key: 'summary',
+                    name: 'Summary',
+                    value: 'Navigation-safe summary',
+                    valueType: 'text',
+                },
+            ],
+            deleteKeys: [],
+            editSessionId: expect.any(String),
+            expectedUpdatedAt: initialNote.updatedAt,
+        });
+    });
+
+    it('uses the version returned by pinning for the next document save', async () => {
+        const user = userEvent.setup();
+        const initialNote = createNote({ updatedAt: '1779700000000' });
+        vi.mocked(pinNote).mockResolvedValue({
+            type: 'success',
+            pinNote: {
+                id: initialNote.id,
+                title: initialNote.title,
+                pinned: true,
+                createdAt: initialNote.createdAt,
+                updatedAt: '1779700001000',
+            },
+        });
+        vi.mocked(updateNote).mockResolvedValue({
+            type: 'success',
+            updateNote: createNote({ title: 'After pin', pinned: true, updatedAt: '1779700002000' }),
+        });
+        renderNote(initialNote);
+
+        await user.click(await screen.findByRole('button', { name: 'Note actions' }));
+        await user.click(screen.getByRole('menuitem', { name: 'Pin' }));
+        await waitFor(() => expect(pinNote).toHaveBeenCalledWith(initialNote.id, true));
+
+        const titleInput = screen.getByRole('textbox', { name: 'Note title' });
+        await user.clear(titleInput);
+        await user.type(titleInput, 'After pin');
+        await user.click(screen.getByRole('button', { name: 'Save' }));
+
+        await waitFor(() => {
+            expect(updateNote).toHaveBeenCalledWith({
+                id: initialNote.id,
+                title: 'After pin',
+                content: initialNote.content,
+                editSessionId: expect.any(String),
+                expectedUpdatedAt: '1779700001000',
+            });
+        });
+    });
+
+    it('waits for an active pin transaction before deleting the note', async () => {
+        const user = userEvent.setup();
+        const initialNote = createNote({ updatedAt: '1779700000000' });
+        const delayedPin = createDeferred<Awaited<ReturnType<typeof pinNote>>>();
+        vi.mocked(pinNote).mockReturnValue(delayedPin.promise);
+        renderNote(initialNote);
+
+        await user.click(await screen.findByRole('button', { name: 'Note actions' }));
+        await user.click(screen.getByRole('menuitem', { name: 'Pin' }));
+        await waitFor(() => expect(pinNote).toHaveBeenCalledTimes(1));
+
+        await user.click(screen.getByRole('button', { name: 'Note actions' }));
+        await user.click(screen.getByRole('menuitem', { name: 'Delete' }));
+        expect(mockUseNoteMutate.onDelete).not.toHaveBeenCalled();
+
+        await act(async () => {
+            delayedPin.resolve({
+                type: 'success',
+                pinNote: {
+                    id: initialNote.id,
+                    title: initialNote.title,
+                    pinned: true,
+                    createdAt: initialNote.createdAt,
+                    updatedAt: '1779700001000',
+                },
+            });
+            await delayedPin.promise;
+        });
+
+        await waitFor(() =>
+            expect(mockUseNoteMutate.onDelete).toHaveBeenCalledWith(initialNote.id, expect.any(Function)),
+        );
+    });
+
+    it('skips a queued property write when reloading an external version', async () => {
+        const user = userEvent.setup();
+        const property = {
+            key: 'summary',
+            name: 'Summary',
+            value: 'Initial summary',
+            valueType: 'text' as const,
+            createdAt: '1779700000000',
+            updatedAt: '1779700000000',
+        };
+        const initialNote = createNote({ properties: [property], updatedAt: '1779700000000' });
+        const remoteNote = createNote({
+            title: 'Remote title',
+            properties: [{ ...property, value: 'Remote summary', updatedAt: '1779700002000' }],
+            updatedAt: '1779700002000',
+        });
+        const delayedPin = createDeferred<Awaited<ReturnType<typeof pinNote>>>();
+        vi.mocked(pinNote).mockReturnValue(delayedPin.promise);
+        renderNote(initialNote);
+
+        await user.click(await screen.findByRole('button', { name: 'Note actions' }));
+        await user.click(screen.getByRole('menuitem', { name: 'Pin' }));
+        await waitFor(() => expect(pinNote).toHaveBeenCalledTimes(1));
+
+        const propertyInput = screen.getByRole('textbox', { name: 'Property value' });
+        await user.clear(propertyInput);
+        await user.type(propertyInput, 'Discarded summary');
+        expect(await screen.findByText('Saving...')).toBeInTheDocument();
+        expect(updateNoteProperties).not.toHaveBeenCalled();
+
+        act(() => {
+            publishServerEvent({
+                type: 'web.note.updated',
+                source: 'web',
+                noteId: initialNote.id,
+                updatedAt: remoteNote.updatedAt,
+                editSessionId: 'other-editor',
+                eventId: 'reload-skips-property-write',
+            });
+        });
+        vi.mocked(fetchNote).mockResolvedValue({ type: 'success', note: remoteNote });
+        await user.click(await screen.findByRole('button', { name: 'Reload latest' }));
+
+        await act(async () => {
+            delayedPin.resolve({
+                type: 'success',
+                pinNote: {
+                    id: initialNote.id,
+                    title: initialNote.title,
+                    pinned: true,
+                    createdAt: initialNote.createdAt,
+                    updatedAt: '1779700001000',
+                },
+            });
+            await delayedPin.promise;
+        });
+
+        await waitFor(() => expect(screen.getByRole('textbox', { name: 'Note title' })).toHaveValue('Remote title'));
+        expect(updateNoteProperties).not.toHaveBeenCalled();
+    });
+
+    it('restores a snapshot only after the active note save transaction finishes', async () => {
+        const user = userEvent.setup();
+        const initialNote = createNote({ updatedAt: '1779700000000' });
+        const delayedSave = createDeferred<Awaited<ReturnType<typeof updateNote>>>();
+        const restoredNote = createNote({
+            title: 'Snapshot title',
+            content: 'Snapshot content',
+            updatedAt: '1779700002000',
+        });
+        vi.mocked(updateNote).mockReturnValue(delayedSave.promise);
+        vi.mocked(fetchNoteSnapshots).mockResolvedValue({
+            type: 'success',
+            noteSnapshots: [
+                {
+                    id: 'snapshot-1',
+                    title: restoredNote.title,
+                    contentPreview: restoredNote.content,
+                    createdAt: '1779699999000',
+                    meta: { entrypoint: 'web', label: 'Web browser' },
+                },
+            ],
+        } as never);
+        vi.mocked(restoreNoteSnapshot).mockResolvedValue({
+            type: 'success',
+            restoreNoteSnapshot: restoredNote,
+        });
+        renderNote(initialNote);
+
+        const titleInput = await screen.findByRole('textbox', { name: 'Note title' });
+        await user.clear(titleInput);
+        await user.type(titleInput, 'Pending local title');
+        await user.click(screen.getByRole('button', { name: 'Save' }));
+        await waitFor(() => expect(updateNote).toHaveBeenCalledTimes(1));
+
+        await user.click(screen.getByRole('button', { name: 'Note actions' }));
+        await user.click(screen.getByRole('menuitem', { name: 'Restore previous version' }));
+        await user.click(await screen.findByRole('button', { name: 'Restore' }));
+        expect(restoreNoteSnapshot).not.toHaveBeenCalled();
+
+        await act(async () => {
+            delayedSave.resolve({
+                type: 'success',
+                updateNote: createNote({ title: 'Pending local title', updatedAt: '1779700001000' }),
+            });
+            await delayedSave.promise;
+        });
+
+        await waitFor(() => expect(restoreNoteSnapshot).toHaveBeenCalledWith('snapshot-1'));
+        await waitFor(() => expect(screen.getByRole('textbox', { name: 'Note title' })).toHaveValue('Snapshot title'));
+        expect(screen.getByLabelText('Editor')).toHaveValue('Snapshot content');
+    });
+
+    it('keeps a layout conflict blocking until the accepted version is committed', async () => {
+        const user = userEvent.setup();
+        const initialNote = createNote({ updatedAt: '1779700000000' });
+        vi.mocked(updateNote)
+            .mockResolvedValueOnce({
+                type: 'error',
+                category: 'graphql',
+                errors: [
+                    {
+                        code: 'NOTE_UPDATE_CONFLICT',
+                        message: 'The note changed elsewhere.',
+                        details: { extensions: { currentUpdatedAt: '1779700001000' } },
+                    },
+                ],
+            })
+            .mockResolvedValueOnce({
+                type: 'success',
+                updateNote: createNote({ layout: 'full', updatedAt: '1779700002000' }),
+            });
+        const queryClient = renderNote(initialNote);
+
+        await user.click(await screen.findByRole('button', { name: 'Note actions' }));
+        await user.click(screen.getByRole('menuitem', { name: 'Change layout' }));
+        await user.click(screen.getByText('Full Width'));
+        await user.click(screen.getByRole('button', { name: 'Apply' }));
+        expect(await screen.findByRole('dialog', { name: /Save paused/ })).toBeInTheDocument();
+
+        const cacheCommit = createDeferred<void>();
+        vi.spyOn(queryClient, 'cancelQueries').mockReturnValue(cacheCommit.promise);
+        await user.click(screen.getByRole('button', { name: 'Overwrite' }));
+        await waitFor(() => expect(updateNote).toHaveBeenCalledTimes(2));
+
+        expect(screen.getByRole('dialog', { name: /Save paused/ })).toBeInTheDocument();
+
+        await act(async () => {
+            cacheCommit.resolve();
+            await cacheCommit.promise;
+        });
+
+        await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
     });
 });

--- a/packages/client/src/pages/Note.tsx
+++ b/packages/client/src/pages/Note.tsx
@@ -1,71 +1,28 @@
-import { useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
-import { getRouteApi, Link, useBlocker } from '@tanstack/react-router';
+import { getRouteApi, Link } from '@tanstack/react-router';
 import classNames from 'classnames';
-import dayjs from 'dayjs';
-import { nanoid } from 'nanoid';
-import { useCallback, useEffect, useRef, useState } from 'react';
-import { createNote, fetchNote, updateNote } from '~/apis/note.api';
+import { useState } from 'react';
 import { QueryBoundary, QueryErrorView } from '~/components/app';
 import { BackReferences } from '~/components/entities';
 import * as Icon from '~/components/icon';
 import {
     LayoutModal,
+    NoteEditorHeader,
     NoteExportModal,
     NoteExternalChangeModal,
     NotePropertiesPanel,
+    NoteRecoveryCallouts,
     RestoreSnapshotModal,
 } from '~/components/note';
 import { ReminderPanel } from '~/components/reminder';
-import { AuxiliaryPanel, Button, Callout, Dropdown, PageLayout, Skeleton } from '~/components/shared';
-import type { EditorRef } from '~/components/shared/Editor';
+import { AuxiliaryPanel, PageLayout, Skeleton } from '~/components/shared';
 import Editor from '~/components/shared/Editor';
-import { MoreButton, Text, useToast } from '~/components/ui';
+import { Text, useToast } from '~/components/ui';
 import useNoteMutate from '~/hooks/resource/useNoteMutate';
-import { useNoteSaveController } from '~/hooks/useNoteSaveController';
-import type { Note, NoteLayout } from '~/models/note.model';
-import { replaceFixedPlaceholder } from '~/modules/fixed-placeholder';
-import { createMarkdownDocumentExport } from '~/modules/note-export';
-import { queryKeys } from '~/modules/query-key-factory';
-import { publishClientNoteUpdatedEvent, subscribeServerEvent } from '~/modules/server-events';
-import { getRecentTimeSinceRefreshDelay, recentTimeSince } from '~/modules/time';
+import { useNoteEditorSession } from '~/hooks/useNoteEditorSession';
+import type { NoteLayout } from '~/models/note.model';
 import { NOTE_ROUTE, SETTINGS_TRASH_ROUTE } from '~/modules/url';
 
 const Route = getRouteApi(NOTE_ROUTE);
-
-const toNoteVersionTime = (updatedAt: string) => {
-    const timestamp = /^\d+$/.test(updatedAt) ? Number(updatedAt) : Date.parse(updatedAt);
-
-    return Number.isFinite(timestamp) ? timestamp : null;
-};
-
-const formatSavedAt = (updatedAt: string) => {
-    const timestamp = toNoteVersionTime(updatedAt);
-
-    return dayjs(timestamp ?? Number(updatedAt)).format('YYYY-MM-DD HH:mm:ss');
-};
-
-const formatSavedAgo = (updatedAt: string, now: number) => {
-    return recentTimeSince(toNoteVersionTime(updatedAt), now);
-};
-
-const createEditSessionId = () => nanoid();
-const NOTE_UPDATE_CONFLICT_CODE = 'NOTE_UPDATE_CONFLICT';
-const SAVE_CONFIRMATION_DURATION_MS = 2200;
-
-const getConflictUpdatedAt = (details: unknown) => {
-    return (details as { extensions?: { currentUpdatedAt?: string } })?.extensions?.currentUpdatedAt;
-};
-
-const compareNoteVersions = (left: string, right: string) => {
-    const leftTime = toNoteVersionTime(left);
-    const rightTime = toNoteVersionTime(right);
-
-    if (leftTime === null || rightTime === null) {
-        return left === right ? 0 : 1;
-    }
-
-    return leftTime - rightTime;
-};
 
 const NOTE_LAYOUT_WIDTH: Record<NoteLayout, string> = {
     narrow: 'max-w-[640px]',
@@ -87,878 +44,209 @@ const notePageFallback = (
     </PageLayout>
 );
 
+function NoteReminders({ noteId }: { noteId: string }) {
+    return (
+        <QueryBoundary
+            fallback={<Skeleton height={107} />}
+            errorTitle="Failed to load reminders"
+            errorDescription="Retry loading reminder details for this note."
+            renderError={({ error, retry }) => (
+                <QueryErrorView
+                    title="Failed to load reminders"
+                    description="Retry loading reminder details for this note."
+                    error={error}
+                    onRetry={retry}
+                    showBackAction={false}
+                    showHomeAction={false}
+                />
+            )}
+        >
+            <ReminderPanel noteId={noteId} />
+        </QueryBoundary>
+    );
+}
+
+function NoteBackReferences({ noteId }: { noteId: string }) {
+    return (
+        <QueryBoundary
+            fallback={<Skeleton height={100} />}
+            errorTitle="Failed to load back references"
+            errorDescription="Retry loading notes that link back here."
+            renderError={({ error, retry }) => (
+                <QueryErrorView
+                    title="Failed to load back references"
+                    description="Retry loading notes that link back here."
+                    error={error}
+                    onRetry={retry}
+                    showBackAction={false}
+                    showHomeAction={false}
+                />
+            )}
+        >
+            <BackReferences
+                noteId={noteId}
+                render={(backReferences) =>
+                    backReferences?.length ? (
+                        <AuxiliaryPanel icon={<Icon.LinkSimple className="h-3.5 w-3.5" />} title="Back References">
+                            <ul className="flex flex-col">
+                                {backReferences.map((backLink) => (
+                                    <li key={backLink.id}>
+                                        <Link
+                                            to={NOTE_ROUTE}
+                                            params={{ id: backLink.id }}
+                                            className="flex items-center gap-2 rounded-[10px] px-2.5 py-1.5 text-fg-secondary transition-colors hover:bg-hover-subtle hover:text-fg-default"
+                                        >
+                                            <Icon.File className="h-3.5 w-3.5 shrink-0 text-fg-tertiary" />
+                                            <Text as="span" variant="body" weight="medium" className="text-current">
+                                                {backLink.title}
+                                            </Text>
+                                        </Link>
+                                    </li>
+                                ))}
+                            </ul>
+                        </AuxiliaryPanel>
+                    ) : null
+                }
+            />
+        </QueryBoundary>
+    );
+}
+
 interface NoteContentProps {
     id: string;
 }
 
-type ExternalNoteChangeSource = 'web' | 'mcp' | 'unknown';
-type ExternalNoteChange =
-    | { type: 'updated'; updatedAt: string; source: ExternalNoteChangeSource }
-    | { type: 'deleted'; source: ExternalNoteChangeSource };
-type NoteDetailCache = Pick<Note, 'title' | 'content' | 'pinned' | 'layout' | 'createdAt' | 'updatedAt' | 'properties'>;
-
 export function NoteContent({ id }: NoteContentProps) {
-    const toast = useToast();
+    const notify = useToast();
     const navigate = Route.useNavigate();
-    const queryClient = useQueryClient();
-    const editorRef = useRef<EditorRef>(null);
-    const titleRef = useRef<HTMLInputElement>(null);
-    const editSessionIdRef = useRef<string>(createEditSessionId());
-
-    const noteQuery = useSuspenseQuery({
-        queryKey: queryKeys.notes.detail(id),
-        queryFn: async () => {
-            const response = await fetchNote(id);
-            if (response.type === 'error') {
-                throw response;
-            }
-            return response.note;
-        },
-        gcTime: 0,
-    });
-    const note = noteQuery.data;
-
-    const [title, setTitle] = useState(note.title);
-    const [lastSavedAt, setLastSavedAt] = useState(() => formatSavedAt(note.updatedAt));
-    const [lastSavedVersion, setLastSavedVersion] = useState(note.updatedAt);
-    const [relativeNow, setRelativeNow] = useState(() => Date.now());
-    const [isPinned, setIsPinned] = useState(note.pinned);
-    const [layout, setLayout] = useState<NoteLayout>(note.layout || 'wide');
     const [isLayoutModalOpen, setIsLayoutModalOpen] = useState(false);
     const [isRestoreModalOpen, setIsRestoreModalOpen] = useState(false);
     const [isExportModalOpen, setIsExportModalOpen] = useState(false);
-    const [externalNoteChange, setExternalNoteChange] = useState<ExternalNoteChange | null>(null);
-    const [editorContentOverride, setEditorContentOverride] = useState<string | null>(null);
-    const [editorRevision, setEditorRevision] = useState(0);
-    const [showSavedConfirmation, setShowSavedConfirmation] = useState(false);
-    const appliedNoteVersionRef = useRef(note.updatedAt);
-    const activeNoteIdRef = useRef(id);
-    const layoutConflictRef = useRef<NoteLayout | null>(null);
-    const allowNextNavigationRef = useRef(false);
-    const updateLastSavedAt = useCallback((updatedAt: string) => {
-        setLastSavedAt(formatSavedAt(updatedAt));
-        setLastSavedVersion(updatedAt);
-        setRelativeNow(Date.now());
-    }, []);
-    const saveController = useNoteSaveController({
+    const session = useNoteEditorSession({
         noteId: id,
-        initialContent: note.content,
-        initialUpdatedAt: note.updatedAt,
-        editSessionIdRef,
-        getContent: () => editorRef.current?.getContent(),
-        onSaved: (updatedAt) => {
-            layoutConflictRef.current = null;
-            appliedNoteVersionRef.current = updatedAt;
-            updateLastSavedAt(updatedAt);
-            setShowSavedConfirmation(true);
-        },
-        onConflict: (updatedAt) => {
-            setExternalNoteChange({
-                type: 'updated',
-                updatedAt,
-                source: 'unknown',
-            });
-            toast('This note changed elsewhere. Choose how to resolve the draft.');
-        },
-        onError: toast,
-    });
-    const {
-        saveStatus,
-        localDraft,
-        serverUpdatedAtRef,
-        hasUnsavedChanges,
-        buildDraft,
-        queueSave,
-        flushPendingSave,
-        restoreLocalDraft,
-        discardLocalDraft,
-        clearDrafts,
-        resolveConflict,
-        pauseForConflict,
-        getPendingDraft,
-        setServerUpdatedAt,
-    } = saveController;
-
-    const shouldBlockNoteNavigation = useCallback(async () => {
-        if (allowNextNavigationRef.current) {
-            allowNextNavigationRef.current = false;
-            return false;
-        }
-
-        if (saveStatus === 'conflict') {
-            toast('Resolve the note conflict before leaving.');
-            return true;
-        }
-
-        const result = await flushPendingSave();
-
-        if (result === 'error') {
-            toast('Save failed. Stay on this note and try again.');
-            return true;
-        }
-
-        return result === 'conflict';
-    }, [flushPendingSave, saveStatus, toast]);
-
-    useBlocker({
-        disabled: saveStatus === 'saved',
-        enableBeforeUnload: false,
-        shouldBlockFn: shouldBlockNoteNavigation,
-    });
-
-    useEffect(() => {
-        if (hasUnsavedChanges) {
-            if (
-                note.updatedAt !== serverUpdatedAtRef.current &&
-                compareNoteVersions(note.updatedAt, serverUpdatedAtRef.current) > 0
-            ) {
-                pauseForConflict(note.updatedAt);
-            }
-
-            return;
-        }
-
-        const appliedNoteVersion = appliedNoteVersionRef.current;
-
-        if (note.updatedAt !== appliedNoteVersion && compareNoteVersions(note.updatedAt, appliedNoteVersion) < 0) {
-            return;
-        }
-
-        setIsPinned(note.pinned);
-        setLayout(note.layout || 'wide');
-        setServerUpdatedAt(note.updatedAt);
-        setTitle(note.title);
-        updateLastSavedAt(note.updatedAt);
-
-        if (appliedNoteVersion !== note.updatedAt) {
-            const currentEditorContent = editorRef.current?.getContent();
-
-            appliedNoteVersionRef.current = note.updatedAt;
-
-            if (currentEditorContent === undefined || currentEditorContent !== note.content) {
-                setEditorContentOverride(null);
-                setEditorRevision((current) => current + 1);
-            }
-        }
-    }, [
-        hasUnsavedChanges,
-        note.layout,
-        note.pinned,
-        note.title,
-        note.updatedAt,
-        pauseForConflict,
-        serverUpdatedAtRef,
-        setServerUpdatedAt,
-        updateLastSavedAt,
-    ]);
-
-    useEffect(() => {
-        if (activeNoteIdRef.current === id) {
-            return;
-        }
-
-        activeNoteIdRef.current = id;
-        editSessionIdRef.current = createEditSessionId();
-        appliedNoteVersionRef.current = note.updatedAt;
-        layoutConflictRef.current = null;
-        setExternalNoteChange(null);
-        setEditorContentOverride(null);
-        setEditorRevision((current) => current + 1);
-        setShowSavedConfirmation(false);
-    }, [id, note.updatedAt]);
-
-    useEffect(() => {
-        if (saveStatus !== 'saved') {
-            return;
-        }
-
-        const timer = window.setTimeout(
-            () => {
-                setRelativeNow(Date.now());
-            },
-            getRecentTimeSinceRefreshDelay(toNoteVersionTime(lastSavedVersion), relativeNow),
-        );
-
-        return () => window.clearTimeout(timer);
-    }, [lastSavedVersion, relativeNow, saveStatus]);
-
-    useEffect(() => {
-        if (!showSavedConfirmation) {
-            return;
-        }
-
-        const timer = window.setTimeout(() => {
-            setShowSavedConfirmation(false);
-        }, SAVE_CONFIRMATION_DURATION_MS);
-
-        return () => window.clearTimeout(timer);
-    }, [showSavedConfirmation]);
-
-    useEffect(() => {
-        if (
-            externalNoteChange?.type !== 'updated' ||
-            saveStatus === 'conflict' ||
-            externalNoteChange.updatedAt !== note.updatedAt
-        ) {
-            return;
-        }
-
-        appliedNoteVersionRef.current = note.updatedAt;
-        setServerUpdatedAt(note.updatedAt);
-        updateLastSavedAt(note.updatedAt);
-        setExternalNoteChange(null);
-    }, [externalNoteChange, note.updatedAt, saveStatus, setServerUpdatedAt, updateLastSavedAt]);
-
-    useEffect(() => {
-        return subscribeServerEvent((event) => {
-            if (event.noteId !== id) {
-                return;
-            }
-
-            if (event.source === 'web' && event.editSessionId === editSessionIdRef.current) {
-                return;
-            }
-
-            if (event.type === 'mcp.note.updated' || event.type === 'web.note.updated') {
-                if (event.updatedAt === note.updatedAt || event.updatedAt === serverUpdatedAtRef.current) {
-                    return;
-                }
-
-                if (hasUnsavedChanges) {
-                    pauseForConflict(event.updatedAt);
-                    setExternalNoteChange({
-                        type: 'updated',
-                        updatedAt: event.updatedAt,
-                        source: event.source,
-                    });
-                    return;
-                }
-
-                setExternalNoteChange({
-                    type: 'updated',
-                    updatedAt: event.updatedAt,
-                    source: event.source,
-                });
-                return;
-            }
-
-            if (event.type === 'mcp.note.deleted') {
-                setExternalNoteChange({ type: 'deleted', source: event.source });
-            }
-        });
-    }, [hasUnsavedChanges, id, note.updatedAt, pauseForConflict, serverUpdatedAtRef]);
-
-    const { onCreate, onDelete, onPinned, deleteWarningDialog } = useNoteMutate();
-
-    const handleChange = () => {
-        queueSave(buildDraft(title));
-    };
-
-    const handleTitleChange = (nextTitle: string) => {
-        setTitle(nextTitle);
-        queueSave(buildDraft(nextTitle));
-    };
-
-    const handleManualSave = () => {
-        queueSave(buildDraft(title), { immediate: true });
-    };
-
-    const handleLayoutSave = async (newLayout: NoteLayout) => {
-        if (hasUnsavedChanges) {
-            setLayout(newLayout);
-            queueSave(buildDraft(title, { layout: newLayout }), { immediate: true });
-            toast('Layout will be saved with your draft.');
-            return;
-        }
-
-        const response = await updateNote({
-            id,
-            layout: newLayout,
-            editSessionId: editSessionIdRef.current,
-            expectedUpdatedAt: serverUpdatedAtRef.current,
-        });
-
-        if (response.type === 'error') {
-            if (response.errors[0].code === NOTE_UPDATE_CONFLICT_CODE) {
-                layoutConflictRef.current = newLayout;
-                setLayout(newLayout);
-                pauseForConflict(getConflictUpdatedAt(response.errors[0].details) ?? serverUpdatedAtRef.current);
-            }
-
-            toast(response.errors[0].message);
-            return;
-        }
-
-        layoutConflictRef.current = null;
-        await queryClient.cancelQueries({
-            queryKey: queryKeys.notes.detail(id),
-            exact: true,
-        });
-        appliedNoteVersionRef.current = response.updateNote.updatedAt;
-        setServerUpdatedAt(response.updateNote.updatedAt);
-        queryClient.setQueryData<NoteDetailCache>(queryKeys.notes.detail(id), (current) => {
-            if (!current) {
-                return current;
-            }
-
-            return {
-                ...current,
-                layout: newLayout,
-                updatedAt: response.updateNote.updatedAt,
-            };
-        });
-        publishClientNoteUpdatedEvent({
-            noteId: id,
-            updatedAt: response.updateNote.updatedAt,
-            editSessionId: editSessionIdRef.current,
-        });
-        updateLastSavedAt(response.updateNote.updatedAt);
-        setLayout(newLayout);
-        toast('Layout has been updated.');
-    };
-
-    const getExportMetadata = () => ({
-        id,
-        title,
-        createdAt: note.createdAt,
-        updatedAt: serverUpdatedAtRef.current || note.updatedAt,
-    });
-
-    const handleCopyMarkdown = async () => {
-        const markdown = editorRef.current?.getMarkdown();
-
-        if (markdown === undefined) {
-            toast('Markdown is not ready yet.');
-            return;
-        }
-
-        try {
-            await navigator.clipboard.writeText(createMarkdownDocumentExport(markdown, getExportMetadata()));
-            toast('Copied note as Markdown.');
-        } catch {
-            toast('Failed to copy Markdown.');
-        }
-    };
-
-    const handleReloadExternalChange = async () => {
-        const response = await noteQuery.refetch();
-
-        if (response.error || !response.data) {
-            toast('Failed to reload the latest note state.');
-            return;
-        }
-
-        clearDrafts();
-        layoutConflictRef.current = null;
-        appliedNoteVersionRef.current = response.data.updatedAt;
-        setServerUpdatedAt(response.data.updatedAt);
-        setTitle(response.data.title);
-        setLayout(response.data.layout || 'wide');
-        updateLastSavedAt(response.data.updatedAt);
-        setEditorContentOverride(null);
-        setEditorRevision((current) => current + 1);
-        setExternalNoteChange(null);
-    };
-
-    const handleOverwriteConflict = async () => {
-        const pendingDraft = getPendingDraft();
-
-        if (pendingDraft) {
-            layoutConflictRef.current = null;
-            setExternalNoteChange(null);
-            await flushPendingSave({ ignoreConflict: true });
-            return;
-        }
-
-        const layoutConflict = layoutConflictRef.current;
-
-        if (layoutConflict) {
-            const response = await updateNote({
-                id,
-                layout: layoutConflict,
-                editSessionId: editSessionIdRef.current,
-                force: true,
-            });
-
-            if (response.type === 'error') {
-                toast(response.errors[0].message);
-                return;
-            }
-
-            layoutConflictRef.current = null;
-            await queryClient.cancelQueries({
-                queryKey: queryKeys.notes.detail(id),
-                exact: true,
-            });
-            appliedNoteVersionRef.current = response.updateNote.updatedAt;
-            resolveConflict();
-            setExternalNoteChange(null);
-            setServerUpdatedAt(response.updateNote.updatedAt);
-            queryClient.setQueryData<NoteDetailCache>(queryKeys.notes.detail(id), (current) => {
-                if (!current) {
-                    return current;
-                }
-
-                return {
-                    ...current,
-                    layout: layoutConflict,
-                    updatedAt: response.updateNote.updatedAt,
-                };
-            });
-            publishClientNoteUpdatedEvent({
-                noteId: id,
-                updatedAt: response.updateNote.updatedAt,
-                editSessionId: editSessionIdRef.current,
-            });
-            updateLastSavedAt(response.updateNote.updatedAt);
-            setLayout(layoutConflict);
-            return;
-        }
-
-        setExternalNoteChange(null);
-        await flushPendingSave({ ignoreConflict: true });
-    };
-
-    const handleClonePendingDraft = async () => {
-        const draft = getPendingDraft();
-
-        if (!draft) {
-            return;
-        }
-
-        const response = await createNote({
-            title: replaceFixedPlaceholder(draft.title || 'untitled'),
-            content: replaceFixedPlaceholder(draft.content),
-            layout: draft.layout ?? layout,
-        });
-
-        if (response.type === 'error') {
-            toast(response.errors[0].message);
-            return;
-        }
-
-        allowNextNavigationRef.current = true;
-        layoutConflictRef.current = null;
-        setExternalNoteChange(null);
-        clearDrafts();
-
-        void Promise.resolve(
+        notify,
+        navigateToNote: (noteId) =>
             navigate({
                 to: NOTE_ROUTE,
-                params: { id: response.createNote.id },
+                params: { id: noteId },
             }),
-        ).finally(() => {
-            allowNextNavigationRef.current = false;
-        });
-    };
+    });
+    const { onCreate, onDelete, deleteWarningDialog } = useNoteMutate();
+    const { document, editor, save, recovery, externalChange, properties, exportDocument, snapshots } = session;
 
-    const handleRestoreLocalDraft = () => {
-        if (!localDraft) {
+    const openTrash = () =>
+        navigate({
+            to: SETTINGS_TRASH_ROUTE,
+            search: { page: 1 },
+        });
+
+    const handleDelete = async () => {
+        const flushResult = await save.flushPendingChanges();
+
+        if (flushResult === 'error' || flushResult === 'conflict') {
             return;
         }
 
-        setTitle(localDraft.title);
-        if (localDraft.layout) {
-            setLayout(localDraft.layout);
+        await onDelete(id, openTrash);
+    };
+
+    const handleCloneNote = async () => {
+        const flushResult = await save.flushPendingChanges();
+
+        if (flushResult === 'error' || flushResult === 'conflict') {
+            return;
         }
-        setEditorContentOverride(localDraft.content);
-        setEditorRevision((current) => current + 1);
-        restoreLocalDraft(localDraft);
-    };
 
-    const handleDiscardLocalDraft = () => {
-        discardLocalDraft();
+        await onCreate(document.titleRef.current?.value || 'untitled', editor.getContent(), document.getLayout());
     };
-
-    const recoveredDraftCreatedAt = localDraft ? dayjs(localDraft.createdAt).format('YYYY-MM-DD HH:mm:ss') : null;
-    const isRecentSaveVisible = saveStatus === 'saved' && showSavedConfirmation;
-    const savedAgoText = formatSavedAgo(lastSavedVersion, relativeNow);
-    const createdAtText = formatSavedAt(note.createdAt);
-    const saveStatusText =
-        saveStatus === 'pending'
-            ? 'Saving...'
-            : saveStatus === 'saving'
-              ? 'Saving now...'
-              : saveStatus === 'error'
-                ? 'Save failed. Try again.'
-                : saveStatus === 'conflict'
-                  ? 'Save paused: changed elsewhere'
-                  : `Saved ${savedAgoText}`;
-    const saveStatusIndicatorClassName = classNames(
-        'inline-flex items-center gap-2 transition-colors',
-        saveStatus === 'saved' && !isRecentSaveVisible && 'text-fg-secondary',
-        isRecentSaveVisible && 'text-accent-success',
-        (saveStatus === 'pending' || saveStatus === 'saving') && 'text-fg-default',
-        (saveStatus === 'error' || saveStatus === 'conflict') && 'text-fg-error',
-    );
-    const saveProgressRingClassName = classNames(
-        'save-progress-ring flex h-4 w-4 shrink-0 items-center justify-center rounded-full',
-        (saveStatus === 'pending' || saveStatus === 'saving') && 'save-progress-ring-active',
-        saveStatus === 'saved' && isRecentSaveVisible && 'save-progress-ring-complete',
-        (saveStatus === 'error' || saveStatus === 'conflict') && 'save-progress-ring-error',
-    );
-    const saveStatusIcon =
-        saveStatus === 'saving' ? (
-            <span className={saveProgressRingClassName} aria-hidden>
-                <span className="h-2 w-2 rounded-full bg-elevated" />
-            </span>
-        ) : saveStatus === 'pending' ? (
-            <span className={saveProgressRingClassName} aria-hidden>
-                <span className="h-2 w-2 rounded-full bg-elevated" />
-            </span>
-        ) : saveStatus === 'error' || saveStatus === 'conflict' ? (
-            <Icon.WarningCircle className="h-3.5 w-3.5" weight="fill" />
-        ) : (
-            <span className={saveProgressRingClassName} aria-hidden>
-                <span className="h-2 w-2 rounded-full bg-elevated" />
-            </span>
-        );
-    const saveStatusIndicator = (
-        <Text
-            as="span"
-            variant="label"
-            weight="medium"
-            className={saveStatusIndicatorClassName}
-            role="status"
-            aria-live="polite"
-            title={lastSavedAt}
-        >
-            {saveStatusIcon}
-            {saveStatusText}
-        </Text>
-    );
-    const isConflictedExternalUpdate = saveStatus === 'conflict' && externalNoteChange?.type === 'updated';
-    const conflictDraft = isConflictedExternalUpdate ? getPendingDraft() : null;
-    const isBlockingExternalChange =
-        externalNoteChange !== null &&
-        !(
-            externalNoteChange.type === 'updated' &&
-            !isConflictedExternalUpdate &&
-            externalNoteChange.updatedAt === note.updatedAt
-        );
 
     return (
-        <PageLayout title={title} variant="none">
-            <main className={classNames('mx-auto', NOTE_LAYOUT_WIDTH[layout])}>
-                <div className="surface-floating sticky top-20 z-[1001] mb-7 px-5 pt-4 pb-3.5">
-                    <div className="flex flex-col gap-3.5">
-                        <div className="flex items-start justify-between gap-5">
-                            <div className="min-w-0 flex-1 pt-0.5">
-                                <Text
-                                    as="div"
-                                    variant="micro"
-                                    weight="semibold"
-                                    tracking="widest"
-                                    transform="uppercase"
-                                    tone="tertiary"
-                                    className="mb-1.5"
-                                >
-                                    Thought in progress
-                                </Text>
-                                <input
-                                    ref={titleRef}
-                                    placeholder="Title"
-                                    className="text-heading sm:text-display w-full bg-transparent font-semibold leading-[1.25] tracking-[-0.02em] outline-none"
-                                    type="text"
-                                    value={title}
-                                    onChange={(event) => handleTitleChange(event.target.value)}
-                                />
-                            </div>
-                            <div className="flex shrink-0 items-center gap-2">
-                                <Dropdown
-                                    button={<MoreButton label="Note actions" size="lg" />}
-                                    items={[
-                                        {
-                                            name: 'Copy Markdown',
-                                            onClick: handleCopyMarkdown,
-                                        },
-                                        {
-                                            name: 'Download document',
-                                            onClick: () => setIsExportModalOpen(true),
-                                        },
-                                        { type: 'separator', key: 'export-separator' },
-                                        {
-                                            name: isPinned ? 'Unpin' : 'Pin',
-                                            onClick: () =>
-                                                onPinned(id, isPinned, () => {
-                                                    setIsPinned((prev) => !prev);
-                                                }),
-                                        },
-                                        {
-                                            name: 'Change layout',
-                                            onClick: () => setIsLayoutModalOpen(true),
-                                        },
-                                        { type: 'separator' },
-                                        {
-                                            name: 'Clone this note',
-                                            onClick: () =>
-                                                onCreate(
-                                                    titleRef.current?.value || 'untitled',
-                                                    editorRef.current?.getContent() || '',
-                                                    layout,
-                                                ),
-                                        },
-                                        {
-                                            name: 'Restore previous version',
-                                            onClick: () => setIsRestoreModalOpen(true),
-                                        },
-                                        { type: 'separator' },
-                                        {
-                                            name: 'Delete',
-                                            onClick: () =>
-                                                onDelete(id, () => {
-                                                    navigate({
-                                                        to: SETTINGS_TRASH_ROUTE,
-                                                        search: { page: 1 },
-                                                    });
-                                                }),
-                                        },
-                                    ]}
-                                />
-                                <Button
-                                    size="sm"
-                                    variant="subtle"
-                                    isLoading={saveStatus === 'saving'}
-                                    disabled={saveStatus === 'conflict'}
-                                    onClick={handleManualSave}
-                                >
-                                    Save
-                                </Button>
-                            </div>
-                        </div>
-                        <div className="flex flex-wrap items-center gap-x-2.5 gap-y-1.5 border-t border-border-subtle/80 pt-3">
-                            {isPinned && (
-                                <Text
-                                    as="span"
-                                    variant="label"
-                                    weight="medium"
-                                    tone="secondary"
-                                    className="inline-flex items-center gap-1.5"
-                                >
-                                    <Icon.Pin className="h-3 w-3" weight="fill" />
-                                    Pinned
-                                </Text>
-                            )}
-                            {isPinned && <span className="h-1 w-1 rounded-full bg-border-secondary" />}
-                            {saveStatusIndicator}
-                            <span className="h-1 w-1 rounded-full bg-border-secondary" />
-                            <Text as="span" variant="micro" weight="medium" tone="tertiary">
-                                Created {createdAtText}
-                            </Text>
-                        </div>
-                    </div>
-                </div>
+        <PageLayout title={document.title} variant="none">
+            <main className={classNames('mx-auto', NOTE_LAYOUT_WIDTH[document.layout])}>
+                <NoteEditorHeader
+                    title={document.title}
+                    titleRef={document.titleRef}
+                    isPinned={document.isPinned}
+                    createdAt={document.createdAt}
+                    saveStatus={save.status}
+                    savedAt={save.lastSavedAt}
+                    savedVersion={save.lastSavedVersion}
+                    saveConfirmationRevision={save.confirmationRevision}
+                    onTitleChange={document.onTitleChange}
+                    onCopyMarkdown={() => void exportDocument.onCopyMarkdown()}
+                    onDownloadDocument={() => setIsExportModalOpen(true)}
+                    onTogglePinned={() => void document.onTogglePinned()}
+                    onChangeLayout={() => setIsLayoutModalOpen(true)}
+                    onCloneNote={() => void handleCloneNote()}
+                    onRestoreVersion={() => setIsRestoreModalOpen(true)}
+                    onDelete={() => void handleDelete()}
+                    onSave={save.onManualSave}
+                />
 
-                {localDraft && (
-                    <Callout tone="danger" className="mb-6">
-                        <div className="flex w-full flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                            <span>A draft from {recoveredDraftCreatedAt} is saved only in this browser.</span>
-                            <div className="flex flex-wrap gap-2">
-                                <Button
-                                    type="button"
-                                    size="sm"
-                                    variant="subtle"
-                                    className="self-start"
-                                    onClick={handleRestoreLocalDraft}
-                                >
-                                    Restore draft
-                                </Button>
-                                <Button
-                                    type="button"
-                                    size="sm"
-                                    variant="ghost"
-                                    className="self-start"
-                                    onClick={handleDiscardLocalDraft}
-                                >
-                                    Discard
-                                </Button>
-                            </div>
-                        </div>
-                    </Callout>
-                )}
-
-                {saveStatus === 'error' && (
-                    <Callout tone="danger" className="mb-6">
-                        <div className="flex w-full flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                            <span>
-                                Save failed. Your latest draft is still available here. Retry before leaving this note.
-                            </span>
-                            <div className="flex flex-wrap gap-2">
-                                <Button
-                                    type="button"
-                                    size="sm"
-                                    variant="subtle"
-                                    className="self-start"
-                                    onClick={handleManualSave}
-                                >
-                                    Retry save
-                                </Button>
-                                <Button
-                                    type="button"
-                                    size="sm"
-                                    variant="ghost"
-                                    className="self-start"
-                                    onClick={() => void handleClonePendingDraft()}
-                                >
-                                    Save as new note
-                                </Button>
-                            </div>
-                        </div>
-                    </Callout>
-                )}
+                <NoteRecoveryCallouts
+                    localDraftCreatedAt={recovery.localDraftCreatedAt}
+                    hasSaveError={save.status === 'error'}
+                    onRestoreDraft={recovery.onRestoreLocalDraft}
+                    onDiscardDraft={recovery.onDiscardLocalDraft}
+                    onRetrySave={save.onManualSave}
+                    onSaveAsNewNote={() => void recovery.onClonePendingDraft()}
+                />
 
                 <div className="flex flex-col gap-5">
                     <NotePropertiesPanel
+                        ref={properties.ref}
                         noteId={id}
-                        properties={note.properties}
-                        expectedUpdatedAt={serverUpdatedAtRef.current}
-                        editSessionId={editSessionIdRef.current}
-                        disabled={saveStatus !== 'saved'}
-                        onSaved={(updatedNote) => {
-                            appliedNoteVersionRef.current = updatedNote.updatedAt;
-                            setServerUpdatedAt(updatedNote.updatedAt);
-                            updateLastSavedAt(updatedNote.updatedAt);
-                            setShowSavedConfirmation(true);
-                            queryClient.setQueryData<NoteDetailCache>(queryKeys.notes.detail(id), (current) => {
-                                if (!current) {
-                                    return current;
-                                }
-
-                                return {
-                                    ...current,
-                                    updatedAt: updatedNote.updatedAt,
-                                    properties: updatedNote.properties,
-                                };
-                            });
-                            publishClientNoteUpdatedEvent({
-                                noteId: id,
-                                updatedAt: updatedNote.updatedAt,
-                                editSessionId: editSessionIdRef.current,
-                            });
-                        }}
+                        properties={document.properties}
+                        expectedUpdatedAt={properties.expectedUpdatedAt}
+                        editSessionId={properties.editSessionId}
+                        disabled={save.status !== 'saved'}
+                        saveProperties={properties.saveProperties}
+                        onPendingChange={properties.onPendingChange}
+                        onSaved={properties.onSaved}
                     />
 
                     <Editor
-                        key={`${id}:${editorRevision}`}
-                        ref={editorRef}
-                        content={editorContentOverride ?? note.content}
+                        key={editor.key}
+                        ref={editor.ref}
+                        content={editor.content}
                         currentNoteId={id}
-                        onChange={handleChange}
+                        onChange={editor.onChange}
                     />
 
-                    <QueryBoundary
-                        fallback={<Skeleton height={107} />}
-                        errorTitle="Failed to load reminders"
-                        errorDescription="Retry loading reminder details for this note."
-                        renderError={({ error, retry }) => (
-                            <QueryErrorView
-                                title="Failed to load reminders"
-                                description="Retry loading reminder details for this note."
-                                error={error}
-                                onRetry={retry}
-                                showBackAction={false}
-                                showHomeAction={false}
-                            />
-                        )}
-                    >
-                        <ReminderPanel noteId={id} />
-                    </QueryBoundary>
-
-                    <QueryBoundary
-                        fallback={<Skeleton height={100} />}
-                        errorTitle="Failed to load back references"
-                        errorDescription="Retry loading notes that link back here."
-                        renderError={({ error, retry }) => (
-                            <QueryErrorView
-                                title="Failed to load back references"
-                                description="Retry loading notes that link back here."
-                                error={error}
-                                onRetry={retry}
-                                showBackAction={false}
-                                showHomeAction={false}
-                            />
-                        )}
-                    >
-                        <BackReferences
-                            noteId={id}
-                            render={(backReferences) =>
-                                backReferences &&
-                                backReferences.length > 0 && (
-                                    <AuxiliaryPanel
-                                        icon={<Icon.LinkSimple className="h-3.5 w-3.5" />}
-                                        title="Back References"
-                                    >
-                                        <ul className="flex flex-col">
-                                            {backReferences.map((backLink) => (
-                                                <li key={backLink.id}>
-                                                    <Link
-                                                        to={NOTE_ROUTE}
-                                                        params={{ id: backLink.id }}
-                                                        className="flex items-center gap-2 rounded-[10px] px-2.5 py-1.5 text-fg-secondary transition-colors hover:bg-hover-subtle hover:text-fg-default"
-                                                    >
-                                                        <Icon.File className="h-3.5 w-3.5 shrink-0 text-fg-tertiary" />
-                                                        <Text
-                                                            as="span"
-                                                            variant="body"
-                                                            weight="medium"
-                                                            className="text-current"
-                                                        >
-                                                            {backLink.title}
-                                                        </Text>
-                                                    </Link>
-                                                </li>
-                                            ))}
-                                        </ul>
-                                    </AuxiliaryPanel>
-                                )
-                            }
-                        />
-                    </QueryBoundary>
+                    <NoteReminders noteId={id} />
+                    <NoteBackReferences noteId={id} />
                 </div>
 
                 <LayoutModal
                     isOpen={isLayoutModalOpen}
                     onClose={() => setIsLayoutModalOpen(false)}
-                    onSave={handleLayoutSave}
-                    currentLayout={layout}
+                    onSave={document.onLayoutSave}
+                    currentLayout={document.layout}
                 />
                 <NoteExternalChangeModal
-                    isOpen={isBlockingExternalChange}
-                    isDeleted={externalNoteChange?.type === 'deleted'}
-                    isConflict={isConflictedExternalUpdate}
-                    hasDraft={conflictDraft !== null}
-                    source={externalNoteChange?.source ?? 'unknown'}
-                    isReloading={noteQuery.isRefetching}
-                    onReload={handleReloadExternalChange}
-                    onOverwrite={() => void handleOverwriteConflict()}
-                    onCloneDraft={() => void handleClonePendingDraft()}
-                    onOpenTrash={() =>
-                        navigate({
-                            to: SETTINGS_TRASH_ROUTE,
-                            search: { page: 1 },
-                        })
-                    }
+                    isOpen={externalChange.isBlocking}
+                    isDeleted={externalChange.value?.type === 'deleted'}
+                    isConflict={externalChange.isConflict}
+                    hasDraft={externalChange.hasConflictDraft}
+                    source={externalChange.value?.source ?? 'unknown'}
+                    isReloading={externalChange.isReloading}
+                    onReload={() => void externalChange.onReload()}
+                    onOverwrite={() => void externalChange.onOverwrite()}
+                    onCloneDraft={() => void recovery.onClonePendingDraft()}
+                    onOpenTrash={() => void openTrash()}
                 />
                 <NoteExportModal
                     isOpen={isExportModalOpen}
-                    metadata={getExportMetadata()}
-                    getHtml={() => editorRef.current?.getHtml()}
-                    getMarkdown={() => editorRef.current?.getMarkdown()}
+                    metadata={exportDocument.metadata}
+                    getHtml={editor.getHtml}
+                    getMarkdown={editor.getMarkdown}
                     onClose={() => setIsExportModalOpen(false)}
                 />
                 <RestoreSnapshotModal
                     isOpen={isRestoreModalOpen}
                     noteId={id}
                     onClose={() => setIsRestoreModalOpen(false)}
-                    onRestored={(restoredNote) => {
-                        editSessionIdRef.current = createEditSessionId();
-                        clearDrafts();
-                        layoutConflictRef.current = null;
-                        appliedNoteVersionRef.current = restoredNote.updatedAt;
-                        setExternalNoteChange(null);
-                        setServerUpdatedAt(restoredNote.updatedAt);
-                        updateLastSavedAt(restoredNote.updatedAt);
-                    }}
+                    restoreSnapshot={snapshots.restore}
                 />
                 {deleteWarningDialog}
             </main>


### PR DESCRIPTION
## :dart: Goal
- Make note editing resilient to overlapping document, property, layout, pin, reload, and snapshot operations.
- Reduce the page-level responsibilities in the note editor while preserving existing user workflows.

## :hammer_and_wrench: Core Changes
- Extract note editor header, recovery, save status, session, navigation guard, and external-change policies from the page.
- Serialize versioned note writes as complete API and cache/version commit transactions.
- Invalidate stale queued writes and drain active transactions before reload or snapshot restore.
- Include property and standalone write activity in navigation, browser unload, delete, and clone safeguards.
- Add regression coverage for delayed responses, stale events, version ordering, navigation flushes, restore ordering, and destructive actions.

## :brain: Key Decisions
- Use one coordinator for all writes that share a note version so request order and accepted cache state cannot diverge.
- Keep server APIs and persistence contracts unchanged; this is a client-side correctness and maintainability change.
- Prefer deterministic serialization over concurrent mutations that can overwrite newer note versions.

## :test_tube: Verification Guide
### How to verify
1. Run `pnpm check:encoding`.
2. Run `pnpm lint`.
3. Run `pnpm test:ci`.
4. Run `pnpm type-check`.
5. Run `pnpm build`.
6. Edit note content and properties, then navigate away; confirm pending changes finish first.
7. Start a pin or layout update, then clone, delete, reload, or restore a snapshot; confirm operations finish in a safe order.

### Expected result
- All quality commands pass.
- The note editor preserves the latest accepted version without stale cache rollback or lost pending property changes.
- Navigation and destructive actions wait for active note transactions.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (not needed; no documentation changes)