### PR TITLE
⚡ Reduce initial client bundle

### DIFF
--- a/packages/client/biome.json
+++ b/packages/client/biome.json
@@ -3,7 +3,15 @@
     "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
     "files": {
         "ignoreUnknown": true,
-        "includes": ["src/**", "vite.config.ts", "tsconfig.json", "tsconfig.node.json", "biome.json", "package.json"]
+        "includes": [
+            "src/**",
+            "build/**",
+            "vite.config.ts",
+            "tsconfig.json",
+            "tsconfig.node.json",
+            "biome.json",
+            "package.json"
+        ]
     },
     "formatter": {
         "enabled": true,
@@ -99,7 +107,7 @@
                 "useNamespaceKeyword": "error"
             }
         },
-        "includes": ["src/**", "vite.config.ts"]
+        "includes": ["src/**", "build/**", "vite.config.ts"]
     },
     "javascript": {
         "formatter": {
@@ -127,7 +135,7 @@
     },
     "overrides": [
         {
-            "includes": ["src/**/*.ts", "src/**/*.tsx", "vite.config.ts"],
+            "includes": ["src/**/*.ts", "src/**/*.tsx", "build/**/*.ts", "vite.config.ts"],
             "linter": {
                 "rules": {
                     "complexity": { "noArguments": "error" },
@@ -159,7 +167,7 @@
             }
         },
         {
-            "includes": ["src/**/*.{js,jsx,ts,tsx}", "vite.config.ts"],
+            "includes": ["src/**/*.{js,jsx,ts,tsx}", "build/**/*.ts", "vite.config.ts"],
             "javascript": { "globals": [] },
             "linter": {
                 "rules": { "correctness": { "useHookAtTopLevel": "error" } }

--- a/packages/client/build/client-bundling.ts
+++ b/packages/client/build/client-bundling.ts
@@ -1,0 +1,137 @@
+import path from 'node:path';
+import type { Plugin, UserConfig } from 'vite';
+
+type RollupOptions = NonNullable<NonNullable<UserConfig['build']>['rollupOptions']>;
+
+/**
+ * Client bundle safety contract:
+ *
+ * 1. Keep route-preload as an independent entry. A normal module script in
+ *    index.html is merged into the app entry and cannot start route downloads
+ *    early enough for cold note URLs.
+ * 2. Manually group only dependencies owned exclusively by the Note route.
+ *    Object-form manualChunks pulls React and other transitive dependencies into
+ *    note chunks, which makes the home entry load them again.
+ * 3. Keep note-runtime together. Splitting its editor/markup/support packages
+ *    produced circular chunks and production-only initialization risk.
+ * 4. Do not silence the remaining note-runtime size warning. It is route-only;
+ *    scripts/ci/check-client-bundle.mjs enforces the actual initial-load budget.
+ *
+ * Production behavior is guarded by the bundle check and
+ * tests/e2e/production-routes.spec.ts. Update those guards with this file.
+ */
+
+const NOTE_PAGE_MODULE_SUFFIX = '/src/pages/Note.tsx';
+const ROUTE_LOADER_MODULE_SUFFIXES = ['/src/route-preload.ts', '/src/router.tsx'];
+
+const normalizeModuleId = (id: string) => id.replaceAll('\\', '/').split('?')[0] ?? id;
+const isRouteLoaderModule = (id: string) => {
+    const normalizedId = normalizeModuleId(id);
+    return ROUTE_LOADER_MODULE_SUFFIXES.some((suffix) => normalizedId.endsWith(suffix));
+};
+
+const getNoteChunkName = (id: string) => {
+    const normalizedId = normalizeModuleId(id);
+
+    if (normalizedId.includes('/node_modules/@blocknote/core/')) {
+        return 'note-core';
+    }
+
+    if (
+        normalizedId.includes('/node_modules/@blocknote/react/') ||
+        normalizedId.includes('/node_modules/@blocknote/mantine/')
+    ) {
+        return 'note-ui';
+    }
+
+    return 'note-runtime';
+};
+
+const createNoteOnlyManualChunks = () => {
+    return (
+        id: string,
+        {
+            getModuleInfo,
+        }: {
+            getModuleInfo: (id: string) => {
+                dynamicImporters: readonly string[];
+                importers: readonly string[];
+                isEntry: boolean;
+            } | null;
+        },
+    ) => {
+        if (!id.includes('/node_modules/')) {
+            return;
+        }
+
+        const owners = new Set<string>();
+        const pending = [id];
+        const visited = new Set<string>();
+
+        while (pending.length > 0) {
+            const currentId = pending.pop();
+
+            if (!currentId || visited.has(currentId)) {
+                continue;
+            }
+
+            visited.add(currentId);
+            const moduleInfo = getModuleInfo(currentId);
+
+            if (!moduleInfo) {
+                continue;
+            }
+
+            if (moduleInfo.isEntry || moduleInfo.dynamicImporters.some(isRouteLoaderModule)) {
+                owners.add(normalizeModuleId(currentId));
+                continue;
+            }
+
+            pending.push(...moduleInfo.importers);
+        }
+
+        const [owner] = owners;
+        return owners.size === 1 && owner?.endsWith(NOTE_PAGE_MODULE_SUFFIX) ? getNoteChunkName(id) : undefined;
+    };
+};
+
+export const createRoutePreloadPlugin = (): Plugin => {
+    let command: 'build' | 'serve' = 'serve';
+
+    return {
+        name: 'ocean-brain-route-preload',
+        configResolved(config) {
+            command = config.command;
+        },
+        transformIndexHtml: {
+            // Post injection is intentional: Vite must not merge this script into the app entry.
+            order: 'post',
+            handler() {
+                return [
+                    {
+                        tag: 'script',
+                        attrs: {
+                            type: 'module',
+                            src: command === 'build' ? '/assets/route-preload.js' : '/src/route-preload.ts',
+                        },
+                        injectTo: 'head-prepend',
+                    },
+                ];
+            },
+        },
+    };
+};
+
+export const createClientRollupOptions = (clientRoot: string): RollupOptions => ({
+    input: {
+        app: path.resolve(clientRoot, 'index.html'),
+        'route-preload': path.resolve(clientRoot, 'src/route-preload.ts'),
+    },
+    output: {
+        entryFileNames(chunkInfo) {
+            return chunkInfo.name === 'route-preload' ? 'assets/route-preload.js' : 'assets/[name]-[hash].js';
+        },
+        manualChunks: createNoteOnlyManualChunks(),
+        onlyExplicitManualChunks: true,
+    },
+});

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -5,7 +5,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "vite build",
+        "build": "vite build && node ../../scripts/ci/check-client-bundle.mjs",
         "lint": "biome check .",
         "format": "biome check --write .",
         "preview": "vite preview",

--- a/packages/client/src/components/layout/SiteLayout/PinnedNotesPanel.spec.tsx
+++ b/packages/client/src/components/layout/SiteLayout/PinnedNotesPanel.spec.tsx
@@ -61,8 +61,8 @@ vi.mock('~/components/app', () => ({
     QueryErrorView: () => <div>Error</div>,
 }));
 
-vi.mock('~/components/entities', () => ({
-    PinnedNotes: ({ render }: { render: (notes: MockPinnedNote[]) => ReactNode }) => <>{render(mockPinnedNotes)}</>,
+vi.mock('~/components/entities/PinnedNotes', () => ({
+    default: ({ render }: { render: (notes: MockPinnedNote[]) => ReactNode }) => <>{render(mockPinnedNotes)}</>,
 }));
 
 vi.mock('~/components/ui', async () => {

--- a/packages/client/src/components/layout/SiteLayout/PinnedNotesPanel.tsx
+++ b/packages/client/src/components/layout/SiteLayout/PinnedNotesPanel.tsx
@@ -16,7 +16,7 @@ import { useEffect, useState } from 'react';
 
 import { reorderNotes } from '~/apis/note.api';
 import { QueryBoundary, QueryErrorView } from '~/components/app';
-import { PinnedNotes } from '~/components/entities';
+import PinnedNotes from '~/components/entities/PinnedNotes';
 import * as Icon from '~/components/icon';
 import { Skeleton } from '~/components/shared';
 import { Text } from '~/components/ui';

--- a/packages/client/src/components/shared/Editor/Editor.tsx
+++ b/packages/client/src/components/shared/Editor/Editor.tsx
@@ -1,5 +1,6 @@
 import { BlockNoteView } from '@blocknote/mantine';
 import { useCreateBlockNote } from '@blocknote/react';
+import '@blocknote/mantine/style.css';
 import { forwardRef, type ClipboardEvent as ReactClipboardEvent, useImperativeHandle } from 'react';
 import { uploadImage } from '~/apis/image.api';
 import schema, { CommandView, ReferenceView, TagView } from '~/components/schema';

--- a/packages/client/src/hooks/resource/useNoteMutate.tsx
+++ b/packages/client/src/hooks/resource/useNoteMutate.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from '@tanstack/react-router';
 import { useState } from 'react';
 
 import { createNote, deleteNote, fetchBackReferences, pinNote } from '~/apis/note.api';
-import { NoteReferenceWarningModal } from '~/components/note';
+import NoteReferenceWarningModal from '~/components/note/NoteReferenceWarningModal';
 import { useConfirm, useToast } from '~/components/ui';
 import type { Note, NoteLayout } from '~/models/note.model';
 import { replaceFixedPlaceholder } from '~/modules/fixed-placeholder';

--- a/packages/client/src/main.tsx
+++ b/packages/client/src/main.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import '@blocknote/mantine/style.css';
 
 import App from './App.tsx';
 import { installAuthRedirectInterceptor } from './modules/auth-redirect.ts';

--- a/packages/client/src/modules/route-preload.spec.ts
+++ b/packages/client/src/modules/route-preload.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { getRoutePreloadTarget } from './route-preload';
+import { APP_ROUTE_PATHS, GRAPH_ROUTE, NOTE_ROUTE } from './url';
+
+describe('getRoutePreloadTarget', () => {
+    it.each(['/note-id', '/123/', '/encoded%20note'])('selects the note bundle for %s', (pathname) => {
+        expect(getRoutePreloadTarget(pathname)).toBe('note');
+    });
+
+    it.each(
+        Object.values(APP_ROUTE_PATHS).filter((pathname) => pathname !== NOTE_ROUTE && pathname !== GRAPH_ROUTE),
+    )('does not preload a heavy route bundle for %s', (pathname) => {
+        expect(getRoutePreloadTarget(pathname)).toBeNull();
+    });
+
+    it('ignores unmatched nested paths', () => {
+        const pathname = '/unknown/path';
+
+        expect(getRoutePreloadTarget(pathname)).toBeNull();
+    });
+
+    it('selects the graph bundle for the graph route', () => {
+        expect(getRoutePreloadTarget('/graph')).toBe('graph');
+    });
+});

--- a/packages/client/src/modules/route-preload.ts
+++ b/packages/client/src/modules/route-preload.ts
@@ -1,0 +1,30 @@
+import { APP_ROUTE_PATHS, GRAPH_ROUTE, NOTE_ROUTE } from './url';
+
+export type RoutePreloadTarget = 'graph' | 'note';
+
+const NON_NOTE_ROOT_SEGMENTS = new Set(
+    Object.values(APP_ROUTE_PATHS)
+        .filter((routePath) => routePath !== NOTE_ROUTE)
+        .map((routePath) => routePath.split('/')[1])
+        .filter((segment): segment is string => Boolean(segment)),
+);
+
+export const getRoutePreloadTarget = (pathname: string): RoutePreloadTarget | null => {
+    const segments = pathname.split('/').filter(Boolean);
+
+    if (segments.length !== 1) {
+        return null;
+    }
+
+    const [firstSegment] = segments;
+
+    if (`/${firstSegment}` === GRAPH_ROUTE) {
+        return 'graph';
+    }
+
+    if (!firstSegment || NON_NOTE_ROOT_SEGMENTS.has(firstSegment)) {
+        return null;
+    }
+
+    return 'note';
+};

--- a/packages/client/src/modules/url.ts
+++ b/packages/client/src/modules/url.ts
@@ -1,20 +1,44 @@
-export const HOME_ROUTE = '/' as const;
-export const VIEWS_ROUTE = '/views' as const;
-export const VIEW_NOTES_ROUTE = '/views/notes' as const;
-export const CALENDAR_ROUTE = '/calendar' as const;
-export const REMINDERS_ROUTE = '/reminders' as const;
-export const GRAPH_ROUTE = '/graph' as const;
-export const SEARCH_ROUTE = '/search' as const;
-export const TAG_ROUTE = '/tag' as const;
-export const NOTE_ROUTE = '/$id' as const;
-export const TAG_NOTES_ROUTE = '/tag/$id' as const;
-export const SETTINGS_ROUTE = '/setting' as const;
-export const SETTINGS_MCP_ROUTE = '/setting/mcp' as const;
-export const SETTINGS_TRASH_ROUTE = '/setting/trash' as const;
-export const SETTINGS_MANAGE_IMAGE_ROUTE = '/setting/manage-image' as const;
-export const SETTINGS_MANAGE_IMAGE_DETAIL_ROUTE = '/setting/manage-image/$id' as const;
-export const SETTINGS_PLACEHOLDER_ROUTE = '/setting/placeholder' as const;
-export const SETTINGS_PROPERTIES_ROUTE = '/setting/properties' as const;
+// Keep every client route in this object. The production route preloader derives
+// reserved root segments from it so a new static route is never mistaken for /$id.
+export const APP_ROUTE_PATHS = {
+    HOME_ROUTE: '/',
+    VIEWS_ROUTE: '/views',
+    VIEW_NOTES_ROUTE: '/views/notes',
+    CALENDAR_ROUTE: '/calendar',
+    REMINDERS_ROUTE: '/reminders',
+    GRAPH_ROUTE: '/graph',
+    SEARCH_ROUTE: '/search',
+    TAG_ROUTE: '/tag',
+    NOTE_ROUTE: '/$id',
+    TAG_NOTES_ROUTE: '/tag/$id',
+    SETTINGS_ROUTE: '/setting',
+    SETTINGS_MCP_ROUTE: '/setting/mcp',
+    SETTINGS_TRASH_ROUTE: '/setting/trash',
+    SETTINGS_MANAGE_IMAGE_ROUTE: '/setting/manage-image',
+    SETTINGS_MANAGE_IMAGE_DETAIL_ROUTE: '/setting/manage-image/$id',
+    SETTINGS_PLACEHOLDER_ROUTE: '/setting/placeholder',
+    SETTINGS_PROPERTIES_ROUTE: '/setting/properties',
+} as const;
+
+export const {
+    HOME_ROUTE,
+    VIEWS_ROUTE,
+    VIEW_NOTES_ROUTE,
+    CALENDAR_ROUTE,
+    REMINDERS_ROUTE,
+    GRAPH_ROUTE,
+    SEARCH_ROUTE,
+    TAG_ROUTE,
+    NOTE_ROUTE,
+    TAG_NOTES_ROUTE,
+    SETTINGS_ROUTE,
+    SETTINGS_MCP_ROUTE,
+    SETTINGS_TRASH_ROUTE,
+    SETTINGS_MANAGE_IMAGE_ROUTE,
+    SETTINGS_MANAGE_IMAGE_DETAIL_ROUTE,
+    SETTINGS_PLACEHOLDER_ROUTE,
+    SETTINGS_PROPERTIES_ROUTE,
+} = APP_ROUTE_PATHS;
 
 export const getTagURL = (id: string) => `/tag/${id}`;
 export const getNoteURL = (id: string) => `/${id}`;

--- a/packages/client/src/pages/Home.tsx
+++ b/packages/client/src/pages/Home.tsx
@@ -1,8 +1,8 @@
 import { getRouteApi } from '@tanstack/react-router';
 
 import { QueryBoundary } from '~/components/app';
-import { Notes } from '~/components/entities';
-import { NoteListCard } from '~/components/note';
+import Notes from '~/components/entities/Notes';
+import NoteListCard from '~/components/note/NoteListCard';
 import { Empty, FallbackRender, NoteFilters, PageLayout, Pagination, Skeleton } from '~/components/shared';
 
 import useNoteMutate from '~/hooks/resource/useNoteMutate';

--- a/packages/client/src/route-preload.ts
+++ b/packages/client/src/route-preload.ts
@@ -1,0 +1,10 @@
+import { getRoutePreloadTarget } from './modules/route-preload';
+
+const preloadTarget = getRoutePreloadTarget(window.location.pathname);
+
+// Best-effort only: TanStack Router owns the real navigation load and its error recovery.
+if (preloadTarget === 'note') {
+    void import('./pages/Note').catch(() => undefined);
+} else if (preloadTarget === 'graph') {
+    void import('./pages/Graph').catch(() => undefined);
+}

--- a/packages/client/src/router.tsx
+++ b/packages/client/src/router.tsx
@@ -220,6 +220,7 @@ const routeTree = rootRoute.addChildren([
 
 export const router = createRouter({
     routeTree,
+    defaultPreload: 'intent',
     defaultPendingComponent: () => <RoutePendingView title="Loading page" description="Preparing the next route." />,
 });
 

--- a/packages/client/tsconfig.node.json
+++ b/packages/client/tsconfig.node.json
@@ -6,5 +6,5 @@
         "moduleResolution": "bundler",
         "allowSyntheticDefaultImports": true
     },
-    "include": ["vite.config.ts"]
+    "include": ["vite.config.ts", "build/**/*.ts"]
 }

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import svgr from 'vite-plugin-svgr';
 import { defineConfig } from 'vitest/config';
 
+import { createClientRollupOptions, createRoutePreloadPlugin } from './build/client-bundling';
 import { createDevAuthGateMiddleware } from './src/dev-auth-gate';
 
 const backendOrigin = process.env.OCEAN_BRAIN_DEV_SERVER_URL || 'http://localhost:6683';
@@ -21,6 +22,7 @@ const imageUploadAdapterPath = isLocalOnlyDemoBuild
 // https://vitejs.dev/config/
 export default defineConfig({
     plugins: [
+        createRoutePreloadPlugin(),
         react(),
         svgr(),
         tailwindcss(),
@@ -50,15 +52,7 @@ export default defineConfig({
     },
     build: {
         sourcemap: false,
-        rollupOptions: {
-            output: {
-                manualChunks: {
-                    'graph-vendor': ['react-force-graph-2d'],
-                    'note-core': ['@blocknote/core'],
-                    'note-vendor': ['@blocknote/react', '@blocknote/mantine'],
-                },
-            },
-        },
+        rollupOptions: createClientRollupOptions(__dirname),
     },
     server: {
         host: '0.0.0.0',

--- a/scripts/ci/check-client-bundle.mjs
+++ b/scripts/ci/check-client-bundle.mjs
@@ -1,0 +1,45 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { gzipSync } from 'node:zlib';
+
+// Validate the files the browser receives from the real production HTML. Keep
+// this aligned with packages/client/build/client-bundling.ts.
+const INITIAL_BUNDLE_BUDGET_KIB = 300;
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const distDirectory = path.resolve(repositoryRoot, 'packages/client/dist');
+const indexPath = path.resolve(distDirectory, 'index.html');
+const indexHtml = fs.readFileSync(indexPath, 'utf8');
+const assetUrls = Array.from(indexHtml.matchAll(/\b(?:href|src)="(\/assets\/[^"?#]+)"/g), (match) => match[1]);
+const uniqueAssetUrls = [...new Set(assetUrls)];
+
+if (!uniqueAssetUrls.includes('/assets/route-preload.js')) {
+    throw new Error('Production index is missing the independent route preload entry.');
+}
+
+const eagerRouteChunks = uniqueAssetUrls.filter((assetUrl) => /\/note-(?:core|runtime|ui)-/.test(assetUrl));
+
+if (eagerRouteChunks.length > 0) {
+    throw new Error(`Production index eagerly loads note-only chunks: ${eagerRouteChunks.join(', ')}`);
+}
+
+const initialGzipBytes = uniqueAssetUrls.reduce((total, assetUrl) => {
+    const assetPath = path.resolve(distDirectory, assetUrl.slice(1));
+
+    if (!fs.existsSync(assetPath)) {
+        throw new Error(`Production index references a missing asset: ${assetUrl}`);
+    }
+
+    return total + gzipSync(fs.readFileSync(assetPath)).byteLength;
+}, gzipSync(indexHtml).byteLength);
+const initialGzipKib = initialGzipBytes / 1024;
+
+if (initialGzipKib > INITIAL_BUNDLE_BUDGET_KIB) {
+    throw new Error(
+        `Production initial bundle is ${initialGzipKib.toFixed(2)} KiB gzip, exceeding the ${INITIAL_BUNDLE_BUDGET_KIB} KiB budget.`,
+    );
+}
+
+console.log(
+    `Production initial bundle: ${initialGzipKib.toFixed(2)} KiB gzip (budget: ${INITIAL_BUNDLE_BUDGET_KIB} KiB).`,
+);

--- a/tests/e2e/production-routes.spec.ts
+++ b/tests/e2e/production-routes.spec.ts
@@ -1,0 +1,55 @@
+import { expect, type Page, test } from '@playwright/test';
+
+const signIn = async (page: Page) => {
+    await page.goto('/');
+    await page.getByLabel('Password').fill('e2e-password');
+    await page.getByRole('button', { name: 'Sign in' }).click();
+    await expect(page).toHaveURL((url) => url.pathname === '/');
+};
+
+const collectRuntimeErrors = (page: Page) => {
+    const errors: string[] = [];
+
+    page.on('pageerror', (error) => errors.push(error.message));
+    page.on('console', (message) => {
+        if (message.type() === 'error') {
+            errors.push(message.text());
+        }
+    });
+
+    return errors;
+};
+
+test('production note chunks render after navigation and a direct hard refresh', async ({ page }) => {
+    const runtimeErrors = collectRuntimeErrors(page);
+    await signIn(page);
+
+    await page.getByRole('button', { name: /Open a new note/ }).click();
+    await expect(page).toHaveURL((url) => /^\/[^/]+$/.test(url.pathname));
+    await expect(page.getByRole('textbox', { name: 'Note title' })).toBeVisible();
+    await expect(page.locator('[contenteditable="true"]').first()).toBeVisible();
+
+    const notePath = new URL(page.url()).pathname;
+    await page.getByRole('textbox', { name: 'Note title' }).fill('Production bundle smoke');
+    await page.getByRole('button', { name: 'Save', exact: true }).click();
+    await expect(page.getByRole('status')).toContainText('Saved');
+
+    await page.goto(notePath);
+    await expect(page.getByRole('textbox', { name: 'Note title' })).toHaveValue('Production bundle smoke');
+    await expect(page.locator('[contenteditable="true"]').first()).toBeVisible();
+    expect(runtimeErrors).toEqual([]);
+});
+
+test('production graph chunks render after a direct hard refresh', async ({ page }) => {
+    const runtimeErrors = collectRuntimeErrors(page);
+    await signIn(page);
+
+    await page.goto('/graph');
+    await expect(page.getByRole('heading', { name: 'Knowledge Graph' })).toBeVisible();
+    await expect(page.getByText('No constellations yet')).toBeVisible();
+
+    await page.reload();
+    await expect(page.getByRole('heading', { name: 'Knowledge Graph' })).toBeVisible();
+    await expect(page.getByText('No constellations yet')).toBeVisible();
+    expect(runtimeErrors).toEqual([]);
+});


### PR DESCRIPTION
## :dart: Goal

Reduce the production client initial payload without regressing cold Note navigation or introducing production-only React/module initialization failures.

## :hammer_and_wrench: Core Changes

- Replaced object-form manual chunks with a documented Note-only, route-aware bundling strategy.
- Added an independent production route preloader and intent-based route preloading for Note and Graph navigation.
- Moved BlockNote CSS and barrel imports out of the initial route, centralized client route paths, and documented bundle safety contracts.
- Added a 300 KiB production initial-bundle guard plus production E2E coverage for Note and Graph hard loads.

## :brain: Key Decisions

- Keep `route-preload.js` independent so cold Note and Graph URLs can start route downloads alongside the app entry.
- Keep `note-runtime` as one route-only lazy chunk because finer splitting introduced circular chunks. The Vite size warning remains visible and its threshold is unchanged.
- Use `APP_ROUTE_PATHS` as the route source of truth so new static routes cannot be mistaken for `/$id`.
- Enforce the real production HTML payload instead of relying on development-mode behavior or only chunk-size warnings.

## :test_tube: Verification Guide

### How to verify

1. Run `pnpm check:encoding`, `pnpm lint`, `pnpm type-check`, and `pnpm test:ci`.
2. Run `pnpm build` and confirm the production initial-bundle guard passes.
3. Run `pnpm test:e2e` against the built client and server.

### Expected result

- Encoding, lint, and type checks pass.
- Unit/integration tests pass: client 320, server 333, and CLI 31.
- Build reports `Production initial bundle: 243.38 KiB gzip (budget: 300 KiB)`.
- Chromium E2E passes 3/3, including Note create/save/direct load and Graph direct reload with no console or page errors.
- The route-only `note-runtime` chunk may still produce the existing Vite size warning; it is not part of the guarded initial payload.

Measured with cache disabled, 1.6 Mbps down, 750 Kbps up, 150 ms RTT, and 4x CPU throttling:

- Home transfer: 781.90 KB -> 248.48 KB
- Home FCP median: 4,852 ms -> 1,828 ms
- Cold Note editor readiness: 5,386 ms -> 5,352 ms

## :white_check_mark: Checklist

- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated where needed
- [x] Production build output served and tested in Chromium
- [x] Initial-bundle budget and eager Note chunk guards enforced
- [x] No deployment, migration, API, or environment changes required
