### PR TITLE
♻️ Refactor MCP tool registration

### DIFF
--- a/packages/cli/src/mcp-intent-write-tools.ts
+++ b/packages/cli/src/mcp-intent-write-tools.ts
@@ -1,27 +1,17 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 
+import {
+    createMcpJsonToolResult,
+    type McpWriteToolRegistrationInput,
+    noteLayoutSchema,
+} from './mcp-tool-support.js';
+
 interface IntentWriteToolNames {
     appendNoteMarkdown: string;
     patchNoteMarkdown: string;
     replaceNoteMarkdown: string;
     updateNoteMetadata: string;
-}
-
-type JsonRequest = <TResponse extends Record<string, unknown>>(
-    serverUrl: string,
-    token: string | undefined,
-    pathName: string,
-    body: Record<string, unknown>
-) => Promise<TResponse>;
-
-
-interface RegisterIntentWriteToolsInput {
-    jsonRequest: JsonRequest;
-    requireWriteToken: (token: string | undefined, toolName: string) => string;
-    serverUrl: string;
-    token?: string;
-    tools: IntentWriteToolNames;
 }
 
 interface DirectWriteResult extends Record<string, unknown> {
@@ -81,6 +71,11 @@ const markdownWritePolicySchema = z.object({
     preserveTags: z.union([z.boolean(), z.literal('warn')]).optional(),
     preserveReferences: z.union([z.boolean(), z.literal('warn')]).optional()
 }).optional();
+
+const markdownWriteBaselineFields = {
+    expectedUpdatedAt: z.string().optional().describe('Expected note updatedAt from the read you based this edit on. Required unless baseMarkdownSha256 is provided.'),
+    baseMarkdownSha256: z.string().optional().describe('SHA-256 of the current markdown. Optional alternative to expectedUpdatedAt.'),
+};
 
 export const MCP_METADATA_PROPERTY_PATCH_LIMIT = 50;
 
@@ -148,15 +143,14 @@ export const registerIntentWriteTools = (
         serverUrl,
         token,
         tools
-    }: RegisterIntentWriteToolsInput
+    }: McpWriteToolRegistrationInput<IntentWriteToolNames>
 ) => {
     server.tool(
         tools.patchNoteMarkdown,
         'Patch a specific part of a note, like finding text with `rg` and editing only that match. Use for localized edits: fix one sentence, replace one paragraph, insert before/after exact text, or edit one section. Do not use for whole-note rewrites; use ocean_brain_replace_note_markdown instead.',
         {
             id: z.string().describe('Note ID to patch'),
-            expectedUpdatedAt: z.string().optional().describe('Expected note updatedAt from the read you based this edit on. Required unless baseMarkdownSha256 is provided.'),
-            baseMarkdownSha256: z.string().optional().describe('SHA-256 of the current markdown. Optional alternative to expectedUpdatedAt.'),
+            ...markdownWriteBaselineFields,
             intent: z.string().describe('Human-readable reason for the patch.'),
             selector: markdownPatchSelectorSchema.describe('Exact text or previously returned match candidate.'),
             operation: markdownPatchOperationSchema.describe('replace, insert_before, or insert_after.'),
@@ -175,12 +169,7 @@ export const registerIntentWriteTools = (
             };
             const result = await jsonRequest<DirectWriteResult>(serverUrl, writeToken, '/api/mcp/notes/patch-markdown', payload);
 
-            return {
-                content: [{
-                    type: 'text' as const,
-                    text: JSON.stringify(result, null, 2)
-                }]
-            };
+            return createMcpJsonToolResult(result);
         }
     );
 
@@ -189,8 +178,7 @@ export const registerIntentWriteTools = (
         'Append markdown without changing existing content, like `cat addition.md >> note.md`. Use for adding logs, status updates, meeting notes, or new sections at the end or after a heading. Do not use to modify or replace existing body content.',
         {
             id: z.string().describe('Note ID to append to'),
-            expectedUpdatedAt: z.string().optional().describe('Expected note updatedAt from the read you based this edit on. Required unless baseMarkdownSha256 is provided.'),
-            baseMarkdownSha256: z.string().optional().describe('SHA-256 of the current markdown. Optional alternative to expectedUpdatedAt.'),
+            ...markdownWriteBaselineFields,
             intent: z.string().describe('Human-readable reason for the append.'),
             insertion: z.string().describe('Markdown to append. Tags are body tokens such as [@tag] or [#tag].'),
             placement: markdownAppendPlacementSchema.optional().describe('Default is end. after_heading requires one unique matching heading.'),
@@ -211,12 +199,7 @@ export const registerIntentWriteTools = (
             };
             const result = await jsonRequest<DirectWriteResult>(serverUrl, writeToken, '/api/mcp/notes/append-markdown', payload);
 
-            return {
-                content: [{
-                    type: 'text' as const,
-                    text: JSON.stringify(result, null, 2)
-                }]
-            };
+            return createMcpJsonToolResult(result);
         }
     );
 
@@ -227,7 +210,7 @@ export const registerIntentWriteTools = (
             id: z.string().describe('Note ID to update'),
             expectedUpdatedAt: z.string().describe('Expected note updatedAt from the read you based this metadata edit on. Required to prevent stale writes.'),
             title: z.string().optional().describe('New note title'),
-            layout: z.enum(['narrow', 'wide', 'full']).optional().describe('New note layout'),
+            layout: noteLayoutSchema.optional().describe('New note layout'),
             properties: metadataPropertyPatchSchema.describe('Patch existing shared property values. Include set and/or deleteKeys; empty patches are rejected.')
         },
         async ({ id, expectedUpdatedAt, title, layout, properties }) => {
@@ -241,12 +224,7 @@ export const registerIntentWriteTools = (
             };
             const result = await jsonRequest<DirectWriteResult>(serverUrl, writeToken, '/api/mcp/notes/metadata', payload);
 
-            return {
-                content: [{
-                    type: 'text' as const,
-                    text: JSON.stringify(result, null, 2)
-                }]
-            };
+            return createMcpJsonToolResult(result);
         }
     );
 
@@ -255,8 +233,7 @@ export const registerIntentWriteTools = (
         'Replace the entire note body, like overwriting a markdown file with `cat new.md > note.md`. Use when the user explicitly asks to rewrite, replace, regenerate, restructure, or overwrite the whole note. Do not use for localized edits such as fixing one sentence, changing one paragraph, or inserting under a heading; use ocean_brain_patch_note_markdown instead.',
         {
             id: z.string().describe('Note ID to replace'),
-            expectedUpdatedAt: z.string().optional().describe('Expected note updatedAt from the read you based this edit on. Required unless baseMarkdownSha256 is provided.'),
-            baseMarkdownSha256: z.string().optional().describe('SHA-256 of the current markdown. Optional alternative to expectedUpdatedAt.'),
+            ...markdownWriteBaselineFields,
             intent: z.string().describe('Human-readable reason for the full replace.'),
             replacement: z.string().describe('Complete replacement markdown body. Tags are body tokens such as [@tag] or [#tag].'),
             policy: markdownWritePolicySchema
@@ -273,12 +250,7 @@ export const registerIntentWriteTools = (
             };
             const result = await jsonRequest<DirectWriteResult>(serverUrl, writeToken, '/api/mcp/notes/replace-markdown', payload);
 
-            return {
-                content: [{
-                    type: 'text' as const,
-                    text: JSON.stringify(result, null, 2)
-                }]
-            };
+            return createMcpJsonToolResult(result);
         }
     );
 };

--- a/packages/cli/src/mcp-legacy-write-tools.ts
+++ b/packages/cli/src/mcp-legacy-write-tools.ts
@@ -1,0 +1,57 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import {
+    createMcpJsonToolResult,
+    type McpWriteToolRegistrationInput,
+    noteLayoutSchema,
+} from './mcp-tool-support.js';
+
+interface LegacyWriteToolNames {
+    updateNote: string;
+}
+
+export const LEGACY_UPDATE_NOTE_DESCRIPTION =
+    'Legacy full-field note update kept for backward compatibility. Prefer ocean_brain_patch_note_markdown for localized body edits, ocean_brain_append_note_markdown for additions, ocean_brain_replace_note_markdown for whole-body rewrites, and ocean_brain_update_note_metadata for title/layout/properties. Use this only when a legacy client needs combined field updates.';
+
+export const registerLegacyWriteTools = (
+    server: McpServer,
+    { jsonRequest, requireWriteToken, serverUrl, token, tools }: McpWriteToolRegistrationInput<LegacyWriteToolNames>,
+) => {
+    server.tool(
+        tools.updateNote,
+        LEGACY_UPDATE_NOTE_DESCRIPTION,
+        {
+            id: z.string().describe('Note ID to update'),
+            title: z.string().optional().describe('New note title'),
+            markdown: z
+                .string()
+                .optional()
+                .describe('Replacement markdown body. In MCP markdown, tags must use [@tag] or [#tag].'),
+            layout: noteLayoutSchema
+                .optional()
+                .describe('Optional note layout: narrow, wide, or full. Prefer wide for most notes unless the user explicitly wants narrow or full.'),
+        },
+        async ({ id, title, markdown, layout }) => {
+            const writeToken = requireWriteToken(token, tools.updateNote);
+            const result = await jsonRequest<{
+                updated?: boolean;
+                code?: string;
+                note?: {
+                    id: string;
+                    title: string;
+                    layout: 'narrow' | 'wide' | 'full';
+                    createdAt: string;
+                    updatedAt: string;
+                };
+            }>(serverUrl, writeToken, '/api/mcp/notes/update', {
+                id,
+                ...(title !== undefined ? { title } : {}),
+                ...(markdown !== undefined ? { markdown } : {}),
+                ...(layout ? { layout } : {}),
+            });
+
+            return createMcpJsonToolResult(result);
+        },
+    );
+};

--- a/packages/cli/src/mcp-tool-support.ts
+++ b/packages/cli/src/mcp-tool-support.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+
+export type McpJsonRequest = <TResponse extends Record<string, unknown>>(
+    serverUrl: string,
+    token: string | undefined,
+    pathName: string,
+    body: Record<string, unknown>,
+) => Promise<TResponse>;
+
+export interface McpWriteToolRegistrationInput<TTools> {
+    jsonRequest: McpJsonRequest;
+    requireWriteToken: (token: string | undefined, toolName: string) => string;
+    serverUrl: string;
+    token?: string;
+    tools: TTools;
+}
+
+export const noteLayoutSchema = z.enum(['narrow', 'wide', 'full']);
+
+export const createMcpTextToolResult = (text: string) => ({
+    content: [
+        {
+            type: 'text' as const,
+            text,
+        },
+    ],
+});
+
+export const createMcpJsonToolResult = (value: unknown) => {
+    return createMcpTextToolResult(JSON.stringify(value, null, 2));
+};

--- a/packages/cli/src/mcp.ts
+++ b/packages/cli/src/mcp.ts
@@ -7,7 +7,13 @@ import { z } from 'zod';
 
 import { formatMcpReadNoteOutput } from './mcp-note-output.js';
 import { registerIntentWriteTools } from './mcp-intent-write-tools.js';
+import { registerLegacyWriteTools } from './mcp-legacy-write-tools.js';
 import { formatPropertyQueryResponse, type PropertyQueryResult } from './mcp-property-query-output.js';
+import {
+    createMcpJsonToolResult,
+    createMcpTextToolResult,
+    noteLayoutSchema,
+} from './mcp-tool-support.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(
@@ -51,7 +57,6 @@ export const OCEAN_BRAIN_MCP_TOOLS = {
     deleteNote: 'ocean_brain_delete_note'
 } as const;
 
-const noteLayoutSchema = z.enum(['narrow', 'wide', 'full']);
 const tagMatchModeSchema = z.enum(['and', 'or']);
 const propertyValueTypeSchema = z.enum(['text', 'url', 'number', 'date', 'boolean', 'select']);
 const propertyFilterOperatorSchema = z.enum(['equals', 'before', 'after', 'exists', 'notExists']);
@@ -215,14 +220,11 @@ const requireWriteToken = (token: string | undefined, toolName: string) => {
     throw new Error(`${toolName} requires an MCP bearer token. Set --token or --token-file.`);
 };
 
-export async function startMcpServer(
+const registerMcpTools = (
+    server: McpServer,
     serverUrl: string,
     token?: string
-) {
-    const server = new McpServer({
-        name: 'ocean-brain',
-        version: pkg.version,
-    });
+) => {
     server.tool(
         OCEAN_BRAIN_MCP_TOOLS.searchNotes,
         'Search Ocean Brain notes by keyword. Returns matching note titles and tags. Use ocean_brain_read_note to get full content for a specific note.',
@@ -268,12 +270,7 @@ export async function startMcpServer(
                 preview: note.contentAsMarkdown.slice(0, 100),
             }));
 
-            return {
-                content: [{
-                    type: 'text' as const,
-                    text: JSON.stringify({ totalCount: result.totalCount, notes }, null, 2),
-                }],
-            };
+            return createMcpJsonToolResult({ totalCount: result.totalCount, notes });
         },
     );
 
@@ -328,12 +325,7 @@ export async function startMcpServer(
                 maxLength
             });
 
-            return {
-                content: [{
-                    type: 'text' as const,
-                    text: output,
-                }],
-            };
+            return createMcpTextToolResult(output);
         },
     );
 
@@ -362,51 +354,17 @@ export async function startMcpServer(
                 ...(layout ? { layout } : {})
             });
 
-            return {
-                content: [{
-                    type: 'text' as const,
-                    text: JSON.stringify(result, null, 2)
-                }]
-            };
+            return createMcpJsonToolResult(result);
         }
     );
 
-    server.tool(
-        OCEAN_BRAIN_MCP_TOOLS.updateNote,
-        'Legacy full-field note update kept for backward compatibility. Prefer ocean_brain_patch_note_markdown for localized body edits, ocean_brain_append_note_markdown for additions, ocean_brain_replace_note_markdown for whole-body rewrites, and ocean_brain_update_note_metadata for title/layout/properties. Use this only when a legacy client needs combined field updates.',
-        {
-            id: z.string().describe('Note ID to update'),
-            title: z.string().optional().describe('New note title'),
-            markdown: z.string().optional().describe('Replacement markdown body. In MCP markdown, tags must use [@tag] or [#tag].'),
-            layout: noteLayoutSchema.optional().describe('Optional note layout: narrow, wide, or full. Prefer wide for most notes unless the user explicitly wants narrow or full.')
-        },
-        async ({ id, title, markdown, layout }) => {
-            const writeToken = requireWriteToken(token, OCEAN_BRAIN_MCP_TOOLS.updateNote);
-            const result = await jsonRequest<{
-                updated?: boolean;
-                code?: string;
-                note?: {
-                    id: string;
-                    title: string;
-                    layout: 'narrow' | 'wide' | 'full';
-                    createdAt: string;
-                    updatedAt: string;
-                };
-            }>(serverUrl, writeToken, '/api/mcp/notes/update', {
-                id,
-                ...(title !== undefined ? { title } : {}),
-                ...(markdown !== undefined ? { markdown } : {}),
-                ...(layout ? { layout } : {})
-            });
-
-            return {
-                content: [{
-                    type: 'text' as const,
-                    text: JSON.stringify(result, null, 2)
-                }]
-            };
-        }
-    );
+    registerLegacyWriteTools(server, {
+        jsonRequest,
+        requireWriteToken,
+        serverUrl,
+        token,
+        tools: OCEAN_BRAIN_MCP_TOOLS,
+    });
 
     registerIntentWriteTools(server, {
         jsonRequest,
@@ -442,12 +400,7 @@ export async function startMcpServer(
                 tags: Array<{ id: string; name: string; referenceCount: number }>;
             };
 
-            return {
-                content: [{
-                    type: 'text' as const,
-                    text: JSON.stringify(result, null, 2),
-                }],
-            };
+            return createMcpJsonToolResult(result);
         },
     );
 
@@ -497,15 +450,10 @@ export async function startMcpServer(
                 }>;
             };
 
-            return {
-                content: [{
-                    type: 'text' as const,
-                    text: JSON.stringify({
-                        totalCount: result.totalCount,
-                        propertyKeys: result.keys
-                    }, null, 2),
-                }],
-            };
+            return createMcpJsonToolResult({
+                totalCount: result.totalCount,
+                propertyKeys: result.keys
+            });
         }
     );
 
@@ -523,18 +471,13 @@ export async function startMcpServer(
             const exactMatches = tagResult.tags.filter((item) => item.name === normalizedTag);
 
             if (exactMatches.length === 0) {
-                return {
-                    content: [{
-                        type: 'text' as const,
-                        text: JSON.stringify({
-                            requestedTag: tag,
-                            normalizedTag,
-                            tagFound: false,
-                            noteCount: 0,
-                            notes: []
-                        }, null, 2),
-                    }],
-                };
+                return createMcpJsonToolResult({
+                    requestedTag: tag,
+                    normalizedTag,
+                    tagFound: false,
+                    noteCount: 0,
+                    notes: []
+                });
             }
 
             const selectedTag = exactMatches[0];
@@ -565,25 +508,20 @@ export async function startMcpServer(
                 }>;
             };
 
-            return {
-                content: [{
-                    type: 'text' as const,
-                    text: JSON.stringify({
-                        requestedTag: tag,
-                        normalizedTag,
-                        tagFound: true,
-                        duplicateExactMatchCount: exactMatches.length,
-                        tag: selectedTag,
-                        totalCount: noteResult.totalCount,
-                        notes: noteResult.notes.map((note) => ({
-                            id: note.id,
-                            title: note.title,
-                            updatedAt: note.updatedAt,
-                            tags: note.tags.map((item) => item.name)
-                        }))
-                    }, null, 2),
-                }],
-            };
+            return createMcpJsonToolResult({
+                requestedTag: tag,
+                normalizedTag,
+                tagFound: true,
+                duplicateExactMatchCount: exactMatches.length,
+                tag: selectedTag,
+                totalCount: noteResult.totalCount,
+                notes: noteResult.notes.map((note) => ({
+                    id: note.id,
+                    title: note.title,
+                    updatedAt: note.updatedAt,
+                    tags: note.tags.map((item) => item.name)
+                }))
+            });
         }
     );
 
@@ -664,26 +602,21 @@ export async function startMcpServer(
                 noteResult = notesData?.notesByTagNames as typeof noteResult;
             }
 
-            return {
-                content: [{
-                    type: 'text' as const,
-                    text: JSON.stringify({
-                        requestedTags: tags,
-                        normalizedTags,
-                        mode,
-                        allTagsFound: missingTags.length === 0,
-                        missingTags,
-                        tags: matchedTags,
-                        totalCount: noteResult.totalCount,
-                        notes: noteResult.notes.map((note) => ({
-                            id: note.id,
-                            title: note.title,
-                            updatedAt: note.updatedAt,
-                            tags: note.tags.map((item) => item.name)
-                        }))
-                    }, null, 2),
-                }],
-            };
+            return createMcpJsonToolResult({
+                requestedTags: tags,
+                normalizedTags,
+                mode,
+                allTagsFound: missingTags.length === 0,
+                missingTags,
+                tags: matchedTags,
+                totalCount: noteResult.totalCount,
+                notes: noteResult.notes.map((note) => ({
+                    id: note.id,
+                    title: note.title,
+                    updatedAt: note.updatedAt,
+                    tags: note.tags.map((item) => item.name)
+                }))
+            });
         }
     );
 
@@ -731,29 +664,20 @@ export async function startMcpServer(
 
             const result = data?.notesByProperties as PropertyQueryResult;
 
-            return {
-                content: [{
-                    type: 'text' as const,
-                    text: JSON.stringify(
-                        formatPropertyQueryResponse({
-                            result,
-                            query: {
-                                propertyFilters,
-                                tagNames,
-                                mode,
-                                sortBy,
-                                sortOrder,
-                                limit,
-                                offset
-                            },
-                            includeProperties: shouldIncludeProperties,
-                            propertyKeys
-                        }),
-                        null,
-                        2
-                    ),
-                }],
-            };
+            return createMcpJsonToolResult(formatPropertyQueryResponse({
+                result,
+                query: {
+                    propertyFilters,
+                    tagNames,
+                    mode,
+                    sortBy,
+                    sortOrder,
+                    limit,
+                    offset
+                },
+                includeProperties: shouldIncludeProperties,
+                propertyKeys
+            }));
         }
     );
 
@@ -798,12 +722,7 @@ export async function startMcpServer(
                 tags: note.tags.map((t) => t.name),
             }));
 
-            return {
-                content: [{
-                    type: 'text' as const,
-                    text: JSON.stringify({ totalCount: result.totalCount, notes }, null, 2),
-                }],
-            };
+            return createMcpJsonToolResult({ totalCount: result.totalCount, notes });
         },
     );
 
@@ -856,18 +775,13 @@ export async function startMcpServer(
                 forceReasons: string[];
             }>;
 
-            return {
-                content: [{
-                    type: 'text' as const,
-                    text: JSON.stringify({
-                        keywords: normalizedKeywords,
-                        limit,
-                        offset,
-                        candidateCount: result.length,
-                        notes: result
-                    }, null, 2),
-                }],
-            };
+            return createMcpJsonToolResult({
+                keywords: normalizedKeywords,
+                limit,
+                offset,
+                candidateCount: result.length,
+                notes: result
+            });
         }
     );
 
@@ -892,12 +806,7 @@ export async function startMcpServer(
                 name
             });
 
-            return {
-                content: [{
-                    type: 'text' as const,
-                    text: JSON.stringify(result, null, 2)
-                }]
-            };
+            return createMcpJsonToolResult(result);
         }
     );
 
@@ -913,18 +822,24 @@ export async function startMcpServer(
             try {
                 const result = await jsonRequest(serverUrl, writeToken, '/api/mcp/notes/delete', { id });
 
-                return {
-                    content: [{
-                        type: 'text' as const,
-                        text: JSON.stringify(result, null, 2)
-                    }]
-                };
+                return createMcpJsonToolResult(result);
             } catch (error) {
                 const message = error instanceof Error ? error.message : 'Unknown MCP note delete error';
                 throw new Error(message);
             }
         }
     );
+};
+
+export async function startMcpServer(
+    serverUrl: string,
+    token?: string
+) {
+    const server = new McpServer({
+        name: 'ocean-brain',
+        version: pkg.version,
+    });
+    registerMcpTools(server, serverUrl, token);
 
     const transport = new StdioServerTransport();
     await server.connect(transport);

--- a/packages/cli/test/mcp-intent-write-tools.test.ts
+++ b/packages/cli/test/mcp-intent-write-tools.test.ts
@@ -197,6 +197,92 @@ describe('registerIntentWriteTools', () => {
         }]);
     });
 
+    test('forwards metadata and full replacement writes through their existing endpoints', async () => {
+        // Arrange
+        const { registeredTools, server } = createFakeMcpServer();
+        const tokenRequests: Array<{ token: string | undefined; toolName: string }> = [];
+        const requests: Array<{
+            serverUrl: string;
+            token: string | undefined;
+            pathName: string;
+            body: Record<string, unknown>;
+        }> = [];
+
+        registerIntentWriteTools(server, {
+            jsonRequest: async (serverUrl, token, pathName, body) => {
+                requests.push({ serverUrl, token, pathName, body });
+                return { status: 'applied', pathName };
+            },
+            requireWriteToken: (token, toolName) => {
+                tokenRequests.push({ token, toolName });
+                return 'write-token';
+            },
+            serverUrl: 'http://localhost:6683',
+            token: 'read-token',
+            tools: TOOL_NAMES
+        });
+        const metadataHandler = registeredTools.get(TOOL_NAMES.updateNoteMetadata)?.handler;
+        const replaceHandler = registeredTools.get(TOOL_NAMES.replaceNoteMarkdown)?.handler;
+
+        // Act
+        assert.ok(metadataHandler);
+        assert.ok(replaceHandler);
+        const metadataResult = parseToolText(await metadataHandler({
+            id: '7',
+            expectedUpdatedAt: '2026-06-04T10:00:00.000Z',
+            title: 'Updated title',
+            layout: 'wide',
+            properties: {
+                set: [{ key: 'state', value: 'done' }],
+                deleteKeys: ['project']
+            }
+        }));
+        const replaceResult = parseToolText(await replaceHandler({
+            id: '8',
+            baseMarkdownSha256: 'hash-a',
+            intent: 'Rewrite the whole note',
+            replacement: '# Replacement',
+            policy: { preserveTags: true }
+        }));
+
+        // Assert
+        assert.deepEqual(tokenRequests, [
+            { token: 'read-token', toolName: TOOL_NAMES.updateNoteMetadata },
+            { token: 'read-token', toolName: TOOL_NAMES.replaceNoteMarkdown }
+        ]);
+        assert.deepEqual(requests, [
+            {
+                serverUrl: 'http://localhost:6683',
+                token: 'write-token',
+                pathName: '/api/mcp/notes/metadata',
+                body: {
+                    id: '7',
+                    expectedUpdatedAt: '2026-06-04T10:00:00.000Z',
+                    title: 'Updated title',
+                    layout: 'wide',
+                    properties: {
+                        set: [{ key: 'state', value: 'done' }],
+                        deleteKeys: ['project']
+                    }
+                }
+            },
+            {
+                serverUrl: 'http://localhost:6683',
+                token: 'write-token',
+                pathName: '/api/mcp/notes/replace-markdown',
+                body: {
+                    id: '8',
+                    baseMarkdownSha256: 'hash-a',
+                    intent: 'Rewrite the whole note',
+                    replacement: '# Replacement',
+                    policy: { preserveTags: true }
+                }
+            }
+        ]);
+        assert.equal(metadataResult.pathName, '/api/mcp/notes/metadata');
+        assert.equal(replaceResult.pathName, '/api/mcp/notes/replace-markdown');
+    });
+
     test('describes write tools by edit unit instead of confirmation flow', () => {
         // Arrange
         const { registeredTools, server } = createFakeMcpServer();

--- a/packages/cli/test/mcp-legacy-write-tools.test.ts
+++ b/packages/cli/test/mcp-legacy-write-tools.test.ts
@@ -1,0 +1,149 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import {
+    LEGACY_UPDATE_NOTE_DESCRIPTION,
+    registerLegacyWriteTools,
+} from '../src/mcp-legacy-write-tools.js';
+
+interface RegisteredTool {
+    description: string;
+    schema: Record<string, unknown>;
+    handler: (input: Record<string, unknown>) => Promise<{
+        content: Array<{
+            text: string;
+            type: string;
+        }>;
+    }>;
+}
+
+const UPDATE_NOTE_TOOL_NAME = 'ocean_brain_update_note';
+
+const createFakeMcpServer = () => {
+    const registeredTools = new Map<string, RegisteredTool>();
+    const server = {
+        tool(
+            name: string,
+            description: string,
+            schema: Record<string, unknown>,
+            handler: RegisteredTool['handler'],
+        ) {
+            registeredTools.set(name, { description, schema, handler });
+        },
+    };
+
+    return {
+        registeredTools,
+        server: server as unknown as McpServer,
+    };
+};
+
+const parseToolText = (result: Awaited<ReturnType<RegisteredTool['handler']>>) => {
+    return JSON.parse(result.content[0].text) as Record<string, unknown>;
+};
+
+describe('registerLegacyWriteTools', () => {
+    test('keeps the legacy update tool contract isolated and explicit', () => {
+        // Arrange
+        const { registeredTools, server } = createFakeMcpServer();
+
+        // Act
+        registerLegacyWriteTools(server, {
+            jsonRequest: async () => ({ updated: true }),
+            requireWriteToken: () => 'write-token',
+            serverUrl: 'http://localhost:6683',
+            token: 'read-token',
+            tools: { updateNote: UPDATE_NOTE_TOOL_NAME },
+        });
+
+        // Assert
+        const tool = registeredTools.get(UPDATE_NOTE_TOOL_NAME);
+        assert.ok(tool);
+        assert.equal(tool.description, LEGACY_UPDATE_NOTE_DESCRIPTION);
+        assert.deepEqual(Object.keys(tool.schema).sort(), ['id', 'layout', 'markdown', 'title']);
+        assert.match(tool.description, /backward compatibility/);
+        assert.match(tool.description, /ocean_brain_patch_note_markdown/);
+        assert.match(tool.description, /ocean_brain_replace_note_markdown/);
+        assert.match(tool.description, /ocean_brain_update_note_metadata/);
+        assert.equal(tool.schema.expectedUpdatedAt, undefined);
+        assert.equal(tool.schema.baseMarkdownSha256, undefined);
+    });
+
+    test('forwards the existing combined update payload and response unchanged', async () => {
+        // Arrange
+        const { registeredTools, server } = createFakeMcpServer();
+        const tokenRequests: Array<{ token: string | undefined; toolName: string }> = [];
+        const requests: Array<{
+            serverUrl: string;
+            token: string | undefined;
+            pathName: string;
+            body: Record<string, unknown>;
+        }> = [];
+
+        registerLegacyWriteTools(server, {
+            jsonRequest: async (serverUrl, token, pathName, body) => {
+                requests.push({ serverUrl, token, pathName, body });
+
+                return {
+                    updated: true,
+                    note: {
+                        id: '7',
+                        title: 'Updated title',
+                        layout: 'wide',
+                        createdAt: '2026-07-01T00:00:00.000Z',
+                        updatedAt: '2026-07-01T00:00:01.000Z',
+                    },
+                };
+            },
+            requireWriteToken: (token, toolName) => {
+                tokenRequests.push({ token, toolName });
+                return 'write-token';
+            },
+            serverUrl: 'http://localhost:6683',
+            token: 'read-token',
+            tools: { updateNote: UPDATE_NOTE_TOOL_NAME },
+        });
+        const handler = registeredTools.get(UPDATE_NOTE_TOOL_NAME)?.handler;
+
+        // Act
+        assert.ok(handler);
+        const result = parseToolText(
+            await handler({
+                id: '7',
+                title: 'Updated title',
+                markdown: '# Updated body',
+                layout: 'wide',
+            }),
+        );
+
+        // Assert
+        assert.deepEqual(tokenRequests, [
+            {
+                token: 'read-token',
+                toolName: UPDATE_NOTE_TOOL_NAME,
+            },
+        ]);
+        assert.deepEqual(requests, [
+            {
+                serverUrl: 'http://localhost:6683',
+                token: 'write-token',
+                pathName: '/api/mcp/notes/update',
+                body: {
+                    id: '7',
+                    title: 'Updated title',
+                    markdown: '# Updated body',
+                    layout: 'wide',
+                },
+            },
+        ]);
+        assert.equal(result.updated, true);
+        assert.deepEqual(result.note, {
+            id: '7',
+            title: 'Updated title',
+            layout: 'wide',
+            createdAt: '2026-07-01T00:00:00.000Z',
+            updatedAt: '2026-07-01T00:00:01.000Z',
+        });
+    });
+});

--- a/packages/cli/test/mcp-tool-contract.test.ts
+++ b/packages/cli/test/mcp-tool-contract.test.ts
@@ -1,0 +1,281 @@
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { describe, test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+import { OCEAN_BRAIN_MCP_TOOLS } from '../src/mcp.js';
+import {
+    createMcpJsonToolResult,
+    createMcpTextToolResult,
+    noteLayoutSchema,
+} from '../src/mcp-tool-support.js';
+
+interface JsonSchema {
+    additionalProperties?: boolean;
+    anyOf?: JsonSchema[];
+    const?: unknown;
+    default?: unknown;
+    enum?: unknown[];
+    items?: JsonSchema;
+    maximum?: number;
+    maxItems?: number;
+    minimum?: number;
+    minItems?: number;
+    properties?: Record<string, JsonSchema>;
+    required?: string[];
+    type?: string | string[];
+}
+
+const EXPECTED_TOOL_ORDER = [
+    OCEAN_BRAIN_MCP_TOOLS.searchNotes,
+    OCEAN_BRAIN_MCP_TOOLS.readNote,
+    OCEAN_BRAIN_MCP_TOOLS.createNote,
+    OCEAN_BRAIN_MCP_TOOLS.updateNote,
+    OCEAN_BRAIN_MCP_TOOLS.patchNoteMarkdown,
+    OCEAN_BRAIN_MCP_TOOLS.appendNoteMarkdown,
+    OCEAN_BRAIN_MCP_TOOLS.updateNoteMetadata,
+    OCEAN_BRAIN_MCP_TOOLS.replaceNoteMarkdown,
+    OCEAN_BRAIN_MCP_TOOLS.listTags,
+    OCEAN_BRAIN_MCP_TOOLS.listProperties,
+    OCEAN_BRAIN_MCP_TOOLS.listNotesByTag,
+    OCEAN_BRAIN_MCP_TOOLS.listNotesByTags,
+    OCEAN_BRAIN_MCP_TOOLS.queryNotesByProperties,
+    OCEAN_BRAIN_MCP_TOOLS.listRecentNotes,
+    OCEAN_BRAIN_MCP_TOOLS.findNoteCleanupCandidates,
+    OCEAN_BRAIN_MCP_TOOLS.createTag,
+    OCEAN_BRAIN_MCP_TOOLS.deleteNote,
+];
+
+const EXPECTED_SCHEMA_KEYS: Record<string, string[]> = {
+    [OCEAN_BRAIN_MCP_TOOLS.searchNotes]: ['limit', 'query'],
+    [OCEAN_BRAIN_MCP_TOOLS.readNote]: ['id', 'maxLength'],
+    [OCEAN_BRAIN_MCP_TOOLS.createNote]: ['layout', 'markdown', 'title'],
+    [OCEAN_BRAIN_MCP_TOOLS.updateNote]: ['id', 'layout', 'markdown', 'title'],
+    [OCEAN_BRAIN_MCP_TOOLS.patchNoteMarkdown]: [
+        'baseMarkdownSha256',
+        'expectedUpdatedAt',
+        'id',
+        'intent',
+        'operation',
+        'policy',
+        'selector',
+    ],
+    [OCEAN_BRAIN_MCP_TOOLS.appendNoteMarkdown]: [
+        'baseMarkdownSha256',
+        'expectedUpdatedAt',
+        'id',
+        'insertion',
+        'intent',
+        'placement',
+        'policy',
+        'separator',
+    ],
+    [OCEAN_BRAIN_MCP_TOOLS.updateNoteMetadata]: [
+        'expectedUpdatedAt',
+        'id',
+        'layout',
+        'properties',
+        'title',
+    ],
+    [OCEAN_BRAIN_MCP_TOOLS.replaceNoteMarkdown]: [
+        'baseMarkdownSha256',
+        'expectedUpdatedAt',
+        'id',
+        'intent',
+        'policy',
+        'replacement',
+    ],
+    [OCEAN_BRAIN_MCP_TOOLS.listTags]: [],
+    [OCEAN_BRAIN_MCP_TOOLS.listProperties]: ['limit', 'offset', 'query'],
+    [OCEAN_BRAIN_MCP_TOOLS.listNotesByTag]: ['limit', 'offset', 'tag'],
+    [OCEAN_BRAIN_MCP_TOOLS.listNotesByTags]: ['limit', 'mode', 'offset', 'tags'],
+    [OCEAN_BRAIN_MCP_TOOLS.queryNotesByProperties]: [
+        'includeProperties',
+        'limit',
+        'mode',
+        'offset',
+        'propertyFilters',
+        'propertyKeys',
+        'sortBy',
+        'sortOrder',
+        'tagNames',
+    ],
+    [OCEAN_BRAIN_MCP_TOOLS.listRecentNotes]: ['limit'],
+    [OCEAN_BRAIN_MCP_TOOLS.findNoteCleanupCandidates]: ['keywords', 'limit', 'offset'],
+    [OCEAN_BRAIN_MCP_TOOLS.createTag]: ['name'],
+    [OCEAN_BRAIN_MCP_TOOLS.deleteNote]: ['id'],
+};
+
+const EXPECTED_REQUIRED_FIELDS: Record<string, string[]> = {
+    [OCEAN_BRAIN_MCP_TOOLS.searchNotes]: ['query'],
+    [OCEAN_BRAIN_MCP_TOOLS.readNote]: ['id'],
+    [OCEAN_BRAIN_MCP_TOOLS.createNote]: ['title'],
+    [OCEAN_BRAIN_MCP_TOOLS.updateNote]: ['id'],
+    [OCEAN_BRAIN_MCP_TOOLS.patchNoteMarkdown]: ['id', 'intent', 'selector', 'operation'],
+    [OCEAN_BRAIN_MCP_TOOLS.appendNoteMarkdown]: ['id', 'intent', 'insertion'],
+    [OCEAN_BRAIN_MCP_TOOLS.updateNoteMetadata]: ['id', 'expectedUpdatedAt'],
+    [OCEAN_BRAIN_MCP_TOOLS.replaceNoteMarkdown]: ['id', 'intent', 'replacement'],
+    [OCEAN_BRAIN_MCP_TOOLS.listTags]: [],
+    [OCEAN_BRAIN_MCP_TOOLS.listProperties]: [],
+    [OCEAN_BRAIN_MCP_TOOLS.listNotesByTag]: ['tag'],
+    [OCEAN_BRAIN_MCP_TOOLS.listNotesByTags]: ['tags'],
+    [OCEAN_BRAIN_MCP_TOOLS.queryNotesByProperties]: ['propertyFilters'],
+    [OCEAN_BRAIN_MCP_TOOLS.listRecentNotes]: [],
+    [OCEAN_BRAIN_MCP_TOOLS.findNoteCleanupCandidates]: [],
+    [OCEAN_BRAIN_MCP_TOOLS.createTag]: ['name'],
+    [OCEAN_BRAIN_MCP_TOOLS.deleteNote]: ['id'],
+};
+
+const cliRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+describe('Ocean Brain MCP stdio contract', () => {
+    test('exposes the existing tools and serialized input schemas', { timeout: 30_000 }, async () => {
+        // Arrange
+        const client = new Client({ name: 'mcp-contract-test', version: '0.0.0' });
+        const transport = new StdioClientTransport({
+            command: process.execPath,
+            args: [
+                '--import',
+                'tsx',
+                path.resolve(cliRoot, 'src/index.ts'),
+                'mcp',
+                '--token',
+                'contract-token',
+            ],
+            cwd: cliRoot,
+            stderr: 'pipe',
+        });
+        let stderrOutput = '';
+        transport.stderr?.on('data', (chunk) => {
+            stderrOutput += String(chunk);
+        });
+
+        try {
+            // Act
+            await client.connect(transport);
+            const { tools } = await client.listTools();
+            const schemas = new Map(
+                tools.map((tool) => [tool.name, tool.inputSchema as JsonSchema]),
+            );
+
+            // Assert
+            assert.deepEqual(tools.map((tool) => tool.name), EXPECTED_TOOL_ORDER);
+
+            for (const tool of tools) {
+                const schema = tool.inputSchema as JsonSchema;
+                assert.ok(tool.description?.trim(), `${tool.name} should keep a description`);
+                assert.equal(schema.type, 'object');
+                assert.deepEqual(
+                    Object.keys(schema.properties ?? {}).sort(),
+                    EXPECTED_SCHEMA_KEYS[tool.name],
+                    `${tool.name} input fields changed`,
+                );
+                assert.deepEqual(
+                    [...(schema.required ?? [])].sort(),
+                    [...EXPECTED_REQUIRED_FIELDS[tool.name]].sort(),
+                    `${tool.name} required fields changed`,
+                );
+            }
+
+            const property = (toolName: string, propertyName: string) => {
+                const propertySchema = schemas.get(toolName)?.properties?.[propertyName];
+                assert.ok(propertySchema, `${toolName}.${propertyName} should exist`);
+                return propertySchema;
+            };
+
+            assert.equal(property(OCEAN_BRAIN_MCP_TOOLS.searchNotes, 'limit').default, 10);
+            assert.equal(property(OCEAN_BRAIN_MCP_TOOLS.readNote, 'maxLength').default, 1000);
+            assert.equal(property(OCEAN_BRAIN_MCP_TOOLS.createNote, 'markdown').default, '');
+            assert.deepEqual(property(OCEAN_BRAIN_MCP_TOOLS.createNote, 'layout').enum, ['narrow', 'wide', 'full']);
+            assert.deepEqual(property(OCEAN_BRAIN_MCP_TOOLS.updateNote, 'layout').enum, ['narrow', 'wide', 'full']);
+            assert.deepEqual(property(OCEAN_BRAIN_MCP_TOOLS.updateNoteMetadata, 'layout').enum, ['narrow', 'wide', 'full']);
+            assert.equal(property(OCEAN_BRAIN_MCP_TOOLS.listProperties, 'query').default, '');
+            assert.equal(property(OCEAN_BRAIN_MCP_TOOLS.listProperties, 'limit').default, 50);
+            assert.equal(property(OCEAN_BRAIN_MCP_TOOLS.listProperties, 'offset').default, 0);
+            assert.equal(property(OCEAN_BRAIN_MCP_TOOLS.listNotesByTags, 'mode').default, 'and');
+            assert.deepEqual(property(OCEAN_BRAIN_MCP_TOOLS.listNotesByTags, 'mode').enum, ['and', 'or']);
+            assert.equal(property(OCEAN_BRAIN_MCP_TOOLS.listRecentNotes, 'limit').default, 10);
+            assert.equal(
+                property(OCEAN_BRAIN_MCP_TOOLS.findNoteCleanupCandidates, 'keywords').default,
+                'temp tmp draft test wip',
+            );
+
+            const variant = (variants: JsonSchema[] | undefined, discriminator: string) => {
+                const matchedVariant = variants?.find((item) => item.properties?.type?.const === discriminator);
+                assert.ok(matchedVariant, `${discriminator} schema variant should exist`);
+                return matchedVariant;
+            };
+            const selectorVariants = property(OCEAN_BRAIN_MCP_TOOLS.patchNoteMarkdown, 'selector').anyOf;
+            assert.deepEqual([...(variant(selectorVariants, 'exact_text').required ?? [])].sort(), ['text', 'type']);
+            assert.deepEqual([...(variant(selectorVariants, 'match_candidate').required ?? [])].sort(), [
+                'type',
+                'text',
+                'matchIndex',
+                'lineStart',
+                'matchSha256',
+                'surroundingHash',
+            ].sort());
+            const operationVariants = property(OCEAN_BRAIN_MCP_TOOLS.patchNoteMarkdown, 'operation').anyOf;
+            assert.deepEqual([...(variant(operationVariants, 'replace').required ?? [])].sort(), ['replacement', 'type']);
+            assert.deepEqual([...(variant(operationVariants, 'insert_before').required ?? [])].sort(), ['insertion', 'type']);
+            assert.deepEqual([...(variant(operationVariants, 'insert_after').required ?? [])].sort(), ['insertion', 'type']);
+
+            const metadataProperties = property(OCEAN_BRAIN_MCP_TOOLS.updateNoteMetadata, 'properties');
+            assert.equal(metadataProperties.properties?.set?.maxItems, 50);
+            assert.equal(metadataProperties.properties?.deleteKeys?.maxItems, 50);
+            assert.deepEqual(
+                [...(metadataProperties.properties?.set?.items?.required ?? [])].sort(),
+                ['key', 'value'],
+            );
+
+            const propertyFilters = property(OCEAN_BRAIN_MCP_TOOLS.queryNotesByProperties, 'propertyFilters');
+            assert.equal(propertyFilters.minItems, 1);
+            assert.equal(propertyFilters.maxItems, 10);
+            assert.deepEqual(
+                [...(propertyFilters.items?.required ?? [])].sort(),
+                ['key', 'operator', 'valueType'],
+            );
+            assert.deepEqual(
+                propertyFilters.items?.properties?.valueType?.enum,
+                ['text', 'url', 'number', 'date', 'boolean', 'select'],
+            );
+            assert.deepEqual(
+                propertyFilters.items?.properties?.operator?.enum,
+                ['equals', 'before', 'after', 'exists', 'notExists'],
+            );
+        } catch (error) {
+            if (!stderrOutput.trim()) {
+                throw error;
+            }
+
+            const message = error instanceof Error ? error.message : String(error);
+            throw new Error(`${message}\nMCP stderr:\n${stderrOutput.trim()}`, { cause: error });
+        } finally {
+            await client.close();
+        }
+    });
+});
+
+describe('MCP tool result support', () => {
+    test('keeps text and pretty JSON response envelopes unchanged', () => {
+        assert.deepEqual(createMcpTextToolResult('plain text'), {
+            content: [{ type: 'text', text: 'plain text' }],
+        });
+        assert.deepEqual(createMcpJsonToolResult({ ok: true, count: 2 }), {
+            content: [{
+                type: 'text',
+                text: '{\n  "ok": true,\n  "count": 2\n}',
+            }],
+        });
+    });
+
+    test('shares the unchanged note layout values across write tools', () => {
+        for (const layout of ['narrow', 'wide', 'full']) {
+            assert.equal(noteLayoutSchema.safeParse(layout).success, true);
+        }
+
+        assert.equal(noteLayoutSchema.safeParse('compact').success, false);
+    });
+});


### PR DESCRIPTION
## :dart: Goal
- Reduce coupling in the CLI MCP server registration while preserving the existing public MCP contract.
- Add executable coverage for tool registration so future refactors cannot silently change tool names, ordering, schemas, or response envelopes.

## :hammer_and_wrench: Core Changes
- Isolated the backward-compatible combined note update tool from the main MCP server module.
- Centralized shared write-tool types, note layout schema, and MCP text/JSON response helpers.
- Added coverage for legacy and intent-based write forwarding plus the real stdio tool contract.

## :brain: Key Decisions
- Retained the legacy update tool unchanged for backward compatibility instead of removing or extending its public fields.
- Tested the public MCP surface through a real stdio client connection, while keeping focused unit tests for endpoint and payload forwarding.

## :test_tube: Verification Guide
### How to verify
1. Run pnpm check:encoding, pnpm lint, pnpm test:ci, pnpm type-check, and pnpm build.
2. Run pnpm --filter ocean-brain type-check and pnpm --filter ocean-brain build.
3. Confirm the MCP contract test reports all 17 registered tools with their existing schemas.

### Expected result
- Encoding and lint checks pass with no errors.
- Client 252 tests, server 76 tests, and CLI 31 tests pass.
- Workspace and CLI type checks and builds complete successfully.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (not required; no documentation, script, or environment changes)