### PR TITLE
🐛 Preserve Markdown content across clipboard workflows

### DIFF
--- a/fixtures/markdown-tilde-cases.json
+++ b/fixtures/markdown-tilde-cases.json
@@ -1,0 +1,93 @@
+{
+	"literalNumericRanges": [
+		{
+			"name": "preserves spaced numeric ranges",
+			"markdown": "Range is 1~3 and 4~5."
+		},
+		{
+			"name": "preserves numeric ranges separated by punctuation",
+			"markdown": "Ranges are 1~3,4~5 and 6~7/8~9."
+		},
+		{
+			"name": "preserves double-tilde comma-separated ranges",
+			"markdown": "Ranges are 41,590~~41,677 and 4,970~~4,980."
+		},
+		{
+			"name": "preserves single-tilde comma-separated ranges",
+			"markdown": "Ranges are 41,590~41,677 and 4,970~4,980."
+		},
+		{
+			"name": "preserves date and percentage ranges",
+			"markdown": "Window: 2026-07-13~2026-07-14 and 99.9%~100.1%."
+		},
+		{
+			"name": "preserves temperature ranges",
+			"markdown": "Temperatures: 10°C~20°C and 30°C~40°C."
+		},
+		{
+			"name": "preserves compound-unit ranges",
+			"markdown": "Speeds: 10m/s~20m/s and 30m/s~40m/s."
+		},
+		{
+			"name": "preserves spaced-unit ranges",
+			"markdown": "Weights: 10 kg~20 kg and 30 kg~40 kg."
+		}
+	],
+	"strikethrough": [
+		{
+			"name": "preserves double-tilde strikethrough",
+			"markdown": "Keep ~~removed~~ text",
+			"struckText": "removed"
+		},
+		{
+			"name": "preserves boundary single-tilde strikethrough",
+			"markdown": "Keep ~removed~ text",
+			"struckText": "removed"
+		},
+		{
+			"name": "preserves prefixed single-tilde strikethrough",
+			"markdown": "prefix~deleted~ text",
+			"struckText": "deleted"
+		},
+		{
+			"name": "preserves suffixed single-tilde strikethrough",
+			"markdown": "이것은 ~삭제~입니다.",
+			"struckText": "삭제"
+		},
+		{
+			"name": "preserves compact single-tilde strikethrough",
+			"markdown": "앞~삭제~뒤",
+			"struckText": "삭제"
+		},
+		{
+			"name": "preserves compact single-tilde strikethrough containing spaces",
+			"markdown": "앞~삭제 내용~뒤",
+			"struckText": "삭제 내용"
+		},
+		{
+			"name": "preserves version-like compact strikethrough",
+			"markdown": "v1~old2~v3",
+			"struckText": "old2"
+		},
+		{
+			"name": "preserves numeric-boundary compact strikethrough",
+			"markdown": "1~삭제2~3",
+			"struckText": "삭제2"
+		},
+		{
+			"name": "preserves version-like double-tilde strikethrough",
+			"markdown": "v1~~deprecated 2~~v3",
+			"struckText": "deprecated 2"
+		},
+		{
+			"name": "preserves numeric-outer single-tilde strikethrough",
+			"markdown": "1~deleted 2~3",
+			"struckText": "deleted 2"
+		},
+		{
+			"name": "preserves numeric-outer double-tilde strikethrough",
+			"markdown": "1~~deleted 2~~3",
+			"struckText": "deleted 2"
+		}
+	]
+}

--- a/packages/client/src/components/shared/Editor/Editor.tsx
+++ b/packages/client/src/components/shared/Editor/Editor.tsx
@@ -1,9 +1,14 @@
 import { BlockNoteView } from '@blocknote/mantine';
 import { useCreateBlockNote } from '@blocknote/react';
-import { forwardRef, useImperativeHandle } from 'react';
+import { forwardRef, type ClipboardEvent as ReactClipboardEvent, useImperativeHandle } from 'react';
 import { uploadImage } from '~/apis/image.api';
 import schema, { CommandView, ReferenceView, TagView } from '~/components/schema';
 import { useToast } from '~/components/ui';
+import {
+    formatBlockNoteMarkdownForExport,
+    handleBlockNotePaste,
+    normalizeBlockNoteCopy,
+} from '~/modules/blocknote-clipboard';
 import {
     type MarkdownBlock,
     prepareBlocksForMarkdown,
@@ -38,6 +43,7 @@ const Editor = forwardRef<EditorRef, EditorProps>(({ content, currentNoteId, edi
         {
             schema,
             initialContent: (content && JSON.parse(content)) || undefined,
+            pasteHandler: (context) => handleBlockNotePaste(context),
             uploadFile: async (file, blockId) => {
                 const removePendingBlock = () => {
                     if (blockId && editor.getBlock(blockId)) {
@@ -74,7 +80,9 @@ const Editor = forwardRef<EditorRef, EditorProps>(({ content, currentNoteId, edi
                     prepared.blocks as Parameters<typeof editor.blocksToMarkdownLossy>[0],
                 );
 
-                return restoreTagPlaceholdersInMarkdown(markdown, prepared.placeholderToTag);
+                return formatBlockNoteMarkdownForExport(
+                    restoreTagPlaceholdersInMarkdown(markdown, prepared.placeholderToTag),
+                );
             },
             getHtml: () => {
                 return editor.blocksToHTMLLossy(editor.document);
@@ -82,8 +90,20 @@ const Editor = forwardRef<EditorRef, EditorProps>(({ content, currentNoteId, edi
         };
     });
 
+    const handleClipboardWrite = (event: ReactClipboardEvent) => {
+        normalizeBlockNoteCopy(event.clipboardData);
+    };
+
     return (
-        <BlockNoteView slashMenu={false} theme={theme} editor={editor} editable={editable} onChange={onChange}>
+        <BlockNoteView
+            slashMenu={false}
+            theme={theme}
+            editor={editor}
+            editable={editable}
+            onChange={onChange}
+            onCopy={handleClipboardWrite}
+            onCut={handleClipboardWrite}
+        >
             <CommandView editor={editor} />
             <ReferenceView
                 currentNoteId={currentNoteId}

--- a/packages/client/src/modules/blocknote-clipboard.spec.ts
+++ b/packages/client/src/modules/blocknote-clipboard.spec.ts
@@ -1,0 +1,440 @@
+// @vitest-environment node
+
+import { readFileSync } from 'node:fs';
+import { cleanHTMLToMarkdown } from '@blocknote/core';
+import { describe, expect, it, vi } from 'vitest';
+import {
+    formatBlockNoteMarkdownForClipboard,
+    formatBlockNoteMarkdownForExport,
+    handleBlockNotePaste,
+    markdownToHTMLWithLiteralNumericRanges,
+    normalizeBlockNoteCopy,
+} from './blocknote-clipboard';
+
+interface TildeContractCases {
+    literalNumericRanges: Array<{ markdown: string; name: string }>;
+    strikethrough: Array<{ markdown: string; name: string; struckText: string }>;
+}
+
+const tildeContractCases = JSON.parse(
+    readFileSync(new URL('../../../../fixtures/markdown-tilde-cases.json', import.meta.url), 'utf8'),
+) as TildeContractCases;
+
+describe('markdownToHTMLWithLiteralNumericRanges', () => {
+    it.each(tildeContractCases.literalNumericRanges)('$name', ({ markdown }) => {
+        const html = markdownToHTMLWithLiteralNumericRanges(markdown);
+
+        expect(html).toContain(markdown);
+        expect(html).not.toContain('<del>');
+    });
+
+    it.each(tildeContractCases.strikethrough)('$name', ({ markdown, struckText }) => {
+        const html = markdownToHTMLWithLiteralNumericRanges(markdown);
+
+        expect(html).toContain(`<del>${struckText}</del>`);
+    });
+
+    it('preserves an email autolink containing a numeric tilde range shape', () => {
+        const markdown = '<a1~b2@example.com>';
+
+        const html = markdownToHTMLWithLiteralNumericRanges(markdown);
+
+        expect(html).toBe('<p><a href="mailto:a1~b2@example.com">a1~b2@example.com</a></p>');
+    });
+
+    it('keeps numeric ranges literal inside angle-bracket text', () => {
+        const markdown = '<1~3> before <4~5>';
+
+        const html = markdownToHTMLWithLiteralNumericRanges(markdown);
+
+        expect(html).toBe('<p>&#x3C;1~3> before &#x3C;4~5></p>');
+    });
+
+    it('preserves text matching the internal tilde placeholder', () => {
+        const placeholder = '\uE000OBTILDE0\uE001';
+        const markdown = `literal ${placeholder} and 1~3 and 4~5`;
+
+        const html = markdownToHTMLWithLiteralNumericRanges(markdown);
+
+        expect(html).toBe(`<p>literal ${placeholder} and 1~3 and 4~5</p>`);
+    });
+
+    it('restores literal tildes in code and link destinations after BlockNote parses Markdown', () => {
+        const markdown = [
+            '`1~3 and 4~5`',
+            '',
+            '[Profile](https://example.com/ranges/1~3/4~5)',
+            '',
+            '```text',
+            '6~7 and 8~9',
+            '```',
+        ].join('\n');
+
+        const html = markdownToHTMLWithLiteralNumericRanges(markdown);
+
+        expect(html).toContain('<code>1~3 and 4~5</code>');
+        expect(html).toContain('href="https://example.com/ranges/1~3/4~5"');
+        expect(html).toContain('<pre><code data-language="text">6~7 and 8~9</code></pre>');
+    });
+});
+
+describe('formatBlockNoteMarkdownForClipboard', () => {
+    it('removes BlockNote serializer artifacts from readable Markdown', () => {
+        const serialized = cleanHTMLToMarkdown(
+            '<p>Prefix <strong>value!</strong>suffix. <a href="https://example.com/?first=1&amp;second=2">Reference</a></p>',
+        );
+
+        const markdown = formatBlockNoteMarkdownForClipboard(serialized);
+
+        expect(markdown).toBe('Prefix **value!**suffix. [Reference](https://example.com/?first=1&second=2)\n');
+    });
+
+    it('normalizes prose around inline code', () => {
+        const serialized = cleanHTMLToMarkdown(
+            '<p><code>x</code> Prefix <strong>value!</strong>suffix. <a href="https://example.com/?first=1&amp;second=2">Reference</a></p>',
+        );
+
+        const markdown = formatBlockNoteMarkdownForClipboard(serialized);
+
+        expect(markdown).toBe('`x` Prefix **value!**suffix. [Reference](https://example.com/?first=1&second=2)\n');
+    });
+
+    it('normalizes generated Markdown inside nested list items', () => {
+        const serialized =
+            '- Parent\n    - Prefix **value!**&#x73;uffix. [Reference](https://example.com/?first=1\\&second=2)\n';
+
+        const markdown = formatBlockNoteMarkdownForClipboard(serialized);
+
+        expect(markdown).toBe(
+            '- Parent\n    - Prefix **value!**suffix. [Reference](https://example.com/?first=1&second=2)\n',
+        );
+    });
+
+    it('leaves serializer-like text inside code unchanged', () => {
+        const markdown = [
+            '`**value!**&#x73;uffix [Reference](https://example.com/?first=1\\&second=2)`',
+            '',
+            '```markdown',
+            '**value!**&#x73;uffix [Reference](https://example.com/?first=1\\&second=2)',
+            '```',
+        ].join('\n');
+
+        const formatted = formatBlockNoteMarkdownForClipboard(markdown);
+
+        expect(formatted).toBe(markdown);
+    });
+
+    it('normalizes serializer artifacts after an unmatched backtick', () => {
+        const serialized = cleanHTMLToMarkdown(
+            '<p>literal ` marker <strong>value!</strong>suffix <a href="https://example.com/?first=1&amp;second=2">Reference</a></p>',
+        );
+
+        const markdown = formatBlockNoteMarkdownForClipboard(serialized);
+
+        expect(markdown).toBe('literal ` marker **value!**suffix [Reference](https://example.com/?first=1&second=2)\n');
+    });
+
+    it('matches inline-code delimiters by exact backtick-run length', () => {
+        const serialized = cleanHTMLToMarkdown(
+            '<p><code>a```b **value!**&amp;#x73;uffix</code> Prefix <strong>value!</strong>suffix</p>',
+        );
+
+        const markdown = formatBlockNoteMarkdownForClipboard(serialized);
+
+        expect(markdown).toBe('`a```b **value!**&#x73;uffix` Prefix **value!**suffix\n');
+    });
+
+    it('preserves a literal character reference after an unmatched attention marker', () => {
+        const markdown = 'Literal *&#x41; text';
+
+        const formatted = formatBlockNoteMarkdownForClipboard(markdown);
+
+        expect(formatted).toBe(markdown);
+    });
+
+    it('normalizes balanced and escaped parentheses in link destinations', () => {
+        const markdown = [
+            '[Balanced](https://example.com/a_(b)?first=1\\&second=2)',
+            '[Escaped](https://example.com/a\\)b?first=1\\&second=2)',
+        ].join(' ');
+
+        const formatted = formatBlockNoteMarkdownForClipboard(markdown);
+
+        expect(formatted).toBe(
+            [
+                '[Balanced](https://example.com/a_(b)?first=1&second=2)',
+                '[Escaped](https://example.com/a\\)b?first=1&second=2)',
+            ].join(' '),
+        );
+    });
+
+    it('leaves a long unmatched link destination unchanged', () => {
+        const markdown = `[Reference](https://example.com/${'\\('.repeat(10_000)}`;
+
+        const formatted = formatBlockNoteMarkdownForClipboard(markdown);
+
+        expect(formatted).toBe(markdown);
+    });
+});
+
+describe('formatBlockNoteMarkdownForExport', () => {
+    it('normalizes link destinations outside inline code', () => {
+        const markdown =
+            '`https://example.com/?first=1\\&second=2` [Reference](https://example.com/?first=1\\&second=2)\n';
+
+        const formatted = formatBlockNoteMarkdownForExport(markdown);
+
+        expect(formatted).toBe(
+            '`https://example.com/?first=1\\&second=2` [Reference](https://example.com/?first=1&second=2)\n',
+        );
+    });
+
+    it('normalizes link destinations after an unmatched backtick', () => {
+        const markdown = 'literal ` marker [Reference](https://example.com/?first=1\\&second=2)\n';
+
+        const formatted = formatBlockNoteMarkdownForExport(markdown);
+
+        expect(formatted).toBe('literal ` marker [Reference](https://example.com/?first=1&second=2)\n');
+    });
+});
+
+describe('normalizeBlockNoteCopy', () => {
+    it('keeps canonical Markdown in its MIME type and writes a readable plain-text form', () => {
+        const canonicalMarkdown = 'Prefix **value!**&#x73;uffix.';
+        const setData = vi.fn();
+        const clipboardData = {
+            getData: vi.fn(() => canonicalMarkdown),
+            setData,
+        };
+
+        normalizeBlockNoteCopy(clipboardData);
+
+        expect(setData).toHaveBeenCalledWith('text/markdown', canonicalMarkdown);
+        expect(setData).toHaveBeenCalledWith('text/plain', 'Prefix **value!**suffix.');
+    });
+
+    it('leaves the clipboard unchanged without serialized Markdown', () => {
+        const setData = vi.fn();
+        const clipboardData = {
+            getData: vi.fn(() => ''),
+            setData,
+        };
+
+        normalizeBlockNoteCopy(clipboardData);
+
+        expect(setData).not.toHaveBeenCalled();
+    });
+});
+
+describe('handleBlockNotePaste', () => {
+    it('parses plain Markdown containing numeric tilde ranges through the protected path', () => {
+        const pasteHTML = vi.fn();
+        const defaultPasteHandler = vi.fn();
+        const event = {
+            clipboardData: {
+                getData: vi.fn(() => '# Guide\n\nRanges are 1~3 and 4~5.'),
+                types: ['text/plain'],
+            },
+        } as unknown as ClipboardEvent;
+
+        const handled = handleBlockNotePaste({
+            event,
+            editor: {
+                getTextCursorPosition: () => ({ block: { type: 'paragraph' } }),
+                pasteHTML,
+            },
+            defaultPasteHandler,
+        });
+
+        expect(handled).toBe(true);
+        expect(pasteHTML).toHaveBeenCalledWith('<h1>Guide</h1>\n<p>Ranges are 1~3 and 4~5.</p>');
+        expect(defaultPasteHandler).not.toHaveBeenCalled();
+    });
+
+    it('keeps BlockNote default handling for ordinary Markdown', () => {
+        const defaultPasteHandler = vi.fn(() => true);
+        const event = {
+            clipboardData: {
+                getData: vi.fn(() => '# Guide\n\nKeep **important** text.'),
+                types: ['text/plain'],
+            },
+        } as unknown as ClipboardEvent;
+
+        const handled = handleBlockNotePaste({
+            event,
+            editor: {
+                getTextCursorPosition: () => ({ block: { type: 'paragraph' } }),
+                pasteHTML: vi.fn(),
+            },
+            defaultPasteHandler,
+        });
+
+        expect(handled).toBe(true);
+        expect(defaultPasteHandler).toHaveBeenCalledOnce();
+    });
+
+    it('uses an explicit Markdown clipboard representation', () => {
+        const pasteHTML = vi.fn();
+        const defaultPasteHandler = vi.fn();
+        const getData = vi.fn((type: string) =>
+            type === 'text/markdown' ? 'Ranges are 1~3 and 4~5.' : 'plain fallback',
+        );
+        const event = {
+            clipboardData: {
+                getData,
+                types: ['text/plain', 'text/markdown'],
+            },
+        } as unknown as ClipboardEvent;
+
+        const handled = handleBlockNotePaste({
+            event,
+            editor: {
+                getTextCursorPosition: () => ({ block: { type: 'paragraph' } }),
+                pasteHTML,
+            },
+            defaultPasteHandler,
+        });
+
+        expect(handled).toBe(true);
+        expect(getData).toHaveBeenCalledWith('text/markdown');
+        expect(pasteHTML).toHaveBeenCalledWith('<p>Ranges are 1~3 and 4~5.</p>');
+        expect(defaultPasteHandler).not.toHaveBeenCalled();
+    });
+
+    it('delegates paste handling inside code blocks', () => {
+        const defaultPasteHandler = vi.fn(() => true);
+        const event = {
+            clipboardData: {
+                getData: vi.fn(() => 'Ranges are 1~3 and 4~5.'),
+                types: ['text/plain'],
+            },
+        } as unknown as ClipboardEvent;
+
+        const handled = handleBlockNotePaste({
+            event,
+            editor: {
+                getTextCursorPosition: () => ({ block: { type: 'codeBlock' } }),
+                pasteHTML: vi.fn(),
+            },
+            defaultPasteHandler,
+        });
+
+        expect(handled).toBe(true);
+        expect(defaultPasteHandler).toHaveBeenCalledOnce();
+    });
+
+    it.each(['Files', 'blocknote/html', 'vscode-editor-data'])('delegates the %s clipboard representation', (type) => {
+        const defaultPasteHandler = vi.fn(() => true);
+        const event = {
+            clipboardData: {
+                getData: vi.fn(() => 'Ranges are 1~3 and 4~5.'),
+                types: [type, 'text/plain'],
+            },
+        } as unknown as ClipboardEvent;
+
+        const handled = handleBlockNotePaste({
+            event,
+            editor: {
+                getTextCursorPosition: () => ({ block: { type: 'paragraph' } }),
+                pasteHTML: vi.fn(),
+            },
+            defaultPasteHandler,
+        });
+
+        expect(handled).toBe(true);
+        expect(defaultPasteHandler).toHaveBeenCalledOnce();
+    });
+
+    it('keeps rich HTML priority for non-Markdown plain text containing numeric tilde ranges', () => {
+        const defaultPasteHandler = vi.fn(() => true);
+        const event = {
+            clipboardData: {
+                getData: vi.fn(() => 'Ranges are 1~3 and 4~5.'),
+                types: ['text/html', 'text/plain'],
+            },
+        } as unknown as ClipboardEvent;
+
+        handleBlockNotePaste({
+            event,
+            editor: {
+                getTextCursorPosition: () => ({ block: { type: 'paragraph' } }),
+                pasteHTML: vi.fn(),
+            },
+            defaultPasteHandler,
+        });
+
+        expect(defaultPasteHandler).toHaveBeenCalledOnce();
+    });
+
+    it('keeps Markdown priority over rich HTML for Markdown-looking plain text', () => {
+        const defaultPasteHandler = vi.fn();
+        const pasteHTML = vi.fn();
+        const event = {
+            clipboardData: {
+                getData: vi.fn(() => '# Guide\n\nRanges are 1~3 and 4~5.'),
+                types: ['text/html', 'text/plain'],
+            },
+        } as unknown as ClipboardEvent;
+
+        const handled = handleBlockNotePaste({
+            event,
+            editor: {
+                getTextCursorPosition: () => ({ block: { type: 'paragraph' } }),
+                pasteHTML,
+            },
+            defaultPasteHandler,
+        });
+
+        expect(handled).toBe(true);
+        expect(pasteHTML).toHaveBeenCalledWith('<h1>Guide</h1>\n<p>Ranges are 1~3 and 4~5.</p>');
+        expect(defaultPasteHandler).not.toHaveBeenCalled();
+    });
+
+    it('keeps Markdown priority over rich HTML for table-shaped plain text', () => {
+        const defaultPasteHandler = vi.fn();
+        const pasteHTML = vi.fn();
+        const markdown = ['| Range |', '| --- |', '| 1~3 |'].join('\n');
+        const event = {
+            clipboardData: {
+                getData: vi.fn(() => markdown),
+                types: ['text/html', 'text/plain'],
+            },
+        } as unknown as ClipboardEvent;
+
+        const handled = handleBlockNotePaste({
+            event,
+            editor: {
+                getTextCursorPosition: () => ({ block: { type: 'paragraph' } }),
+                pasteHTML,
+            },
+            defaultPasteHandler,
+        });
+
+        expect(handled).toBe(true);
+        expect(pasteHTML).toHaveBeenCalledOnce();
+        expect(defaultPasteHandler).not.toHaveBeenCalled();
+    });
+
+    it('delegates long malformed table-shaped plain text without backtracking', () => {
+        const defaultPasteHandler = vi.fn(() => true);
+        const markdown = `|${'a|'.repeat(10_000)}1~3`;
+        const event = {
+            clipboardData: {
+                getData: vi.fn(() => markdown),
+                types: ['text/html', 'text/plain'],
+            },
+        } as unknown as ClipboardEvent;
+
+        const handled = handleBlockNotePaste({
+            event,
+            editor: {
+                getTextCursorPosition: () => ({ block: { type: 'paragraph' } }),
+                pasteHTML: vi.fn(),
+            },
+            defaultPasteHandler,
+        });
+
+        expect(handled).toBe(true);
+        expect(defaultPasteHandler).toHaveBeenCalledOnce();
+    });
+});

--- a/packages/client/src/modules/blocknote-clipboard.ts
+++ b/packages/client/src/modules/blocknote-clipboard.ts
@@ -1,0 +1,536 @@
+import { markdownToHTML } from '@blocknote/core';
+
+interface BlockNotePasteEditor {
+    getTextCursorPosition: () => {
+        block: {
+            type: string;
+        };
+    };
+    pasteHTML: (html: string) => unknown;
+}
+
+interface BlockNotePasteContext {
+    event: ClipboardEvent;
+    editor: BlockNotePasteEditor;
+    defaultPasteHandler: () => boolean | undefined;
+}
+
+interface MarkdownClipboardData {
+    getData: (type: string) => string;
+    setData: (type: string, data: string) => void;
+}
+
+const MARKDOWN_FENCE_PATTERN = /^ {0,3}(`{3,}|~{3,})/;
+const MARKDOWN_ANGLE_BRACKET_TOKEN_PATTERN = /<[^<>\n]*>/g;
+const TILDE_RUN_PATTERN = /~+/g;
+const NUMERIC_ENDPOINT_TOKEN_CHARACTER_PATTERN = /[\p{L}\p{M}\p{N}\p{Sc}%‰.,+\-/:°℃℉µμ·²³^]/u;
+const NUMERIC_ENDPOINT_START_PATTERN = /^(?:[+-]?\p{Sc}?|\p{Sc}[+-]?)\p{N}/u;
+const NUMERIC_CHARACTER_REFERENCE_PATTERN = /&#(?:x[0-9a-f]+|\d+);/giu;
+const SPECIAL_PASTE_TYPES = new Set(['Files', 'blocknote/html', 'vscode-editor-data']);
+const NUMERIC_TILDE_RANGE_PLACEHOLDER_PREFIX = '\uE000OBTILDE';
+const NUMERIC_TILDE_RANGE_PLACEHOLDER_SUFFIX = '\uE001';
+
+// Keep this aligned with BlockNote's detectMarkdown helper so HTML/plain-text
+// clipboard priority remains unchanged when the protected path is needed.
+const BLOCKNOTE_NON_TABLE_MARKDOWN_DETECTION_PATTERNS = [
+    /(^|\n) {0,3}#{1,6} {1,8}[^\n]{1,64}\r?\n\r?\n\s{0,32}\S/,
+    /(_|__|\*|\*\*|~~|==|\+\+)(?!\s)(?:[^\s](?:.{0,62}[^\s])?|\S)(?=\1)/,
+    /\[[^\]]{1,128}\]\(https?:\/\/\S{1,999}\)/,
+    /(?:\s|^)`(?!\s)(?:[^\s`](?:[^`]{0,46}[^\s`])?|[^\s`])`([^\w]|$)/,
+    /(?:^|\n)\s{0,5}-\s{1}[^\n]+\n\s{0,15}-\s/,
+    /(?:^|\n)\s{0,5}\d+\.\s{1}[^\n]+\n\s{0,15}\d+\.\s/,
+    /\n{2} {0,3}-{2,48}\n{2}/,
+    /(?:\n|^)(```|~~~|\$\$)(?!`|~)[^\s]{0,64} {0,64}[^\n]{0,64}\n[\s\S]{0,9999}?\s*\1 {0,64}(?:\n+|$)/,
+    /(?:\n|^)(?!\s)\w[^\n]{0,64}\n(-|=)\1{0,64}\n\n\s{0,64}(\w|$)/,
+    /(?:^|(\r?\n\r?\n))( {0,3}>[^\n]{1,333}\n){1,999}($|(\r?\n))/,
+];
+
+const hasMarkdownTableRow = (markdown: string) => {
+    return markdown.split('\n').some((line) => {
+        const trimmedLine = line.trim();
+        return trimmedLine.length > 2 && trimmedLine.startsWith('|') && trimmedLine.endsWith('|');
+    });
+};
+
+const matchesBlockNoteMarkdownDetection = (markdown: string) => {
+    return (
+        BLOCKNOTE_NON_TABLE_MARKDOWN_DETECTION_PATTERNS.some((pattern) => pattern.test(markdown)) ||
+        hasMarkdownTableRow(markdown)
+    );
+};
+
+const splitMarkdownLineEnding = (line: string) => {
+    if (line.endsWith('\r\n')) {
+        return { body: line.slice(0, -2), ending: '\r\n' };
+    }
+
+    if (line.endsWith('\n') || line.endsWith('\r')) {
+        return { body: line.slice(0, -1), ending: line.slice(-1) };
+    }
+
+    return { body: line, ending: '' };
+};
+
+const countRepeatedCharacter = (value: string, start: number, character: string) => {
+    let cursor = start;
+
+    while (value[cursor] === character) {
+        cursor += 1;
+    }
+
+    return cursor - start;
+};
+
+const decodeNumericCharacterReference = (reference: string) => {
+    const value = reference.slice(2, -1);
+    const isHexadecimal = value[0]?.toLowerCase() === 'x';
+    const codePoint = Number.parseInt(isHexadecimal ? value.slice(1) : value, isHexadecimal ? 16 : 10);
+
+    if (!Number.isSafeInteger(codePoint) || codePoint < 0 || codePoint > 0x10ffff) {
+        return reference;
+    }
+
+    return String.fromCodePoint(codePoint);
+};
+
+const createNumericTildeRangePlaceholder = (markdown: string) => {
+    const decodedMarkdown = markdown.replace(NUMERIC_CHARACTER_REFERENCE_PATTERN, decodeNumericCharacterReference);
+    const lowercaseMarkdown = markdown.toLowerCase();
+    let index = 0;
+    let placeholder = `${NUMERIC_TILDE_RANGE_PLACEHOLDER_PREFIX}${index}${NUMERIC_TILDE_RANGE_PLACEHOLDER_SUFFIX}`;
+
+    while (
+        markdown.includes(placeholder) ||
+        lowercaseMarkdown.includes(encodeURIComponent(placeholder).toLowerCase()) ||
+        decodedMarkdown.includes(placeholder)
+    ) {
+        index += 1;
+        placeholder = `${NUMERIC_TILDE_RANGE_PLACEHOLDER_PREFIX}${index}${NUMERIC_TILDE_RANGE_PLACEHOLDER_SUFFIX}`;
+    }
+
+    return placeholder;
+};
+
+const isPotentialNumericTildeRangeRun = (value: string, start: number, end: number) => {
+    if (end - start > 2) {
+        return false;
+    }
+
+    return hasNumericEndpointBefore(value, start) && hasNumericEndpointAfter(value, end);
+};
+
+const findEndpointTokenBefore = (value: string, end: number) => {
+    let start = end;
+
+    while (start > 0 && NUMERIC_ENDPOINT_TOKEN_CHARACTER_PATTERN.test(value[start - 1] ?? '')) {
+        start -= 1;
+    }
+
+    return {
+        start,
+        token: value.slice(start, end),
+    };
+};
+
+const findEndpointTokenAfter = (value: string, start: number) => {
+    let end = start;
+
+    while (end < value.length && NUMERIC_ENDPOINT_TOKEN_CHARACTER_PATTERN.test(value[end] ?? '')) {
+        end += 1;
+    }
+
+    return value.slice(start, end);
+};
+
+const hasNumericEndpointBefore = (value: string, end: number) => {
+    const endpoint = findEndpointTokenBefore(value, end);
+
+    if (NUMERIC_ENDPOINT_START_PATTERN.test(endpoint.token)) {
+        return true;
+    }
+
+    if (!endpoint.token) {
+        return false;
+    }
+
+    let previousEnd = endpoint.start;
+
+    while (previousEnd > 0 && (value[previousEnd - 1] === ' ' || value[previousEnd - 1] === '\t')) {
+        previousEnd -= 1;
+    }
+
+    if (previousEnd === endpoint.start) {
+        return false;
+    }
+
+    return NUMERIC_ENDPOINT_START_PATTERN.test(findEndpointTokenBefore(value, previousEnd).token);
+};
+
+const hasNumericEndpointAfter = (value: string, start: number) => {
+    return NUMERIC_ENDPOINT_START_PATTERN.test(findEndpointTokenAfter(value, start));
+};
+
+const getNumericTildeRangeRuns = (value: string) => {
+    const numericRuns: Array<{ length: number; start: number }> = [];
+    const pendingNumericBoundaryStrikeOpeners = new Set<number>();
+
+    for (const match of value.matchAll(TILDE_RUN_PATTERN)) {
+        const start = match.index;
+        const length = match[0].length;
+        const end = start + length;
+
+        if (length > 2) {
+            continue;
+        }
+
+        const canOpen = end < value.length && !/\s/u.test(value[end] ?? '');
+        const canClose = start > 0 && !/\s/u.test(value[start - 1] ?? '');
+        const isNumericRange = isPotentialNumericTildeRangeRun(value, start, end);
+
+        if (isNumericRange) {
+            // Preserve a valid legacy strike atomically when only its closing
+            // delimiter also resembles a numeric range, e.g. 1~deleted 2~3.
+            if (canClose && pendingNumericBoundaryStrikeOpeners.delete(length)) {
+                continue;
+            }
+
+            numericRuns.push({ length, start });
+            continue;
+        }
+
+        if (canClose && pendingNumericBoundaryStrikeOpeners.delete(length)) {
+            continue;
+        }
+
+        if (canOpen && hasNumericEndpointBefore(value, start)) {
+            pendingNumericBoundaryStrikeOpeners.add(length);
+        }
+    }
+
+    return numericRuns;
+};
+
+const replaceNumericTildeRangeMarkers = (text: string, placeholder: string) => {
+    let result = '';
+    let cursor = 0;
+    const numericRunStarts = new Set(getNumericTildeRangeRuns(text).map((run) => run.start));
+
+    for (const match of text.matchAll(TILDE_RUN_PATTERN)) {
+        const start = match.index;
+        const end = start + match[0].length;
+        result += text.slice(cursor, start);
+        result += numericRunStarts.has(start) ? placeholder.repeat(match[0].length) : match[0];
+        cursor = end;
+    }
+
+    return result + text.slice(cursor);
+};
+
+const shouldKeepAngleBracketTokenUnchanged = (token: string) => {
+    const innerText = token.slice(1, -1);
+    const isAutolink =
+        /^[a-z][a-z0-9.+-]{1,31}:[^\s<>]*$/i.test(innerText) || /^[^\s@<>]+@[^\s@<>]+\.[^\s@<>]+$/.test(innerText);
+    const isHtmlTag = /^<\/?[a-z][\w:-]*(?:\s[^<>]*)?\/?\s*>$/i.test(token) || /^<![^<>]*>$/.test(token);
+
+    return isAutolink || isHtmlTag;
+};
+
+const protectNumericTildeRanges = (markdown: string, placeholder: string) => {
+    let result = '';
+    let cursor = 0;
+
+    for (const match of markdown.matchAll(MARKDOWN_ANGLE_BRACKET_TOKEN_PATTERN)) {
+        const matchStart = match.index;
+        result += replaceNumericTildeRangeMarkers(markdown.slice(cursor, matchStart), placeholder);
+        result += shouldKeepAngleBracketTokenUnchanged(match[0])
+            ? match[0]
+            : replaceNumericTildeRangeMarkers(match[0], placeholder);
+        cursor = matchStart + match[0].length;
+    }
+
+    return result + replaceNumericTildeRangeMarkers(markdown.slice(cursor), placeholder);
+};
+
+const hasNumericTildeRangeMarkers = (markdown: string) => {
+    return getNumericTildeRangeRuns(markdown).length > 0;
+};
+
+export const markdownToHTMLWithLiteralNumericRanges = (markdown: string) => {
+    if (!hasNumericTildeRangeMarkers(markdown)) {
+        return markdownToHTML(markdown);
+    }
+
+    const placeholder = createNumericTildeRangePlaceholder(markdown);
+    const protectedMarkdown = protectNumericTildeRanges(markdown, placeholder);
+    const encodedPlaceholder = encodeURIComponent(placeholder);
+
+    return markdownToHTML(protectedMarkdown).split(placeholder).join('~').split(encodedPlaceholder).join('~');
+};
+
+const isEscapedMarkdownCharacter = (value: string, index: number) => {
+    let precedingBackslashes = 0;
+
+    for (let cursor = index - 1; cursor >= 0 && value[cursor] === '\\'; cursor -= 1) {
+        precedingBackslashes += 1;
+    }
+
+    return precedingBackslashes % 2 === 1;
+};
+
+const findMatchingBacktickRunEnd = (line: string, start: number, delimiterLength: number) => {
+    let cursor = start + delimiterLength;
+
+    while (cursor < line.length) {
+        const candidate = line.indexOf('`', cursor);
+
+        if (candidate === -1) {
+            return null;
+        }
+
+        const candidateLength = countRepeatedCharacter(line, candidate, '`');
+
+        if (candidateLength === delimiterLength) {
+            return candidate + candidateLength;
+        }
+
+        cursor = candidate + candidateLength;
+    }
+
+    return null;
+};
+
+const findNextInlineCodeSpan = (line: string, cursor: number) => {
+    let codeStart = line.indexOf('`', cursor);
+
+    while (codeStart !== -1) {
+        const delimiterLength = countRepeatedCharacter(line, codeStart, '`');
+
+        if (!isEscapedMarkdownCharacter(line, codeStart)) {
+            const end = findMatchingBacktickRunEnd(line, codeStart, delimiterLength);
+
+            if (end !== null) {
+                return { start: codeStart, end };
+            }
+        }
+
+        codeStart = line.indexOf('`', codeStart + delimiterLength);
+    }
+
+    return null;
+};
+
+const transformMarkdownLineOutsideInlineCode = (line: string, transform: (text: string) => string) => {
+    let result = '';
+    let cursor = 0;
+
+    while (cursor < line.length) {
+        const codeSpan = findNextInlineCodeSpan(line, cursor);
+
+        if (!codeSpan) {
+            result += transform(line.slice(cursor));
+            break;
+        }
+
+        result += transform(line.slice(cursor, codeSpan.start));
+        result += line.slice(codeSpan.start, codeSpan.end);
+        cursor = codeSpan.end;
+    }
+
+    return result;
+};
+
+const transformSerializedMarkdownText = (markdown: string, transform: (text: string) => string) => {
+    let activeFence: { length: number; marker: '`' | '~' } | null = null;
+
+    return markdown
+        .split(/(?<=\n)/)
+        .map((line) => {
+            const { body, ending } = splitMarkdownLineEnding(line);
+
+            if (activeFence) {
+                const closingFencePattern = new RegExp(`^ {0,3}${activeFence.marker}{${activeFence.length},} *$`);
+
+                if (closingFencePattern.test(body)) {
+                    activeFence = null;
+                }
+
+                return line;
+            }
+
+            const openingFence = body.match(MARKDOWN_FENCE_PATTERN)?.[1];
+
+            if (openingFence) {
+                activeFence = {
+                    marker: openingFence[0] as '`' | '~',
+                    length: openingFence.length,
+                };
+                return line;
+            }
+
+            return `${transformMarkdownLineOutsideInlineCode(body, transform)}${ending}`;
+        })
+        .join('');
+};
+
+const findMarkdownLinkDestinationEnd = (markdown: string, destinationStart: number) => {
+    let parenthesisDepth = 0;
+
+    for (let cursor = destinationStart; cursor < markdown.length; cursor += 1) {
+        const character = markdown[cursor];
+
+        if (character === '\\') {
+            cursor += 1;
+            continue;
+        }
+
+        if (character === '(') {
+            parenthesisDepth += 1;
+            continue;
+        }
+
+        if (character !== ')') {
+            continue;
+        }
+
+        if (parenthesisDepth > 0) {
+            parenthesisDepth -= 1;
+            continue;
+        }
+
+        return cursor;
+    }
+
+    return null;
+};
+
+const normalizeLinkDestinations = (markdown: string) => {
+    let result = '';
+    let cursor = 0;
+
+    while (cursor < markdown.length) {
+        const destinationPrefix = markdown.indexOf('](', cursor);
+
+        if (destinationPrefix === -1) {
+            result += markdown.slice(cursor);
+            break;
+        }
+
+        const destinationStart = destinationPrefix + 2;
+        const destinationEnd = findMarkdownLinkDestinationEnd(markdown, destinationStart);
+
+        if (destinationEnd === null) {
+            result += markdown.slice(cursor);
+            break;
+        }
+
+        result += markdown.slice(cursor, destinationStart);
+        result += markdown.slice(destinationStart, destinationEnd).split('\\&').join('&');
+        result += ')';
+        cursor = destinationEnd + 1;
+    }
+
+    return result;
+};
+
+const hasMatchingAttentionDelimiterBefore = (source: string, boundary: number) => {
+    const marker = source[boundary - 1];
+
+    if (marker !== '*' && marker !== '_') {
+        return false;
+    }
+
+    let delimiterStart = boundary - 1;
+
+    while (delimiterStart > 0 && source[delimiterStart - 1] === marker) {
+        delimiterStart -= 1;
+    }
+
+    const delimiter = source.slice(delimiterStart, boundary);
+    const openingDelimiter = source.lastIndexOf(delimiter, delimiterStart - 1);
+
+    return openingDelimiter !== -1 && openingDelimiter + delimiter.length < delimiterStart;
+};
+
+const hasMatchingAttentionDelimiterAfter = (source: string, boundary: number) => {
+    const marker = source[boundary];
+
+    if (marker !== '*' && marker !== '_') {
+        return false;
+    }
+
+    let delimiterEnd = boundary + 1;
+
+    while (delimiterEnd < source.length && source[delimiterEnd] === marker) {
+        delimiterEnd += 1;
+    }
+
+    const delimiter = source.slice(boundary, delimiterEnd);
+    const closingDelimiter = source.indexOf(delimiter, delimiterEnd);
+
+    return closingDelimiter !== -1 && delimiterEnd < closingDelimiter;
+};
+
+const isGeneratedAttentionBoundary = (source: string, offset: number, referenceLength: number) => {
+    return (
+        hasMatchingAttentionDelimiterBefore(source, offset) ||
+        hasMatchingAttentionDelimiterAfter(source, offset + referenceLength)
+    );
+};
+
+export const formatBlockNoteMarkdownForClipboard = (markdown: string) => {
+    return transformSerializedMarkdownText(markdown, (text) => {
+        const readableReferences = text.replace(
+            NUMERIC_CHARACTER_REFERENCE_PATTERN,
+            (reference, offset: number, source: string) => {
+                return isGeneratedAttentionBoundary(source, offset, reference.length)
+                    ? decodeNumericCharacterReference(reference)
+                    : reference;
+            },
+        );
+
+        return normalizeLinkDestinations(readableReferences);
+    });
+};
+
+export const formatBlockNoteMarkdownForExport = (markdown: string) => {
+    return transformSerializedMarkdownText(markdown, normalizeLinkDestinations);
+};
+
+export const normalizeBlockNoteCopy = (clipboardData: MarkdownClipboardData) => {
+    const canonicalMarkdown = clipboardData.getData('text/plain');
+
+    if (!canonicalMarkdown) {
+        return;
+    }
+
+    clipboardData.setData('text/markdown', canonicalMarkdown);
+    clipboardData.setData('text/plain', formatBlockNoteMarkdownForClipboard(canonicalMarkdown));
+};
+
+export const handleBlockNotePaste = ({ event, editor, defaultPasteHandler }: BlockNotePasteContext) => {
+    const clipboardData = event.clipboardData;
+
+    if (!clipboardData || editor.getTextCursorPosition().block.type === 'codeBlock') {
+        return defaultPasteHandler();
+    }
+
+    const types = Array.from(clipboardData.types);
+
+    if (types.some((type) => SPECIAL_PASTE_TYPES.has(type))) {
+        return defaultPasteHandler();
+    }
+
+    const hasMarkdown = types.includes('text/markdown');
+    const markdown = clipboardData.getData(hasMarkdown ? 'text/markdown' : 'text/plain');
+
+    if (!markdown || !hasNumericTildeRangeMarkers(markdown)) {
+        return defaultPasteHandler();
+    }
+
+    if (!hasMarkdown && types.includes('text/html') && !matchesBlockNoteMarkdownDetection(markdown)) {
+        return defaultPasteHandler();
+    }
+
+    editor.pasteHTML(markdownToHTMLWithLiteralNumericRanges(markdown));
+    return true;
+};

--- a/packages/client/src/modules/note-export-download.spec.ts
+++ b/packages/client/src/modules/note-export-download.spec.ts
@@ -1,5 +1,7 @@
+import { cleanHTMLToMarkdown, markdownToHTML } from '@blocknote/core';
 import JSZip from 'jszip';
 import { describe, expect, it } from 'vitest';
+import { formatBlockNoteMarkdownForExport } from './blocknote-clipboard';
 import { createNoteExportBlob, getNoteExportOutputExtension } from './note-export-download';
 
 const metadata = {
@@ -53,6 +55,31 @@ describe('note-export-download', () => {
         expect(result.blob.type).toBe('text/markdown;charset=utf-8');
         expect(await result.blob.text()).toContain('Hello');
         expect(await result.blob.text()).not.toContain('/assets/images/');
+    });
+
+    it('keeps document-only markdown downloads portable at ambiguous emphasis boundaries', async () => {
+        const serialized = cleanHTMLToMarkdown(
+            '<p>Prefix <strong>value!</strong>suffix. <a href="https://example.com/?first=1&amp;second=2">Reference</a></p>',
+        );
+
+        const result = await createNoteExportBlob({
+            format: 'markdown',
+            includeAssets: false,
+            includeMetadata: false,
+            metadata,
+            source: {
+                getHtml: () => undefined,
+                getMarkdown: () => formatBlockNoteMarkdownForExport(serialized),
+            },
+        });
+
+        expect(result.type).toBe('success');
+        if (result.type !== 'success') return;
+        const markdown = await result.blob.text();
+        expect(markdown).toContain('&#x73;');
+        expect(markdownToHTML(markdown)).toContain('<strong>value!</strong>suffix.');
+        expect(markdown).toContain('[Reference](https://example.com/?first=1&second=2)');
+        expect(markdown).not.toContain('\\&');
     });
 
     it('creates a zip download blob when assets are included', async () => {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -10,8 +10,8 @@
         "start": "node dist/start.js",
         "lint": "biome check .",
         "format": "biome check --write .",
-        "test": "tsx --tsconfig tsconfig.json --test src/**/*.test.ts test/**/*.test.ts",
-        "test:ci": "tsx --tsconfig tsconfig.json --test src/**/*.test.ts test/**/*.test.ts",
+        "test": "tsx --tsconfig tsconfig.json --test \"src/**/*.test.ts\" \"test/**/*.test.ts\"",
+        "test:ci": "tsx --tsconfig tsconfig.json --test \"src/**/*.test.ts\" \"test/**/*.test.ts\"",
         "type-check": "tsc --noEmit"
     },
     "dependencies": {

--- a/packages/server/src/modules/blocknote.ts
+++ b/packages/server/src/modules/blocknote.ts
@@ -375,7 +375,10 @@ function replaceExplicitReferenceTokens(
 }
 
 const MARKDOWN_ANGLE_BRACKET_TOKEN_PATTERN = /<([^<>\n]+)>/g;
-const MARKDOWN_NUMERIC_TILDE_RANGE_PATTERN = /(\d)~(?=\d)/g;
+const TILDE_RUN_PATTERN = /~+/g;
+const NUMERIC_ENDPOINT_TOKEN_CHARACTER_PATTERN = /[\p{L}\p{M}\p{N}\p{Sc}%‰.,+\-/:°℃℉µμ·²³^]/u;
+const NUMERIC_ENDPOINT_START_PATTERN = /^(?:[+-]?\p{Sc}?|\p{Sc}[+-]?)\p{N}/u;
+const NUMERIC_CHARACTER_REFERENCE_PATTERN = /&#(?:x[0-9a-f]+|\d+);/giu;
 const MARKDOWN_FENCED_CODE_PATTERN = /^ {0,3}(`{3,}|~{3,})/;
 const ANGLE_BRACKET_PLACEHOLDER_PREFIX = '\uE000OBANGLE';
 const ANGLE_BRACKET_PLACEHOLDER_SUFFIX = '\uE001';
@@ -432,23 +435,52 @@ export function hasLiteralAngleBracketTextTokenLoss(sourceMarkdown: string, rend
     return false;
 }
 
-function countNumericTildeRangeMarkers(markdown: string) {
-    return [...markdown.matchAll(MARKDOWN_NUMERIC_TILDE_RANGE_PATTERN)].length;
+function getNumericTildeRangeRunSignatures(markdown: string) {
+    const normalizedMarkdown = markdown.replace(/\\(?=~)/g, '');
+    return getNumericTildeRangeRuns(normalizedMarkdown).map((run) => {
+        const leftEndpoint = getNumericEndpointBefore(normalizedMarkdown, run.start);
+        const rightEndpoint = getNumericEndpointAfter(normalizedMarkdown, run.start + run.length);
+
+        return JSON.stringify([leftEndpoint, run.length, rightEndpoint]);
+    });
 }
 
 export function hasNumericTildeRangeMarkers(markdown: string) {
-    return countNumericTildeRangeMarkers(markdown) > 0;
+    return getNumericTildeRangeRunSignatures(markdown).length > 0;
 }
 
 export function hasNumericTildeRangeMarkerLoss(sourceMarkdown: string, renderedMarkdown: string) {
-    const sourceCount = countNumericTildeRangeMarkers(sourceMarkdown);
+    const sourceRunSignatures = getNumericTildeRangeRunSignatures(sourceMarkdown);
 
-    return sourceCount > 0 && countNumericTildeRangeMarkers(renderedMarkdown) < sourceCount;
+    if (sourceRunSignatures.length === 0) {
+        return false;
+    }
+
+    const renderedRunSignatures = getNumericTildeRangeRunSignatures(renderedMarkdown);
+    let renderedIndex = 0;
+
+    for (const sourceRunSignature of sourceRunSignatures) {
+        while (
+            renderedIndex < renderedRunSignatures.length &&
+            renderedRunSignatures[renderedIndex] !== sourceRunSignature
+        ) {
+            renderedIndex += 1;
+        }
+
+        if (renderedIndex === renderedRunSignatures.length) {
+            return true;
+        }
+
+        renderedIndex += 1;
+    }
+
+    return false;
 }
 
 function protectMarkdownNumericTildeRanges(markdown: string) {
     const protectedLines: string[] = [];
     const placeholderToToken = new Map<string, string>();
+    const createPlaceholder = createNumericTildeRangePlaceholderFactory(markdown);
     let activeFence: { marker: '`' | '~'; length: number } | null = null;
 
     for (const line of markdown.split(/(?<=\n)/)) {
@@ -480,7 +512,9 @@ function protectMarkdownNumericTildeRanges(markdown: string) {
             continue;
         }
 
-        protectedLines.push(`${protectMarkdownLineNumericTildeRanges(lineBody, placeholderToToken)}${lineEnding}`);
+        protectedLines.push(
+            `${protectMarkdownLineNumericTildeRanges(lineBody, placeholderToToken, createPlaceholder)}${lineEnding}`,
+        );
     }
 
     return {
@@ -492,6 +526,11 @@ function protectMarkdownNumericTildeRanges(markdown: string) {
 function protectMarkdownLineEndHardBreakMarkers(markdown: string) {
     const protectedLines: string[] = [];
     const placeholderToToken = new Map<string, string>();
+    const createPlaceholder = createProtectedTextPlaceholderFactory(
+        markdown,
+        HARD_BREAK_PLACEHOLDER_PREFIX,
+        HARD_BREAK_PLACEHOLDER_SUFFIX,
+    );
     let activeFence: { marker: '`' | '~'; length: number } | null = null;
     const lines = markdown.split(/(?<=\n)/);
 
@@ -531,6 +570,7 @@ function protectMarkdownLineEndHardBreakMarkers(markdown: string) {
                 lineEnding,
                 isMarkdownHardBreakContinuationLine(nextLineBody),
                 placeholderToToken,
+                createPlaceholder,
             )}${lineEnding}`,
         );
     }
@@ -544,6 +584,11 @@ function protectMarkdownLineEndHardBreakMarkers(markdown: string) {
 function protectMarkdownTextAngleBrackets(markdown: string) {
     const protectedLines: string[] = [];
     const placeholderToToken = new Map<string, string>();
+    const createPlaceholder = createProtectedTextPlaceholderFactory(
+        markdown,
+        ANGLE_BRACKET_PLACEHOLDER_PREFIX,
+        ANGLE_BRACKET_PLACEHOLDER_SUFFIX,
+    );
     let activeFence: { marker: '`' | '~'; length: number } | null = null;
 
     for (const line of markdown.split(/(?<=\n)/)) {
@@ -575,7 +620,9 @@ function protectMarkdownTextAngleBrackets(markdown: string) {
             continue;
         }
 
-        protectedLines.push(`${protectMarkdownLineTextAngleBrackets(lineBody, placeholderToToken)}${lineEnding}`);
+        protectedLines.push(
+            `${protectMarkdownLineTextAngleBrackets(lineBody, placeholderToToken, createPlaceholder)}${lineEnding}`,
+        );
     }
 
     return {
@@ -610,37 +657,39 @@ function isClosingFenceLine(line: string, fence: { marker: '`' | '~'; length: nu
     return new RegExp(`^ {0,3}${escapedMarker}{${fence.length},} *$`).test(line);
 }
 
-function protectMarkdownLineTextAngleBrackets(line: string, placeholderToToken: Map<string, string>) {
+function protectMarkdownLineTextAngleBrackets(
+    line: string,
+    placeholderToToken: Map<string, string>,
+    createPlaceholder: () => string,
+) {
     let result = '';
     let cursor = 0;
 
     while (cursor < line.length) {
-        const codeStart = line.indexOf('`', cursor);
+        const codeSpan = findNextInlineCodeSpan(line, cursor);
 
-        if (codeStart === -1) {
-            result += replaceLiteralAngleBracketTextTokens(line.slice(cursor), placeholderToToken);
+        if (!codeSpan) {
+            result += replaceLiteralAngleBracketTextTokens(line.slice(cursor), placeholderToToken, createPlaceholder);
             break;
         }
 
-        result += replaceLiteralAngleBracketTextTokens(line.slice(cursor, codeStart), placeholderToToken);
-
-        const delimiterLength = countRepeatedCharacter(line, codeStart, '`');
-        const codeEnd = line.indexOf('`'.repeat(delimiterLength), codeStart + delimiterLength);
-
-        if (codeEnd === -1) {
-            result += replaceLiteralAngleBracketTextTokens(line.slice(codeStart), placeholderToToken);
-            break;
-        }
-
-        const codeEndExclusive = codeEnd + delimiterLength;
-        result += line.slice(codeStart, codeEndExclusive);
-        cursor = codeEndExclusive;
+        result += replaceLiteralAngleBracketTextTokens(
+            line.slice(cursor, codeSpan.start),
+            placeholderToToken,
+            createPlaceholder,
+        );
+        result += line.slice(codeSpan.start, codeSpan.end);
+        cursor = codeSpan.end;
     }
 
     return result;
 }
 
-function protectMarkdownLineNumericTildeRanges(line: string, placeholderToToken: Map<string, string>) {
+function protectMarkdownLineNumericTildeRanges(
+    line: string,
+    placeholderToToken: Map<string, string>,
+    createPlaceholder: () => string,
+) {
     let result = '';
     let cursor = 0;
 
@@ -648,11 +697,15 @@ function protectMarkdownLineNumericTildeRanges(line: string, placeholderToToken:
         const protectedSpan = findNextMarkdownProtectedSpan(line, cursor);
 
         if (!protectedSpan) {
-            result += replaceNumericTildeRangeMarkers(line.slice(cursor), placeholderToToken);
+            result += replaceNumericTildeRangeMarkers(line.slice(cursor), placeholderToToken, createPlaceholder);
             break;
         }
 
-        result += replaceNumericTildeRangeMarkers(line.slice(cursor, protectedSpan.start), placeholderToToken);
+        result += replaceNumericTildeRangeMarkers(
+            line.slice(cursor, protectedSpan.start),
+            placeholderToToken,
+            createPlaceholder,
+        );
         result += line.slice(protectedSpan.start, protectedSpan.end);
         cursor = protectedSpan.end;
     }
@@ -661,38 +714,37 @@ function protectMarkdownLineNumericTildeRanges(line: string, placeholderToToken:
 }
 
 function findNextMarkdownProtectedSpan(line: string, cursor: number) {
-    const codeSpan = findNextInlineCodeSpan(line, cursor);
-    const linkDestinationSpan = findNextMarkdownLinkDestinationSpan(line, cursor);
+    return [
+        findNextInlineCodeSpan(line, cursor),
+        findNextMarkdownLinkDestinationSpan(line, cursor),
+        findNextMarkdownAngleBracketSpan(line, cursor),
+    ].reduce<{ start: number; end: number } | null>((nextSpan, span) => {
+        if (!span || (nextSpan && nextSpan.start <= span.start)) {
+            return nextSpan;
+        }
 
-    if (!codeSpan) {
-        return linkDestinationSpan;
-    }
-
-    if (!linkDestinationSpan) {
-        return codeSpan;
-    }
-
-    return codeSpan.start <= linkDestinationSpan.start ? codeSpan : linkDestinationSpan;
+        return span;
+    }, null);
 }
 
 function findNextInlineCodeSpan(line: string, cursor: number) {
-    const codeStart = line.indexOf('`', cursor);
+    let codeStart = line.indexOf('`', cursor);
 
-    if (codeStart === -1) {
-        return null;
+    while (codeStart !== -1) {
+        const delimiterLength = countRepeatedCharacter(line, codeStart, '`');
+
+        if (!isEscapedMarkdownCharacter(line, codeStart)) {
+            const end = findMatchingBacktickRunEnd(line, codeStart, delimiterLength);
+
+            if (end !== null) {
+                return { start: codeStart, end };
+            }
+        }
+
+        codeStart = line.indexOf('`', codeStart + delimiterLength);
     }
 
-    const delimiterLength = countRepeatedCharacter(line, codeStart, '`');
-    const codeEnd = line.indexOf('`'.repeat(delimiterLength), codeStart + delimiterLength);
-
-    if (codeEnd === -1) {
-        return null;
-    }
-
-    return {
-        start: codeStart,
-        end: codeEnd + delimiterLength,
-    };
+    return null;
 }
 
 function findNextMarkdownLinkDestinationSpan(line: string, cursor: number) {
@@ -703,37 +755,196 @@ function findNextMarkdownLinkDestinationSpan(line: string, cursor: number) {
     }
 
     const destinationStart = linkDestinationPrefix + 2;
-    const destinationEnd = line.indexOf(')', destinationStart);
+    let parenthesisDepth = 0;
 
-    if (destinationEnd === -1) {
+    for (let destinationEnd = destinationStart; destinationEnd < line.length; destinationEnd += 1) {
+        const character = line[destinationEnd];
+
+        if (character === '\\') {
+            destinationEnd += 1;
+            continue;
+        }
+
+        if (character === '(') {
+            parenthesisDepth += 1;
+            continue;
+        }
+
+        if (character !== ')') {
+            continue;
+        }
+
+        if (parenthesisDepth > 0) {
+            parenthesisDepth -= 1;
+            continue;
+        }
+
+        return {
+            start: destinationStart,
+            end: destinationEnd,
+        };
+    }
+
+    return null;
+}
+
+function findNextMarkdownAngleBracketSpan(line: string, cursor: number) {
+    const start = line.indexOf('<', cursor);
+
+    if (start === -1) {
         return null;
     }
 
-    return {
-        start: destinationStart,
-        end: destinationEnd,
-    };
+    const end = line.indexOf('>', start + 1);
+
+    if (end === -1) {
+        return null;
+    }
+
+    return { start, end: end + 1 };
 }
 
-function replaceLiteralAngleBracketTextTokens(text: string, placeholderToToken: Map<string, string>) {
+function replaceLiteralAngleBracketTextTokens(
+    text: string,
+    placeholderToToken: Map<string, string>,
+    createPlaceholder: () => string,
+) {
     return text.replace(MARKDOWN_ANGLE_BRACKET_TOKEN_PATTERN, (match, innerText: string) => {
         if (isMarkdownAutolinkAngleBracketText(innerText)) {
             return match;
         }
 
-        const placeholder = createAngleBracketPlaceholder(placeholderToToken.size);
+        const placeholder = createPlaceholder();
         placeholderToToken.set(placeholder, match);
 
         return placeholder;
     });
 }
 
-function replaceNumericTildeRangeMarkers(text: string, placeholderToToken: Map<string, string>) {
-    return text.replace(MARKDOWN_NUMERIC_TILDE_RANGE_PATTERN, (match, leadingDigit: string) => {
-        const placeholder = createNumericTildeRangePlaceholder(placeholderToToken.size);
-        placeholderToToken.set(placeholder, '~');
+function isPotentialNumericTildeRangeRun(value: string, start: number, end: number) {
+    if (end - start > 2) {
+        return false;
+    }
 
-        return `${leadingDigit}${placeholder}`;
+    return getNumericEndpointBefore(value, start) !== null && getNumericEndpointAfter(value, end) !== null;
+}
+
+function findEndpointTokenBefore(value: string, end: number) {
+    let start = end;
+
+    while (start > 0 && NUMERIC_ENDPOINT_TOKEN_CHARACTER_PATTERN.test(value[start - 1] ?? '')) {
+        start -= 1;
+    }
+
+    return {
+        start,
+        token: value.slice(start, end),
+    };
+}
+
+function findEndpointTokenAfter(value: string, start: number) {
+    let end = start;
+
+    while (end < value.length && NUMERIC_ENDPOINT_TOKEN_CHARACTER_PATTERN.test(value[end] ?? '')) {
+        end += 1;
+    }
+
+    return value.slice(start, end);
+}
+
+function getNumericEndpointBefore(value: string, end: number) {
+    const endpoint = findEndpointTokenBefore(value, end);
+
+    if (NUMERIC_ENDPOINT_START_PATTERN.test(endpoint.token)) {
+        return endpoint.token;
+    }
+
+    if (!endpoint.token) {
+        return null;
+    }
+
+    let previousEnd = endpoint.start;
+
+    while (previousEnd > 0 && (value[previousEnd - 1] === ' ' || value[previousEnd - 1] === '\t')) {
+        previousEnd -= 1;
+    }
+
+    if (previousEnd === endpoint.start) {
+        return null;
+    }
+
+    const previousEndpoint = findEndpointTokenBefore(value, previousEnd);
+
+    return NUMERIC_ENDPOINT_START_PATTERN.test(previousEndpoint.token)
+        ? value.slice(previousEndpoint.start, end)
+        : null;
+}
+
+function getNumericEndpointAfter(value: string, start: number) {
+    const endpoint = findEndpointTokenAfter(value, start);
+    return NUMERIC_ENDPOINT_START_PATTERN.test(endpoint) ? endpoint : null;
+}
+
+function getNumericTildeRangeRuns(value: string) {
+    const numericRuns: Array<{ length: number; start: number }> = [];
+    const pendingNumericBoundaryStrikeOpeners = new Set<number>();
+
+    for (const match of value.matchAll(TILDE_RUN_PATTERN)) {
+        const start = match.index;
+        const length = match[0].length;
+        const end = start + length;
+
+        if (length > 2) {
+            continue;
+        }
+
+        const canOpen = end < value.length && !/\s/u.test(value[end] ?? '');
+        const canClose = start > 0 && !/\s/u.test(value[start - 1] ?? '');
+        const isNumericRange = isPotentialNumericTildeRangeRun(value, start, end);
+
+        if (isNumericRange) {
+            // Preserve a valid legacy strike atomically when only its closing
+            // delimiter also resembles a numeric range, e.g. 1~deleted 2~3.
+            if (canClose && pendingNumericBoundaryStrikeOpeners.delete(length)) {
+                continue;
+            }
+
+            numericRuns.push({ length, start });
+            continue;
+        }
+
+        if (canClose && pendingNumericBoundaryStrikeOpeners.delete(length)) {
+            continue;
+        }
+
+        if (canOpen && getNumericEndpointBefore(value, start) !== null) {
+            pendingNumericBoundaryStrikeOpeners.add(length);
+        }
+    }
+
+    return numericRuns;
+}
+
+function replaceNumericTildeRangeMarkers(
+    text: string,
+    placeholderToToken: Map<string, string>,
+    createPlaceholder: () => string,
+) {
+    const numericRunStarts = new Set(getNumericTildeRangeRuns(text).map((run) => run.start));
+
+    return text.replace(TILDE_RUN_PATTERN, (tildeRun: string, offset: number) => {
+        if (!numericRunStarts.has(offset)) {
+            return tildeRun;
+        }
+
+        return [...tildeRun]
+            .map(() => {
+                const placeholder = createPlaceholder();
+                placeholderToToken.set(placeholder, '~');
+
+                return placeholder;
+            })
+            .join('');
     });
 }
 
@@ -742,12 +953,13 @@ function protectMarkdownLineEndHardBreakMarker(
     lineEnding: string,
     hasContinuationLine: boolean,
     placeholderToToken: Map<string, string>,
+    createPlaceholder: () => string,
 ) {
     if (!lineEnding || !line.endsWith('\\')) {
         return line;
     }
 
-    const placeholder = createHardBreakPlaceholder(placeholderToToken.size);
+    const placeholder = createPlaceholder();
     const shouldPreserveAsHardBreak = hasContinuationLine && !hasUnclosedInlineCodeSpanAtLineEnd(line);
     placeholderToToken.set(placeholder, shouldPreserveAsHardBreak ? '\n' : '\\');
 
@@ -804,16 +1016,46 @@ function hasUnclosedInlineCodeSpanAtLineEnd(line: string) {
     return openDelimiter !== null;
 }
 
-function createAngleBracketPlaceholder(index: number) {
-    return `${ANGLE_BRACKET_PLACEHOLDER_PREFIX}${index}${ANGLE_BRACKET_PLACEHOLDER_SUFFIX}`;
+function decodeNumericCharacterReference(reference: string) {
+    const value = reference.slice(2, -1);
+    const isHexadecimal = value[0]?.toLowerCase() === 'x';
+    const codePoint = Number.parseInt(isHexadecimal ? value.slice(1) : value, isHexadecimal ? 16 : 10);
+
+    if (!Number.isSafeInteger(codePoint) || codePoint < 0 || codePoint > 0x10ffff) {
+        return reference;
+    }
+
+    return String.fromCodePoint(codePoint);
 }
 
-function createNumericTildeRangePlaceholder(index: number) {
-    return `${NUMERIC_TILDE_RANGE_PLACEHOLDER_PREFIX}${index}${NUMERIC_TILDE_RANGE_PLACEHOLDER_SUFFIX}`;
+function createNumericTildeRangePlaceholderFactory(markdown: string) {
+    return createProtectedTextPlaceholderFactory(
+        markdown,
+        NUMERIC_TILDE_RANGE_PLACEHOLDER_PREFIX,
+        NUMERIC_TILDE_RANGE_PLACEHOLDER_SUFFIX,
+    );
 }
 
-function createHardBreakPlaceholder(index: number) {
-    return `${HARD_BREAK_PLACEHOLDER_PREFIX}${index}${HARD_BREAK_PLACEHOLDER_SUFFIX}`;
+function createProtectedTextPlaceholderFactory(markdown: string, prefix: string, suffix: string) {
+    const decodedMarkdown = markdown.replace(NUMERIC_CHARACTER_REFERENCE_PATTERN, decodeNumericCharacterReference);
+    const lowercaseMarkdown = markdown.toLowerCase();
+    let index = 0;
+
+    return () => {
+        let placeholder = `${prefix}${index}${suffix}`;
+
+        while (
+            markdown.includes(placeholder) ||
+            lowercaseMarkdown.includes(encodeURIComponent(placeholder).toLowerCase()) ||
+            decodedMarkdown.includes(placeholder)
+        ) {
+            index += 1;
+            placeholder = `${prefix}${index}${suffix}`;
+        }
+
+        index += 1;
+        return placeholder;
+    };
 }
 
 function countRepeatedCharacter(value: string, start: number, character: string) {
@@ -824,6 +1066,38 @@ function countRepeatedCharacter(value: string, start: number, character: string)
     }
 
     return cursor - start;
+}
+
+function isEscapedMarkdownCharacter(value: string, index: number) {
+    let precedingBackslashes = 0;
+
+    for (let cursor = index - 1; cursor >= 0 && value[cursor] === '\\'; cursor -= 1) {
+        precedingBackslashes += 1;
+    }
+
+    return precedingBackslashes % 2 === 1;
+}
+
+function findMatchingBacktickRunEnd(line: string, start: number, delimiterLength: number) {
+    let cursor = start + delimiterLength;
+
+    while (cursor < line.length) {
+        const candidate = line.indexOf('`', cursor);
+
+        if (candidate === -1) {
+            return null;
+        }
+
+        const candidateLength = countRepeatedCharacter(line, candidate, '`');
+
+        if (candidateLength === delimiterLength) {
+            return candidate + candidateLength;
+        }
+
+        cursor = candidate + candidateLength;
+    }
+
+    return null;
 }
 
 function findTagPlaceholderAtCursor(text: string, cursor: number, placeholderToTag: Map<string, string>) {
@@ -882,12 +1156,7 @@ function restoreProtectedTextPlaceholders(blocks: BlockNote[], placeholderToToke
         return blocks;
     }
 
-    return mapBlocks(blocks, (content) =>
-        mapBlockContent(
-            content,
-            (inline) => restoreProtectedTextInValue(inline, placeholderToToken) as BlockNoteInline,
-        ),
-    );
+    return restoreProtectedTextInValue(blocks, placeholderToToken) as BlockNote[];
 }
 
 function restoreProtectedTextInValue(value: unknown, placeholderToToken: Map<string, string>): unknown {
@@ -922,6 +1191,10 @@ function restoreProtectedText(text: string, placeholderToToken: Map<string, stri
                 .join(`${placeholder}\r\n`);
         }
 
+        restoredText = restoredText.replace(
+            new RegExp(encodeURIComponent(placeholder), 'gi'),
+            encodeURIComponent(token),
+        );
         restoredText = restoredText.split(placeholder).join(token);
     }
 

--- a/packages/server/test/blocknote.test.ts
+++ b/packages/server/test/blocknote.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 import {
@@ -6,9 +7,20 @@ import {
     countReferenceInlinesFromContentJson,
     extractLiteralAngleBracketTextTokens,
     extractTagIdsFromContentJson,
+    hasNumericTildeRangeMarkerLoss,
+    hasNumericTildeRangeMarkers,
     hasUnsupportedMarkdownBlocks,
     markdownToBlocksJson,
 } from '../src/modules/blocknote.js';
+
+interface TildeContractCases {
+    literalNumericRanges: Array<{ markdown: string; name: string }>;
+    strikethrough: Array<{ markdown: string; name: string; struckText: string }>;
+}
+
+const tildeContractCases = JSON.parse(
+    readFileSync(new URL('../../../fixtures/markdown-tilde-cases.json', import.meta.url), 'utf8'),
+) as TildeContractCases;
 
 const noopMarkdownImportDeps = {
     ensureTag: async () => {
@@ -692,17 +704,40 @@ test('markdownToBlocksJson preserves Markdown autolinks while protecting spaced 
     assert.doesNotMatch(roundTripMarkdown, /&lt;/);
 });
 
-test('markdownToBlocksJson preserves numeric tilde ranges as plain text', async () => {
-    const markdown = 'Range is 1~3 and 4~5.';
+test('markdownToBlocksJson preserves numeric ranges inside angle-bracket text', async () => {
+    const markdown = '<1~3> before <4~5>';
 
-    const contentJson = await markdownToBlocksJson(markdown, {
-        ensureTag: async () => {
-            throw new Error('should not ensure tags');
-        },
-        findNotesByTitle: async () => [],
-    });
+    const contentJson = await markdownToBlocksJson(markdown, noopMarkdownImportDeps);
     const blocks = JSON.parse(contentJson);
     const roundTripMarkdown = await blocksToMarkdown(contentJson);
+
+    assert.equal(blocks[0].content[0].text, markdown);
+    assert.equal(blocks[0].content[0].styles.strike, undefined);
+    assert.equal(roundTripMarkdown.trim(), markdown);
+});
+
+for (const { markdown, name } of tildeContractCases.literalNumericRanges) {
+    test(`markdownToBlocksJson ${name} as plain text`, async () => {
+        const contentJson = await markdownToBlocksJson(markdown, noopMarkdownImportDeps);
+        const blocks = JSON.parse(contentJson);
+        const roundTripMarkdown = await blocksToMarkdown(contentJson);
+
+        assert.deepEqual(blocks[0].content, [
+            {
+                type: 'text',
+                text: markdown,
+                styles: {},
+            },
+        ]);
+        assert.equal(roundTripMarkdown.trim(), markdown);
+    });
+}
+
+test('markdownToBlocksJson preserves text matching its internal tilde placeholder', async () => {
+    const markdown = 'literal \uE000OBTILDE0\uE001 and 1~3 and 4~5';
+
+    const contentJson = await markdownToBlocksJson(markdown, noopMarkdownImportDeps);
+    const blocks = JSON.parse(contentJson);
 
     assert.deepEqual(blocks[0].content, [
         {
@@ -711,7 +746,64 @@ test('markdownToBlocksJson preserves numeric tilde ranges as plain text', async 
             styles: {},
         },
     ]);
-    assert.equal(roundTripMarkdown.trim(), markdown);
+});
+
+test('markdownToBlocksJson preserves encoded text matching its internal tilde placeholder', async () => {
+    const encodedPlaceholder = '%ee%80%80OBTILDE0%ee%80%81';
+    const markdown = `1~3 [literal](https://example.com/${encodedPlaceholder})`;
+
+    const contentJson = await markdownToBlocksJson(markdown, noopMarkdownImportDeps);
+    const blocks = JSON.parse(contentJson);
+
+    assert.equal(blocks[0].content[1].href, `https://example.com/${encodedPlaceholder}`);
+    assert.equal(blocks[0].content[0].text, '1~3 ');
+});
+
+test('markdownToBlocksJson restores numeric ranges in bare URL destinations', async () => {
+    const markdown = 'https://example.com/?range=1~3&other=4~5';
+
+    const contentJson = await markdownToBlocksJson(markdown, noopMarkdownImportDeps);
+    const blocks = JSON.parse(contentJson);
+    const roundTripMarkdown = await blocksToMarkdown(contentJson);
+
+    assert.equal(blocks[0].content[0].href, markdown);
+    assert.doesNotMatch(JSON.stringify(blocks), /OBTILDE/);
+    assert.doesNotMatch(roundTripMarkdown, /OBTILDE/);
+});
+
+test('markdownToBlocksJson protects balanced link destinations containing numeric ranges', async () => {
+    const destination = 'https://example.com/a(b)c/1~3/4~5';
+    const markdown = `[Range](${destination})`;
+
+    const contentJson = await markdownToBlocksJson(markdown, noopMarkdownImportDeps);
+    const blocks = JSON.parse(contentJson);
+    const roundTripMarkdown = await blocksToMarkdown(contentJson);
+
+    assert.equal(blocks[0].content[0].href, destination);
+    assert.doesNotMatch(JSON.stringify(blocks), /OBTILDE/);
+    assert.doesNotMatch(roundTripMarkdown, /OBTILDE/);
+});
+
+test('markdownToBlocksJson keeps angle placeholder-shaped image names literal', async () => {
+    const placeholder = '\uE000OBANGLE0\uE001';
+    const markdown = `![literal ${placeholder}](https://example.com/x.png)\n\nKeep <MARKER> text.`;
+
+    const contentJson = await markdownToBlocksJson(markdown, noopMarkdownImportDeps);
+    const blocks = JSON.parse(contentJson);
+
+    assert.equal(blocks[0].props.name, `literal ${placeholder}`);
+    assert.equal(blocks[1].content[0].text, 'Keep <MARKER> text.');
+});
+
+test('markdownToBlocksJson keeps hard-break placeholder-shaped image names literal', async () => {
+    const placeholder = '\uE000OBHARDBREAK0\uE001';
+    const markdown = `![literal ${placeholder}](https://example.com/x.png)\n\nline one\\\nline two`;
+
+    const contentJson = await markdownToBlocksJson(markdown, noopMarkdownImportDeps);
+    const blocks = JSON.parse(contentJson);
+
+    assert.equal(blocks[0].props.name, `literal ${placeholder}`);
+    assert.equal(blocks[1].content[0].text, 'line one\nline two');
 });
 
 test('markdownToBlocksJson preserves numeric tilde ranges across hard break lines', async () => {
@@ -825,39 +917,19 @@ test('markdownToBlocksJson preserves trailing backslashes inside multiline inlin
     assert.match(renderedMarkdown, /foo\\ bar/);
 });
 
-test('markdownToBlocksJson preserves double-tilde strikethrough', async () => {
-    const markdown = 'Keep ~~strike~~ text';
+for (const { markdown, name, struckText } of tildeContractCases.strikethrough) {
+    test(`markdownToBlocksJson ${name}`, async () => {
+        const contentJson = await markdownToBlocksJson(markdown, noopMarkdownImportDeps);
+        const blocks = JSON.parse(contentJson);
+        const roundTripMarkdown = await blocksToMarkdown(contentJson);
+        const struckContent = blocks[0].content.find(
+            (inline: { styles?: { strike?: boolean }; text?: string }) => inline.styles?.strike,
+        );
 
-    const contentJson = await markdownToBlocksJson(markdown, {
-        ensureTag: async () => {
-            throw new Error('should not ensure tags');
-        },
-        findNotesByTitle: async () => [],
+        assert.equal(struckContent?.text, struckText);
+        assert.ok(roundTripMarkdown.includes(`~~${struckText}~~`));
     });
-    const blocks = JSON.parse(contentJson);
-    const roundTripMarkdown = await blocksToMarkdown(contentJson);
-
-    assert.deepEqual(blocks[0].content, [
-        {
-            type: 'text',
-            text: 'Keep ',
-            styles: {},
-        },
-        {
-            type: 'text',
-            text: 'strike',
-            styles: {
-                strike: true,
-            },
-        },
-        {
-            type: 'text',
-            text: ' text',
-            styles: {},
-        },
-    ]);
-    assert.equal(roundTripMarkdown.trim(), markdown);
-});
+}
 
 test('markdownToBlocksJson leaves numeric tilde ranges unchanged inside code', async () => {
     const markdown = ['Code is `1~3 and 4~5`.', '', '~~~', '1~3 and 4~5', '~~~'].join('\n');
@@ -889,6 +961,82 @@ test('markdownToBlocksJson restores numeric tilde ranges in link destinations', 
 
     assert.equal(blocks[0].content[0].href, 'https://example.com/range/1~3');
     assert.equal(roundTripMarkdown.trim(), markdown);
+});
+
+test('markdownToBlocksJson restores numeric tilde ranges in image names', async () => {
+    const markdown = '![1~3 and 4~5](https://example.com/ranges.png)';
+
+    const contentJson = await markdownToBlocksJson(markdown, noopMarkdownImportDeps);
+    const blocks = JSON.parse(contentJson);
+    const roundTripMarkdown = await blocksToMarkdown(contentJson);
+
+    assert.equal(blocks[0].props.name, '1~3 and 4~5');
+    assert.doesNotMatch(blocks[0].props.name, /OBTILDE/);
+    assert.doesNotMatch(roundTripMarkdown, /OBTILDE/);
+    assert.equal(hasNumericTildeRangeMarkerLoss(markdown, roundTripMarkdown), false);
+});
+
+test('numeric tilde range loss detection accepts portable backslash escapes', () => {
+    assert.equal(hasNumericTildeRangeMarkerLoss('1~3 and 4~5', '1\\~3 and 4\\~5'), false);
+    assert.equal(hasNumericTildeRangeMarkerLoss('1~~3 and 4~~5', '1\\~\\~3 and 4\\~\\~5'), false);
+});
+
+test('numeric tilde range loss detection rejects changed delimiter lengths', () => {
+    assert.equal(hasNumericTildeRangeMarkerLoss('1~3 and 4~5', '1~~3 and 4~~5'), true);
+    assert.equal(hasNumericTildeRangeMarkerLoss('1~~3 and 4~~5', '1~3 and 4~5'), true);
+    assert.equal(hasNumericTildeRangeMarkerLoss('1~3 and 4~~5', '1~~3 and 4~5'), true);
+});
+
+test('numeric tilde range loss detection rejects changed endpoints', () => {
+    assert.equal(hasNumericTildeRangeMarkerLoss('1~3 and 4~5', '1~4 and 4~5'), true);
+    assert.equal(hasNumericTildeRangeMarkerLoss('10 kg~20 kg', '10 kg~30 kg'), true);
+});
+
+test('numeric tilde range loss detection accepts duplicated link representations', () => {
+    const sourceMarkdown = 'https://example.com/?range=1~3';
+
+    assert.equal(hasNumericTildeRangeMarkers(sourceMarkdown), true);
+    assert.equal(
+        hasNumericTildeRangeMarkerLoss(
+            sourceMarkdown,
+            '[https://example.com/?range=1~3](https://example.com/?range=1~3)',
+        ),
+        false,
+    );
+});
+
+test('markdownToBlocksJson leaves nonnumeric tildes in image names unchanged', async () => {
+    const markdown = '![a~b](https://example.com/ranges.png)';
+
+    const contentJson = await markdownToBlocksJson(markdown, noopMarkdownImportDeps);
+    const blocks = JSON.parse(contentJson);
+
+    assert.equal(blocks[0].props.name, 'a~b');
+    assert.doesNotMatch(JSON.stringify(blocks), /OBTILDE/);
+});
+
+test('markdownToBlocksJson preserves email autolinks containing tildes', async () => {
+    const markdown = '<a1~b2@example.com>';
+
+    const contentJson = await markdownToBlocksJson(markdown, noopMarkdownImportDeps);
+    const blocks = JSON.parse(contentJson);
+    const roundTripMarkdown = await blocksToMarkdown(contentJson);
+
+    assert.equal(blocks[0].content[0].type, 'link');
+    assert.equal(blocks[0].content[0].href, 'mailto:a1~b2@example.com');
+    assert.equal(roundTripMarkdown.trim(), markdown);
+});
+
+test('markdownToBlocksJson matches inline-code delimiters by exact backtick-run length', async () => {
+    const markdown = '`a```b 1~3 and 4~5` outside 6~7 and 8~9';
+
+    const contentJson = await markdownToBlocksJson(markdown, noopMarkdownImportDeps);
+    const blocks = JSON.parse(contentJson);
+
+    assert.equal(blocks[0].content[0].text, 'a```b 1~3 and 4~5');
+    assert.equal(blocks[0].content[0].styles.code, true);
+    assert.equal(blocks[0].content.at(-1).text, ' outside 6~7 and 8~9');
+    assert.equal(blocks[0].content.at(-1).styles.strike, undefined);
 });
 
 test('extractLiteralAngleBracketTextTokens ignores Markdown autolinks', () => {


### PR DESCRIPTION
## :dart: Goal
- Keep numeric tilde ranges literal when Markdown is pasted or imported into notes.
- Restore readable clipboard output while preserving portable Markdown semantics and existing strikethrough behavior.

## :hammer_and_wrench: Core Changes
- Add a focused BlockNote clipboard adapter for protected range paste, readable plain-text copy, canonical Markdown MIME output, and export normalization.
- Replace backtracking-prone link and table detection expressions with linear scans for untrusted clipboard input.
- Harden server-side Markdown import with collision-safe placeholders, balanced link destination handling, and numeric-range loss detection.
- Add shared English regression fixtures covering numeric ranges, units, dates, comma-separated values, and legacy strikethrough cases.
- Update the server test scripts so nested source and test suites are included in local and CI runs.

## :brain: Key Decisions
- Continue using BlockNote as the Markdown parser and isolate compatibility handling around ambiguous tilde ranges.
- Keep text/plain readable for copy workflows while retaining canonical entities in text/markdown and exports where they protect emphasis boundaries.
- Preserve existing single- and double-tilde strikethrough behavior and treat this as a backward-compatible patch.

## :test_tube: Verification Guide
### How to verify
1. Run pnpm check:encoding, pnpm lint, pnpm test:ci, pnpm type-check, and pnpm build.
2. Paste Markdown containing comma-separated numeric tilde ranges into a note and confirm the ranges remain literal instead of becoming strikethrough.
3. Copy the pasted note again and confirm plain text is readable, then export and re-import Markdown to confirm formatting is preserved.

### Expected result
- Encoding, lint, type-check, and build complete successfully.
- Client 300 tests, server 333 tests, and CLI 25 tests pass.
- Numeric tilde ranges remain literal, legacy strikethrough remains formatted, and no internal placeholder leaks into copied or exported content.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (not needed for this backward-compatible bug fix)