### PR TITLE
🐛 Reject compressed request bodies

### DIFF
--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -24,8 +24,8 @@ export const createAppWithMcpAuth = (authConfig: AuthConfig, mcpAdminService: Mc
 
     app.use(logger)
         .use(createSessionMiddleware(authConfig))
-        .use(express.urlencoded({ extended: false }))
-        .use(express.json({ limit: '50mb' }))
+        .use(express.urlencoded({ extended: false, inflate: false }))
+        .use(express.json({ limit: '50mb', inflate: false }))
         .use('/api', createApiRouter(authConfig, mcpAdminService))
         .use(createAuthPagesRouter(authConfig))
         .use('/graphql', createGraphqlRouter(authConfig, mcpAdminService))

--- a/packages/server/src/modules/error-handler.ts
+++ b/packages/server/src/modules/error-handler.ts
@@ -18,6 +18,9 @@ export const createAppError = (status: number, code: string, message: string, de
     return new AppError(status, code, message, details);
 };
 
+const hasErrorType = (error: unknown, type: string) =>
+    error instanceof Error && 'type' in error && (error as Error & { type?: unknown }).type === type;
+
 export const createErrorHandler = (): ErrorRequestHandler => {
     return (error, _req, res, next) => {
         if (res.headersSent) {
@@ -31,6 +34,16 @@ export const createErrorHandler = (): ErrorRequestHandler => {
                     code: error.code,
                     message: error.message,
                     ...(error.details ? { details: error.details } : {}),
+                })
+                .end();
+            return;
+        }
+
+        if (hasErrorType(error, 'encoding.unsupported')) {
+            res.status(415)
+                .json({
+                    code: 'UNSUPPORTED_CONTENT_ENCODING',
+                    message: 'Compressed request bodies are not supported.',
                 })
                 .end();
             return;

--- a/packages/server/test/request-body.test.ts
+++ b/packages/server/test/request-body.test.ts
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict';
+import type { AddressInfo } from 'node:net';
+import test from 'node:test';
+import { gzipSync } from 'node:zlib';
+import { createApp } from '../src/app.js';
+import { AUTH_SESSION_COOKIE_NAME, type AuthConfig } from '../src/modules/auth-mode.js';
+
+const passwordAuthConfig: AuthConfig = {
+    mode: 'password',
+    password: 'secret',
+    sessionSecret: 'session-secret',
+    cookieName: AUTH_SESSION_COOKIE_NAME,
+    source: 'password',
+};
+
+test('server rejects compressed JSON request bodies before authentication', async (t) => {
+    const app = createApp(passwordAuthConfig);
+    const server = app.listen(0);
+
+    await new Promise<void>((resolve, reject) => {
+        server.once('listening', resolve);
+        server.once('error', reject);
+    });
+
+    t.after(async () => {
+        await new Promise<void>((resolve, reject) => {
+            server.close((error) => {
+                if (error) {
+                    reject(error);
+                    return;
+                }
+
+                resolve();
+            });
+        });
+    });
+
+    const address = server.address() as AddressInfo;
+    const expandedBody = JSON.stringify({ padding: 'a'.repeat(8 * 1024 * 1024) });
+    const compressedBody = gzipSync(expandedBody);
+
+    assert.ok(compressedBody.length < 16 * 1024);
+
+    const response = await fetch(`http://127.0.0.1:${address.port}/api/image`, {
+        method: 'POST',
+        headers: {
+            'Content-Encoding': 'gzip',
+            'Content-Type': 'application/json',
+        },
+        body: compressedBody,
+    });
+    const body = (await response.json()) as Record<string, unknown>;
+
+    assert.equal(response.status, 415);
+    assert.deepEqual(body, {
+        code: 'UNSUPPORTED_CONTENT_ENCODING',
+        message: 'Compressed request bodies are not supported.',
+    });
+});


### PR DESCRIPTION
## :dart: Goal
- Prevent unauthenticated clients from forcing the server to inflate highly compressed request bodies before authentication.
- Return a stable client error for request compression that Ocean Brain does not support.

## :hammer_and_wrench: Core Changes
- Disable automatic inflation for JSON and URL-encoded request parsers while preserving existing uncompressed payload limits.
- Map unsupported request content encodings to a structured `415 UNSUPPORTED_CONTENT_ENCODING` response.
- Add an English integration regression test using a small gzip payload that expands to more than 8 MiB.

## :brain: Key Decisions
- Reject compressed request bodies instead of adding route-specific decompression because the web client, MCP CLI, and public documentation do not use request compression.
- Keep the existing 50 MiB limit for uncompressed JSON so image uploads and current API behavior remain backward compatible.
- Treat reverse-proxy response compression as unrelated; Nginx, Caddy, or other proxies can continue compressing responses normally.

## :test_tube: Verification Guide
### How to verify
1. Run `pnpm --filter @ocean-brain/server exec tsx --tsconfig tsconfig.json --test test/request-body.test.ts`.
2. Run `pnpm test:ci`.
3. Run `pnpm check:encoding`, `pnpm lint`, `pnpm type-check`, and `pnpm build`.

### Expected result
- A gzip-compressed JSON request is rejected with HTTP 415 before authentication, and all existing tests and quality checks pass.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (not needed; compressed request bodies were not a documented contract)
