### PR TITLE
🐛 Normalize hidden whitespace in Markdown patches

### DIFF
--- a/packages/server/src/features/note/services/markdown-intent-write.test.ts
+++ b/packages/server/src/features/note/services/markdown-intent-write.test.ts
@@ -79,6 +79,63 @@ test('markdown intent write applies an exact text patch through guarded update a
     });
 });
 
+test('markdown intent write patches displayed text when stored Markdown contains hidden spaces', async () => {
+    const updates: unknown[] = [];
+    const service = createMarkdownIntentWriteService({
+        findNoteById: async () => createNote({ content: '* [[Example]](note:1) — **Search\u00a0result&#x20;line**' }),
+        renderMarkdown: async (content) => content,
+        parseMarkdownToContentJson: async (markdown) => `json:${markdown}`,
+        extractTagIds: () => [],
+        updateNote: async (input) => {
+            updates.push(input);
+            return {
+                note: {
+                    id: input.id,
+                    title: 'Existing',
+                    content: input.data.content ?? '',
+                    layout: 'wide',
+                    pinned: false,
+                    order: 0,
+                    createdAt: new Date('2026-05-28T00:00:00.000Z'),
+                    updatedAt: new Date('2026-05-28T00:00:01.000Z'),
+                },
+                snapshot: {
+                    id: '12',
+                    createdAt: new Date('2026-05-28T00:00:00.500Z'),
+                    meta: { label: 'MCP' },
+                },
+            };
+        },
+    });
+
+    const result = await service.patchNoteMarkdown({
+        id: 7,
+        expectedUpdatedAt: '2026-05-28T00:00:00.000Z',
+        intent: 'Replace displayed text',
+        selector: {
+            type: 'exact_text',
+            text: '**Search result line**',
+        },
+        operation: {
+            type: 'replace',
+            replacement: '**Updated result line**',
+        },
+    });
+
+    assert.equal(result.status, 'applied');
+    assert.deepEqual(updates, [
+        {
+            id: 7,
+            data: {
+                content: 'json:* [[Example]](note:1) — **Updated result line**',
+                tagIds: [],
+            },
+            expectedUpdatedAt: '2026-05-28T00:00:00.000Z',
+            snapshotMeta: '{"entrypoint":"mcp","label":"MCP"}',
+        },
+    ]);
+});
+
 test('markdown intent write refuses apply when the note changed after the expected baseline', async () => {
     const service = createMarkdownIntentWriteService({
         findNoteById: async () => createNote({ updatedAt: new Date('2026-05-28T00:00:02.000Z') }),

--- a/packages/server/src/features/note/services/markdown-patch.test.ts
+++ b/packages/server/src/features/note/services/markdown-patch.test.ts
@@ -83,6 +83,92 @@ test('markdown patch plan fails when exact text is missing', () => {
     });
 });
 
+test('markdown patch plan matches displayed text across encoded and special spaces', () => {
+    const result = buildMarkdownPatchPlan({
+        note: {
+            ...note,
+            markdown: '* [[Example]](note:1) — **Search\u00a0result&#x20;line**',
+        },
+        expectedUpdatedAt: note.updatedAt,
+        intent: 'Replace the displayed bold text',
+        selector: {
+            type: 'exact_text',
+            text: '**Search result line**',
+        },
+        operation: {
+            type: 'replace',
+            replacement: '**Updated result line**',
+        },
+    });
+
+    assert.equal(result.status, 'planned');
+
+    if (result.status !== 'planned') {
+        throw new Error('expected planned result');
+    }
+
+    assert.equal(result.afterMarkdown, '* [[Example]](note:1) — **Updated result line**');
+});
+
+test('markdown patch plan keeps visually identical normalized matches ambiguous', () => {
+    const firstPlan = buildMarkdownPatchPlan({
+        note: {
+            ...note,
+            markdown: 'Same text\nSame\u00a0text',
+        },
+        expectedUpdatedAt: note.updatedAt,
+        intent: 'Replace only the second displayed line',
+        selector: {
+            type: 'exact_text',
+            text: 'Same text',
+        },
+        operation: {
+            type: 'replace',
+            replacement: 'Updated text',
+        },
+    });
+
+    assert.equal(firstPlan.status, 'needs_disambiguation');
+
+    if (firstPlan.status !== 'needs_disambiguation') {
+        throw new Error('expected needs_disambiguation result');
+    }
+
+    const selected = firstPlan.matches[1];
+
+    assert.ok(selected);
+
+    const result = buildMarkdownPatchPlan({
+        note: {
+            ...note,
+            markdown: 'Same text\nSame\u00a0text',
+        },
+        expectedUpdatedAt: note.updatedAt,
+        intent: 'Replace only the second displayed line',
+        selector: {
+            type: 'match_candidate',
+            text: selected.text,
+            matchIndex: selected.matchIndex,
+            lineStart: selected.lineStart,
+            matchSha256: selected.matchSha256,
+            surroundingHash: selected.surroundingHash,
+            positionHint: selected.positionHint,
+        },
+        operation: {
+            type: 'replace',
+            replacement: 'Updated text',
+        },
+    });
+
+    assert.equal(result.status, 'planned');
+
+    if (result.status !== 'planned') {
+        throw new Error('expected planned result');
+    }
+
+    assert.equal(result.afterMarkdown, 'Same text\nUpdated text');
+});
+
 test('markdown patch plan accepts epoch millisecond baselines from GraphQL clients', () => {
     const result = buildMarkdownPatchPlan({
         note: {

--- a/packages/server/src/features/note/services/markdown-patch.ts
+++ b/packages/server/src/features/note/services/markdown-patch.ts
@@ -177,6 +177,12 @@ interface RawTextMatch {
     text: string;
 }
 
+interface NormalizedMarkdownPatchText {
+    text: string;
+    rawStarts: number[];
+    rawEnds: number[];
+}
+
 interface HeadingMatch {
     heading: string;
     level: number;
@@ -211,6 +217,86 @@ const getLineRange = (markdown: string, match: RawTextMatch) => {
     };
 };
 
+const MARKDOWN_PATCH_WHITESPACE_PATTERN = /\p{Zs}|&nbsp;|&#(?:x[0-9a-f]+|\d+);/giu;
+const SPACE_SEPARATOR_PATTERN = /^\p{Zs}$/u;
+
+const normalizePatchWhitespaceToken = (value: string) => {
+    if (!value.startsWith('&')) {
+        return ' ';
+    }
+
+    if (/^&nbsp;$/i.test(value)) {
+        return ' ';
+    }
+
+    const numericValue = value.slice(2, -1);
+    const isHexadecimal = numericValue.toLowerCase().startsWith('x');
+    const codePoint = Number.parseInt(isHexadecimal ? numericValue.slice(1) : numericValue, isHexadecimal ? 16 : 10);
+
+    if (!Number.isSafeInteger(codePoint) || codePoint < 0 || codePoint > 0x10ffff) {
+        return value;
+    }
+
+    return SPACE_SEPARATOR_PATTERN.test(String.fromCodePoint(codePoint)) ? ' ' : value;
+};
+
+const normalizeMarkdownPatchText = (value: string): NormalizedMarkdownPatchText => {
+    let text = '';
+    const rawStarts: number[] = [];
+    const rawEnds: number[] = [];
+
+    const appendText = (appendValue: string, rawStart: number, rawEnd: number) => {
+        text += appendValue;
+
+        for (let index = 0; index < appendValue.length; index += 1) {
+            rawStarts.push(rawStart);
+            rawEnds.push(rawEnd);
+        }
+    };
+
+    const appendRawRange = (start: number, end: number) => {
+        for (let index = start; index < end; ) {
+            const codePoint = value.codePointAt(index);
+
+            if (codePoint === undefined) {
+                break;
+            }
+
+            const character = String.fromCodePoint(codePoint);
+            appendText(character, index, index + character.length);
+            index += character.length;
+        }
+    };
+
+    let sourceCursor = 0;
+
+    for (const match of value.matchAll(MARKDOWN_PATCH_WHITESPACE_PATTERN)) {
+        const start = match.index;
+        const token = match[0];
+        const end = start + token.length;
+
+        appendRawRange(sourceCursor, start);
+
+        const normalizedToken = normalizePatchWhitespaceToken(token);
+
+        if (normalizedToken === token) {
+            appendRawRange(start, end);
+        } else {
+            appendText(normalizedToken, start, end);
+        }
+
+        sourceCursor = end;
+    }
+
+    appendRawRange(sourceCursor, value.length);
+
+    return {
+        text,
+        rawStarts,
+        rawEnds,
+    };
+};
+
 const buildExcerpt = (markdown: string, start: number, end: number) => {
     const excerpt = markdown.slice(start, end).trim();
 
@@ -240,22 +326,32 @@ const toPatchMatch = (markdown: string, match: RawTextMatch, totalMatches: numbe
 
 const findExactTextMatches = (markdown: string, text: string) => {
     const matches: RawTextMatch[] = [];
+    const normalizedMarkdown = normalizeMarkdownPatchText(markdown);
+    const normalizedText = normalizeMarkdownPatchText(text).text;
     let searchStart = 0;
 
-    while (searchStart <= markdown.length) {
-        const start = markdown.indexOf(text, searchStart);
+    while (searchStart <= normalizedMarkdown.text.length) {
+        const start = normalizedMarkdown.text.indexOf(normalizedText, searchStart);
 
         if (start === -1) {
             break;
         }
 
+        const end = start + normalizedText.length;
+        const rawStart = normalizedMarkdown.rawStarts[start];
+        const rawEnd = normalizedMarkdown.rawEnds[end - 1];
+
+        if (rawStart === undefined || rawEnd === undefined) {
+            break;
+        }
+
         matches.push({
             matchIndex: matches.length,
-            start,
-            end: start + text.length,
-            text,
+            start: rawStart,
+            end: rawEnd,
+            text: markdown.slice(rawStart, rawEnd),
         });
-        searchStart = start + text.length;
+        searchStart = end;
     }
 
     return matches;
@@ -510,11 +606,21 @@ const createChangePlan = ({
 };
 
 const matchHasAnchors = (markdown: string, match: RawTextMatch, selector: ExactTextMarkdownPatchSelector) => {
-    if (selector.before !== undefined && !markdown.slice(0, match.start).endsWith(selector.before)) {
+    if (
+        selector.before !== undefined &&
+        !normalizeMarkdownPatchText(markdown.slice(0, match.start)).text.endsWith(
+            normalizeMarkdownPatchText(selector.before).text,
+        )
+    ) {
         return false;
     }
 
-    if (selector.after !== undefined && !markdown.slice(match.end).startsWith(selector.after)) {
+    if (
+        selector.after !== undefined &&
+        !normalizeMarkdownPatchText(markdown.slice(match.end)).text.startsWith(
+            normalizeMarkdownPatchText(selector.after).text,
+        )
+    ) {
         return false;
     }
 


### PR DESCRIPTION
## :dart: Goal
- Let localized Markdown edits find text that appears identical after encoded or special spaces are rendered.
- Prevent valid patch requests from failing when the stored whitespace differs from the displayed whitespace.

## :hammer_and_wrench: Core Changes
- Normalize display-equivalent spaces only while finding an exact-text match.
- Preserve the original Markdown and apply edits at the mapped source range.
- Add regression coverage for patch planning and guarded writes.

## :brain: Key Decisions
- Keep stored Markdown unchanged; normalization is comparison-only.
- Require match selection when multiple stored ranges render as the same text.
- No documentation, environment, or configuration changes are included.

## :test_tube: Verification Guide
### How to verify
1. Run `pnpm --filter @ocean-brain/server exec tsx --tsconfig tsconfig.json --test src/features/note/services/markdown-patch.test.ts src/features/note/services/markdown-intent-write.test.ts src/features/note/http/mcp-authoring.test.ts`.
2. Run `pnpm --filter @ocean-brain/server type-check` and `pnpm --filter @ocean-brain/server lint`.
3. Run `pnpm check:encoding` and `pnpm --filter @ocean-brain/server build`.

### Expected result
- The 42 targeted tests pass, and type-check, lint, encoding, and server build complete successfully.
- A selector containing ordinary spaces can patch Markdown stored with encoded or special spaces.
- Visually identical duplicate matches require explicit selection.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation reviewed; no updates needed
