### PR TITLE
🐛 Prevent image delete path traversal

### DIFF
--- a/packages/server/src/features/image/services/delete.test.ts
+++ b/packages/server/src/features/image/services/delete.test.ts
@@ -9,6 +9,26 @@ test('resolveStoredImagePath strips the public prefix', () => {
     assert.equal(resolvedPath.endsWith('/images/2026/4/15/sample.png'), true);
 });
 
+test('resolveStoredImagePath rejects non-canonical and escaping image URLs', () => {
+    const invalidUrls = [
+        '/assets/images/',
+        '/assets/images/../../outside.txt',
+        '/assets/images/%2e%2e/%2e%2e/outside.txt',
+        '/assets/images//etc/passwd',
+        '/assets/images/2026/./sample.png',
+        '/assets/images/2026\\..\\..\\outside.txt',
+        '/assets/images/2026%5c..%5c..%5coutside.txt',
+        '/assets/images/sample.png?download=true',
+        '/assets/images/sample.png#preview',
+        '/assets/images/%E0%A4%A',
+        '/other/assets/images/sample.png',
+    ];
+
+    for (const url of invalidUrls) {
+        assert.throws(() => resolveStoredImagePath(url), /inside the image directory/);
+    }
+});
+
 test('image delete service returns false when the image does not exist', async () => {
     let deleted = false;
 
@@ -52,4 +72,33 @@ test('image delete service removes the file before deleting the image row', asyn
     assert.equal(result, true);
     assert.deepEqual(removed, ['/var/data/assets/images/2026/4/15/sample.png']);
     assert.deepEqual(deleted, [8]);
+});
+
+test('image delete service preserves the file and row when the stored URL escapes the image directory', async () => {
+    let fileChecked = false;
+    let fileRemoved = false;
+    let rowDeleted = false;
+
+    const service = createImageDeleteService({
+        deleteImageRecord: async () => {
+            rowDeleted = true;
+        },
+        fileExists: () => {
+            fileChecked = true;
+            return true;
+        },
+        findImageById: async () => ({
+            id: 9,
+            url: '/assets/images/../../outside.txt',
+        }),
+        removeFile: async () => {
+            fileRemoved = true;
+        },
+        resolveImagePath: resolveStoredImagePath,
+    });
+
+    await assert.rejects(() => service.deleteImageById(9), /inside the image directory/);
+    assert.equal(fileChecked, false);
+    assert.equal(fileRemoved, false);
+    assert.equal(rowDeleted, false);
 });

--- a/packages/server/src/features/image/services/delete.ts
+++ b/packages/server/src/features/image/services/delete.ts
@@ -18,8 +18,51 @@ interface ImageDeleteDeps {
     resolveImagePath: (url: string) => string;
 }
 
+const PUBLIC_IMAGE_PATH_PREFIX = '/assets/images/';
+const INVALID_STORED_IMAGE_PATH_MESSAGE = 'Stored image URL must point to a file inside the image directory.';
+
+const invalidStoredImagePath = () => new Error(INVALID_STORED_IMAGE_PATH_MESSAGE);
+
 export const resolveStoredImagePath = (url: string) => {
-    return path.resolve(paths.imageDir, url.replace('/assets/images/', ''));
+    if (!url.startsWith(PUBLIC_IMAGE_PATH_PREFIX)) {
+        throw invalidStoredImagePath();
+    }
+
+    let relativePath: string;
+
+    try {
+        relativePath = decodeURIComponent(url.slice(PUBLIC_IMAGE_PATH_PREFIX.length));
+    } catch {
+        throw invalidStoredImagePath();
+    }
+
+    const pathSegments = relativePath.split('/');
+    const isCanonicalRelativePath =
+        relativePath.length > 0 &&
+        !relativePath.includes('\\') &&
+        !relativePath.includes('\0') &&
+        !relativePath.includes('?') &&
+        !relativePath.includes('#') &&
+        pathSegments.every((segment) => segment.length > 0 && segment !== '.' && segment !== '..');
+
+    if (!isCanonicalRelativePath) {
+        throw invalidStoredImagePath();
+    }
+
+    const imageDir = path.resolve(paths.imageDir);
+    const imagePath = path.resolve(imageDir, relativePath);
+    const relativeImagePath = path.relative(imageDir, imagePath);
+    const isInsideImageDir =
+        relativeImagePath.length > 0 &&
+        relativeImagePath !== '..' &&
+        !relativeImagePath.startsWith(`..${path.sep}`) &&
+        !path.isAbsolute(relativeImagePath);
+
+    if (!isInsideImageDir) {
+        throw invalidStoredImagePath();
+    }
+
+    return imagePath;
 };
 
 export const createImageDeleteService = (deps: ImageDeleteDeps) => {


### PR DESCRIPTION
## :dart: Goal
- Prevent a stored image URL from resolving outside the configured image directory during deletion.
- Include this security hardening in the planned 0.9.0 minor release.

## :hammer_and_wrench: Core Changes
- Require stored image URLs to use the exact `/assets/images/` prefix and a canonical relative file path.
- Decode URL-encoded segments before validating traversal, absolute-path, backslash, query, fragment, and malformed encoding cases.
- Keep both the file and database row untouched when path validation fails.
- Add regression coverage for valid deletion and raw or encoded escape attempts.

## :brain: Key Decisions
- Fail closed before checking or removing any file so corrupted or manipulated database values cannot hide a partial delete.
- Validate both the URL shape and the final resolved path for defense in depth.
- Keep the existing delete service contract for valid stored image URLs.

## :test_tube: Verification Guide
### How to verify
1. Run `pnpm --filter @ocean-brain/server exec tsx --tsconfig tsconfig.json --test src/features/image/services/delete.test.ts`.
2. Run `pnpm --filter @ocean-brain/server test:ci`.
3. Run `pnpm --filter @ocean-brain/server lint`, `pnpm --filter @ocean-brain/server type-check`, and `pnpm check:encoding`.

### Expected result
- Image delete service tests pass 5/5, including raw and encoded traversal rejection.
- Server tests pass 396/396.
- Lint, type-check, and encoding checks pass.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (not required; behavior and verification are captured in the task note and this PR)
