### PR TITLE
🐛 Preserve keyword search on semantic failures

### DIFF
--- a/packages/server/src/features/search/hybrid-search.test.ts
+++ b/packages/server/src/features/search/hybrid-search.test.ts
@@ -125,6 +125,26 @@ test('keeps lexical search usable when the embedding API is unavailable', async 
     assert.equal(result.semanticError, 'Embedding API is offline.');
 });
 
+test('keeps lexical search usable when semantic search initialization throws', async () => {
+    const search = createHybridNoteSearch({
+        listLexicalNoteIds: async () => [2, 1],
+        trySemanticSearch: async () => {
+            throw new Error('SQLite vector extension is unavailable.');
+        },
+        findNotesByIds: async (ids) => ids.map(createNote),
+    });
+
+    const result = await search({ query: 'search', limit: 10, offset: 0 });
+
+    assert.deepEqual(
+        result.notes.map((note) => note.id),
+        [2, 1],
+    );
+    assert.equal(result.semanticAvailable, false);
+    assert.equal(result.semanticUsed, false);
+    assert.equal(result.semanticError, 'SQLite vector extension is unavailable.');
+});
+
 test('lexical mode does not call the embedding search dependency', async () => {
     let semanticCalls = 0;
     const search = createHybridNoteSearch({

--- a/packages/server/src/features/search/hybrid-search.ts
+++ b/packages/server/src/features/search/hybrid-search.ts
@@ -52,6 +52,13 @@ export interface HybridNoteSearchResult {
 
 const MAX_HYBRID_CANDIDATES = 80;
 
+const unavailableSemanticAttempt = (error: unknown): SemanticSearchAttempt => ({
+    available: false,
+    used: false,
+    matches: [],
+    error: error instanceof Error ? error.message : 'Semantic search is unavailable.',
+});
+
 const buildLexicalWhere = (query: string): Prisma.NoteWhereInput | undefined => {
     const parsedQuery = parseNoteSearchQuery(query);
     if (!parsedQuery.hasFilters) {
@@ -210,7 +217,9 @@ export const createHybridNoteSearch = (dependencies: HybridNoteSearchDependencie
                       matches: [],
                       error: null,
                   } satisfies SemanticSearchAttempt)
-                : dependencies.trySemanticSearch(normalizedQuery, candidateLimit),
+                : dependencies
+                      .trySemanticSearch(normalizedQuery, candidateLimit)
+                      .catch((error) => unavailableSemanticAttempt(error)),
         ]);
         const rankedCandidates = fuseHybridSearchRanks({
             lexicalNoteIds,


### PR DESCRIPTION
## :dart: Goal
- Keep keyword search available when semantic search initialization or its SQLite extension fails.
- Make the optional semantic layer fail independently instead of rejecting the complete hybrid search request.

## :hammer_and_wrench: Core Changes
- Convert thrown semantic-search failures into an unavailable semantic attempt with a visible error message.
- Preserve lexical candidates, ranking, pagination, and result metadata during that failure.
- Add a regression test for a vector-extension initialization exception.

## :brain: Key Decisions
- Catch only the optional semantic branch so canonical note-database failures still surface normally.
- Report semantic availability as false while returning keyword matches through the existing response contract.
- Keep explicit lexical mode unchanged and free of semantic calls.

## :test_tube: Verification Guide
### How to verify
1. Run `pnpm --filter @ocean-brain/server exec tsx --tsconfig tsconfig.json --test src/features/search/hybrid-search.test.ts`.
2. Run `pnpm --filter @ocean-brain/server test:ci`.
3. Run `pnpm --filter @ocean-brain/server lint`, `pnpm --filter @ocean-brain/server type-check`, and `pnpm check:encoding`.

### Expected result
- Hybrid search tests pass 9/9 and return keyword matches when semantic initialization throws.
- Server tests pass 397/397.
- Lint, type-check, and encoding checks pass.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (not required; the public API contract is unchanged)
