### PR TITLE
🐛 Guard snapshot restores and property schemas

### DIFF
--- a/packages/client/src/apis/note.api.spec.ts
+++ b/packages/client/src/apis/note.api.spec.ts
@@ -5,6 +5,7 @@ import {
     fetchTrashedNote,
     fetchTrashedNotes,
     purgeTrashedNote,
+    restoreNoteSnapshot,
     updateNote,
 } from '~/apis/note.api';
 import { graphQuery } from '~/modules/graph-query';
@@ -234,6 +235,24 @@ describe('note.api', () => {
                     label: 'Web browser',
                 },
             },
+        });
+    });
+
+    it('sends the current note version when restoring a snapshot', async () => {
+        vi.mocked(graphQuery).mockResolvedValue({
+            type: 'success',
+            restoreNoteSnapshot: {
+                id: '7',
+                title: 'Restored note',
+                updatedAt: '1770000001000',
+            },
+        } as never);
+
+        await restoreNoteSnapshot('snapshot-1', '1770000000000');
+
+        expect(graphQuery).toHaveBeenCalledWith(expect.stringContaining('$expectedUpdatedAt: String!'), {
+            id: 'snapshot-1',
+            expectedUpdatedAt: '1770000000000',
         });
     });
 });

--- a/packages/client/src/apis/note.api.ts
+++ b/packages/client/src/apis/note.api.ts
@@ -706,15 +706,15 @@ export function fetchNoteSnapshotDiff(id: string, target: 'next' | 'previous' | 
     );
 }
 
-export function restoreNoteSnapshot(id: string) {
+export function restoreNoteSnapshot(id: string, expectedUpdatedAt: string) {
     return graphQuery<
         {
             restoreNoteSnapshot: Pick<Note, 'id' | 'title' | 'updatedAt' | 'layout' | 'pinned' | 'content'>;
         },
-        { id: string }
+        { id: string; expectedUpdatedAt: string }
     >(
-        `mutation RestoreNoteSnapshot($id: ID!) {
-            restoreNoteSnapshot(id: $id) {
+        `mutation RestoreNoteSnapshot($id: ID!, $expectedUpdatedAt: String!) {
+            restoreNoteSnapshot(id: $id, expectedUpdatedAt: $expectedUpdatedAt) {
                 id
                 title
                 pinned
@@ -723,7 +723,7 @@ export function restoreNoteSnapshot(id: string) {
                 updatedAt
             }
         }`,
-        { id },
+        { id, expectedUpdatedAt },
     );
 }
 

--- a/packages/client/src/components/note/RestoreSnapshotModal.spec.tsx
+++ b/packages/client/src/components/note/RestoreSnapshotModal.spec.tsx
@@ -35,7 +35,14 @@ const renderModal = (props: Partial<ComponentProps<typeof RestoreSnapshotModal>>
     render(
         <QueryClientProvider client={queryClient}>
             <ToastProvider>
-                <RestoreSnapshotModal isOpen noteId="7" onClose={onClose} onRestored={onRestored} {...props} />
+                <RestoreSnapshotModal
+                    isOpen
+                    noteId="7"
+                    onClose={onClose}
+                    onRestored={onRestored}
+                    restoreSnapshot={(id) => restoreNoteSnapshot(id, '1774915199000')}
+                    {...props}
+                />
             </ToastProvider>
         </QueryClientProvider>,
     );
@@ -121,7 +128,7 @@ describe('<RestoreSnapshotModal />', () => {
         await user.click(screen.getByRole('button', { name: /view content/i }));
         await user.click(screen.getByRole('button', { name: /restore this version/i }));
 
-        await waitFor(() => expect(restoreNoteSnapshot).toHaveBeenCalledWith('snapshot-1', expect.anything()));
+        await waitFor(() => expect(restoreNoteSnapshot).toHaveBeenCalledWith('snapshot-1', '1774915199000'));
         expect(onRestored).toHaveBeenCalledWith(expect.objectContaining({ id: '7' }));
         expect(onClose).toHaveBeenCalledTimes(1);
     });

--- a/packages/client/src/components/note/RestoreSnapshotModal.tsx
+++ b/packages/client/src/components/note/RestoreSnapshotModal.tsx
@@ -2,7 +2,12 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import dayjs from 'dayjs';
 import { useEffect, useRef, useState } from 'react';
 
-import { fetchNoteSnapshot, fetchNoteSnapshotDiff, fetchNoteSnapshots, restoreNoteSnapshot } from '~/apis/note.api';
+import {
+    fetchNoteSnapshot,
+    fetchNoteSnapshotDiff,
+    fetchNoteSnapshots,
+    type restoreNoteSnapshot,
+} from '~/apis/note.api';
 import { Button, Modal, ModalActionRow, SurfaceCard } from '~/components/shared';
 import { Text, useToast } from '~/components/ui';
 import type { Note } from '~/models/note.model';
@@ -12,7 +17,7 @@ interface RestoreSnapshotModalProps {
     isOpen: boolean;
     noteId: string;
     onClose: () => void;
-    restoreSnapshot?: (id: string) => Promise<Awaited<ReturnType<typeof restoreNoteSnapshot>> | undefined>;
+    restoreSnapshot: (id: string) => Promise<Awaited<ReturnType<typeof restoreNoteSnapshot>> | undefined>;
     onRestored?: (note: Pick<Note, 'id' | 'updatedAt'>) => void;
 }
 
@@ -36,7 +41,7 @@ export default function RestoreSnapshotModal({
     isOpen,
     noteId,
     onClose,
-    restoreSnapshot = restoreNoteSnapshot,
+    restoreSnapshot,
     onRestored,
 }: RestoreSnapshotModalProps) {
     const toast = useToast();

--- a/packages/client/src/hooks/useNoteEditorSession.ts
+++ b/packages/client/src/hooks/useNoteEditorSession.ts
@@ -608,7 +608,7 @@ export function useNoteEditorSession({ noteId, navigateToNote, notify }: UseNote
             await drainWrites();
             sessionGenerationRef.current += 1;
             return executeWrite(async () => {
-                const response = await restoreNoteSnapshot(snapshotId);
+                const response = await restoreNoteSnapshot(snapshotId, serverUpdatedAtRef.current);
 
                 if (response.type === 'error') {
                     return response;

--- a/packages/client/src/pages/Note.external-change.spec.tsx
+++ b/packages/client/src/pages/Note.external-change.spec.tsx
@@ -829,7 +829,7 @@ describe('<NoteContent /> external change handling', () => {
             await delayedSave.promise;
         });
 
-        await waitFor(() => expect(restoreNoteSnapshot).toHaveBeenCalledWith('snapshot-1'));
+        await waitFor(() => expect(restoreNoteSnapshot).toHaveBeenCalledWith('snapshot-1', '1779700001000'));
         await waitFor(() => expect(screen.getByRole('textbox', { name: 'Note title' })).toHaveValue('Snapshot title'));
         expect(screen.getByLabelText('Editor')).toHaveValue('Snapshot content');
     });

--- a/packages/server/src/features/note/graphql/note.mutation.resolver.ts
+++ b/packages/server/src/features/note/graphql/note.mutation.resolver.ts
@@ -193,21 +193,44 @@ export const noteMutationResolvers: NoteMutationResolvers = {
     },
     restoreNoteSnapshot: async (
         _,
-        { id }: { id: string },
+        { id, expectedUpdatedAt }: { id: string; expectedUpdatedAt: string },
         context: {
             req?: Request;
         },
     ) => {
-        const note = await restoreNoteSnapshot(Number(id), {
-            meta: createSnapshotMetaFromUserAgent(getRequestUserAgent(context.req)),
-        });
+        try {
+            const note = await restoreNoteSnapshot(Number(id), {
+                expectedUpdatedAt,
+                meta: createSnapshotMetaFromUserAgent(getRequestUserAgent(context.req)),
+            });
 
-        if (!note) {
-            throw 'NOT FOUND';
+            if (!note) {
+                throw 'NOT FOUND';
+            }
+
+            notifySemanticSearchNoteChanged(note.id);
+            return note;
+        } catch (error) {
+            if (isNoteVersionConflictError(error)) {
+                throw new GraphQLError(error.message, {
+                    extensions: {
+                        code: error.code,
+                        currentUpdatedAt: error.currentUpdatedAt,
+                        expectedUpdatedAt: error.expectedUpdatedAt,
+                    },
+                });
+            }
+
+            if (isInvalidNoteVersionError(error) || isMissingNoteVersionError(error)) {
+                throw new GraphQLError(error.message, {
+                    extensions: {
+                        code: error.code,
+                    },
+                });
+            }
+
+            throw error;
         }
-
-        notifySemanticSearchNoteChanged(note.id);
-        return note;
     },
     restoreTrashedNote: async (_, { id }: { id: string }) => {
         const note = await restoreTrashedNoteById(Number(id));

--- a/packages/server/src/features/note/graphql/note.type-defs.ts
+++ b/packages/server/src/features/note/graphql/note.type-defs.ts
@@ -294,7 +294,7 @@ export const noteMutation = gql`
         createNote(note: NoteInput!): Note!
         updateNote(id: ID!, note: NoteInput!, editSessionId: String, expectedUpdatedAt: String, force: Boolean): Note!
         deleteNote(id: ID!): Boolean!
-        restoreNoteSnapshot(id: ID!): Note!
+        restoreNoteSnapshot(id: ID!, expectedUpdatedAt: String!): Note!
         restoreTrashedNote(id: ID!): Note!
         purgeTrashedNote(id: ID!): Boolean!
         createNotePropertyKey(input: NotePropertyDefinitionInput!): NotePropertyKey!

--- a/packages/server/src/features/note/services/properties.test.ts
+++ b/packages/server/src/features/note/services/properties.test.ts
@@ -11,6 +11,7 @@ import {
     renamePropertyFiltersInViewQuery,
     resolveNotePropertiesPatchValueTypes,
     updateNotePropertiesWithVersionGuard,
+    viewQueryReferencesProperty,
 } from './properties.js';
 import { MissingNoteVersionError } from './write-conflict.js';
 
@@ -168,6 +169,24 @@ test('property option updates keep values referenced by saved views', () => {
         }),
         null,
     );
+});
+
+test('property definition deletion detects references from saved views', () => {
+    const query = JSON.stringify({
+        propertyFilters: [
+            {
+                key: 'state',
+                name: 'State',
+                valueType: 'select',
+                operator: 'equals',
+                value: 'doing',
+            },
+        ],
+    });
+
+    assert.equal(viewQueryReferencesProperty({ query, key: 'state' }), true);
+    assert.equal(viewQueryReferencesProperty({ query, key: 'project' }), false);
+    assert.equal(viewQueryReferencesProperty({ query: '{invalid', key: 'state' }), false);
 });
 
 test('property definition rename refreshes saved view filter labels', () => {

--- a/packages/server/src/features/note/services/properties.ts
+++ b/packages/server/src/features/note/services/properties.ts
@@ -527,6 +527,16 @@ export const findReferencedRemovedPropertyOptionValue = ({
     return null;
 };
 
+export const viewQueryReferencesProperty = ({ query, key }: { query: string | null; key: string }) => {
+    const parsed = parseViewQueryRecord(query);
+
+    if (!parsed || !Array.isArray(parsed.propertyFilters)) {
+        return false;
+    }
+
+    return parsed.propertyFilters.some((filter) => isRecord(filter) && getNormalizedViewFilterKey(filter) === key);
+};
+
 const buildTypedValueData = async (
     input: NotePropertySetInput,
     definitionId: number,
@@ -985,6 +995,20 @@ export const deleteNotePropertyDefinition = async ({
 
         if (!definition) {
             return null;
+        }
+
+        const referencingViewSections = await tx.viewSection.findMany({
+            where: { query: { contains: definition.key } },
+            select: { title: true, query: true },
+        });
+        const referencingView = referencingViewSections.find((section) =>
+            viewQueryReferencesProperty({ query: section.query, key: definition.key }),
+        );
+
+        if (referencingView) {
+            throw new InvalidNotePropertyInputError(
+                `Property ${definition.key} is used by view ${referencingView.title} and cannot be deleted.`,
+            );
         }
 
         const affectedNoteCount = definition._count.properties;

--- a/packages/server/src/features/note/services/snapshot.test.ts
+++ b/packages/server/src/features/note/services/snapshot.test.ts
@@ -1,7 +1,12 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { createNoteSnapshotService, resolveRestoredSnapshotTags } from './snapshot.js';
+import {
+    createNoteSnapshotService,
+    resolveRestoredSnapshotPropertyTarget,
+    resolveRestoredSnapshotTags,
+} from './snapshot.js';
+import { isNoteVersionConflictError } from './write-conflict.js';
 
 test('captureBaseline stores one snapshot per note edit session', async () => {
     const snapshots: Array<{
@@ -201,6 +206,106 @@ test('captureBaseline creates a new snapshot when the payload changed in a new s
     assert.deepEqual(trimCalls, [{ noteId: 7, keep: 10, limit: 100 }]);
 });
 
+test('restoreSnapshot rejects a stale note version before creating a safety snapshot', async () => {
+    let createSnapshotCallCount = 0;
+    let updateNoteCallCount = 0;
+    const service = createNoteSnapshotService({
+        findNoteById: async () => ({
+            id: 7,
+            title: 'Current title',
+            content: '{"type":"current"}',
+            pinned: false,
+            order: 0,
+            layout: 'wide',
+            updatedAt: new Date('2026-03-31T00:00:01.000Z'),
+        }),
+        findSnapshotByEditSessionId: async () => null,
+        findLatestSnapshot: async () => null,
+        createSnapshot: async () => {
+            createSnapshotCallCount += 1;
+            throw new Error('should not create a safety snapshot');
+        },
+        purgeExpiredSnapshots: async () => 0,
+        trimOverflowSnapshots: async () => 0,
+        listSnapshots: async () => [],
+        findSnapshotById: async () => ({
+            id: 3,
+            noteId: 7,
+            title: 'Previous title',
+            payload: JSON.stringify({
+                title: 'Previous title',
+                content: '{"type":"previous"}',
+                pinned: false,
+                order: 0,
+                layout: 'wide',
+            }),
+            editSessionId: null,
+            meta: null,
+            createdAt: new Date('2026-03-30T00:00:00.000Z'),
+        }),
+        updateNote: async () => {
+            updateNoteCallCount += 1;
+            throw new Error('should not restore a stale snapshot');
+        },
+    });
+
+    await assert.rejects(
+        () => service.restoreSnapshot(3, { expectedUpdatedAt: '2026-03-31T00:00:00.000Z' }),
+        (error: unknown) => isNoteVersionConflictError(error),
+    );
+    assert.equal(createSnapshotCallCount, 0);
+    assert.equal(updateNoteCallCount, 0);
+});
+
+test('snapshot property restore keeps only values compatible with the current shared schema', async () => {
+    const definitions = new Map([
+        ['memo', { id: 10, valueType: 'text' as const }],
+        ['state', { id: 20, valueType: 'select' as const }],
+    ]);
+    const options = new Map([['20:doing', { id: 30 }]]);
+    const dependencies = {
+        findDefinitionByKey: async (key: string) => definitions.get(key) ?? null,
+        findOptionByValue: async (definitionId: number, value: string) =>
+            options.get(`${definitionId}:${value}`) ?? null,
+    };
+
+    assert.deepEqual(
+        await resolveRestoredSnapshotPropertyTarget(
+            { key: 'memo', valueType: 'text', optionValue: null },
+            dependencies,
+        ),
+        { propertyDefinitionId: 10, optionId: null },
+    );
+    assert.deepEqual(
+        await resolveRestoredSnapshotPropertyTarget(
+            { key: 'state', valueType: 'select', optionValue: 'doing' },
+            dependencies,
+        ),
+        { propertyDefinitionId: 20, optionId: 30 },
+    );
+    assert.equal(
+        await resolveRestoredSnapshotPropertyTarget(
+            { key: 'removed', valueType: 'text', optionValue: null },
+            dependencies,
+        ),
+        null,
+    );
+    assert.equal(
+        await resolveRestoredSnapshotPropertyTarget(
+            { key: 'memo', valueType: 'number', optionValue: null },
+            dependencies,
+        ),
+        null,
+    );
+    assert.equal(
+        await resolveRestoredSnapshotPropertyTarget(
+            { key: 'state', valueType: 'select', optionValue: 'removed-option' },
+            dependencies,
+        ),
+        null,
+    );
+});
+
 test('restoreSnapshot reapplies payload and stores the current state first', async () => {
     const calls: string[] = [];
     const createdSnapshots: Array<{
@@ -231,6 +336,7 @@ test('restoreSnapshot reapplies payload and stores the current state first', asy
             pinned: true,
             order: 2,
             layout: 'full',
+            updatedAt: new Date('2026-03-31T00:00:00.000Z'),
         }),
         findSnapshotByEditSessionId: async () => null,
         findLatestSnapshot: async () => null,
@@ -286,7 +392,10 @@ test('restoreSnapshot reapplies payload and stores the current state first', asy
         },
     });
 
-    const restored = await service.restoreSnapshot(3, { meta: '{"label":"Web browser"}' });
+    const restored = await service.restoreSnapshot(3, {
+        expectedUpdatedAt: '2026-03-31T00:00:00.000Z',
+        meta: '{"label":"Web browser"}',
+    });
 
     assert.equal(createdSnapshots.length, 1);
     assert.equal(createdSnapshots[0]?.title, 'Current title');
@@ -300,6 +409,7 @@ test('restoreSnapshot reapplies payload and stores the current state first', asy
                 pinned: false,
                 order: 0,
                 layout: 'wide',
+                expectedUpdatedAt: '2026-03-31T00:00:00.000Z',
             },
         },
     ]);
@@ -334,6 +444,7 @@ test('restoreSnapshot skips saving a safety snapshot when the latest snapshot al
             pinned: true,
             order: 2,
             layout: 'full',
+            updatedAt: new Date('2026-03-31T00:00:00.000Z'),
         }),
         findSnapshotByEditSessionId: async () => null,
         findLatestSnapshot: async () => ({
@@ -379,7 +490,10 @@ test('restoreSnapshot skips saving a safety snapshot when the latest snapshot al
         },
     });
 
-    const restored = await service.restoreSnapshot(3, { meta: '{"label":"Web browser"}' });
+    const restored = await service.restoreSnapshot(3, {
+        expectedUpdatedAt: '2026-03-31T00:00:00.000Z',
+        meta: '{"label":"Web browser"}',
+    });
 
     assert.deepEqual(updated, [
         {
@@ -390,6 +504,7 @@ test('restoreSnapshot skips saving a safety snapshot when the latest snapshot al
                 pinned: false,
                 order: 0,
                 layout: 'wide',
+                expectedUpdatedAt: '2026-03-31T00:00:00.000Z',
             },
         },
     ]);
@@ -406,6 +521,7 @@ test('restoreSnapshot keeps existing snapshots when note update fails', async ()
             pinned: false,
             order: 0,
             layout: 'wide',
+            updatedAt: new Date('2026-03-31T00:00:00.000Z'),
         }),
         findSnapshotByEditSessionId: async () => null,
         findLatestSnapshot: async () => null,
@@ -444,7 +560,10 @@ test('restoreSnapshot keeps existing snapshots when note update fails', async ()
         },
     });
 
-    await assert.rejects(() => service.restoreSnapshot(3), /UPDATE_FAILED/);
+    await assert.rejects(
+        () => service.restoreSnapshot(3, { expectedUpdatedAt: '2026-03-31T00:00:00.000Z' }),
+        /UPDATE_FAILED/,
+    );
     assert.equal(trimCallCount, 0);
 });
 
@@ -479,6 +598,7 @@ test('restoreSnapshot syncs tag relations from restored content', async () => {
             pinned: false,
             order: 0,
             layout: 'wide',
+            updatedAt: new Date('2026-03-31T00:00:00.000Z'),
         }),
         findSnapshotByEditSessionId: async () => null,
         findLatestSnapshot: async () => null,
@@ -522,7 +642,10 @@ test('restoreSnapshot syncs tag relations from restored content', async () => {
         },
     });
 
-    await service.restoreSnapshot(3, { meta: '{"label":"Web browser"}' });
+    await service.restoreSnapshot(3, {
+        expectedUpdatedAt: '2026-03-31T00:00:00.000Z',
+        meta: '{"label":"Web browser"}',
+    });
 
     assert.deepEqual(updated, [
         {
@@ -534,6 +657,7 @@ test('restoreSnapshot syncs tag relations from restored content', async () => {
                 order: 0,
                 layout: 'wide',
                 tagIds: [5, 7],
+                expectedUpdatedAt: '2026-03-31T00:00:00.000Z',
             },
         },
     ]);
@@ -571,6 +695,7 @@ test('restoreSnapshot clears tag relations when restored content has no tags', a
             pinned: false,
             order: 0,
             layout: 'wide',
+            updatedAt: new Date('2026-03-31T00:00:00.000Z'),
         }),
         findSnapshotByEditSessionId: async () => null,
         findLatestSnapshot: async () => null,
@@ -614,7 +739,10 @@ test('restoreSnapshot clears tag relations when restored content has no tags', a
         },
     });
 
-    await service.restoreSnapshot(3, { meta: '{"label":"Web browser"}' });
+    await service.restoreSnapshot(3, {
+        expectedUpdatedAt: '2026-03-31T00:00:00.000Z',
+        meta: '{"label":"Web browser"}',
+    });
 
     assert.deepEqual(updated[0]?.input.tagIds, []);
 });

--- a/packages/server/src/features/note/services/snapshot.ts
+++ b/packages/server/src/features/note/services/snapshot.ts
@@ -1,6 +1,6 @@
 import { FILE_HEADERS_ONLY, formatPatch, structuredPatch } from 'diff';
 import { ensureTagByName } from '~/features/tag/services/organization.js';
-import models, { type NoteLayout, type PropertyValueType } from '~/models.js';
+import models, { type NoteLayout, Prisma, type PropertyValueType } from '~/models.js';
 import { blocksToMarkdown, extractTagIdsFromContentJson } from '~/modules/blocknote.js';
 import { type BlockNoteTreeNode, parseBlockNoteContent, walkBlockNoteTree } from '~/modules/blocknote-tree.js';
 import {
@@ -11,6 +11,7 @@ import {
 } from '~/modules/recovery-retention.js';
 import { calculateMarkdownSha256 } from './markdown-patch.js';
 import { buildNoteSearchProjection, extractVisibleSearchTextFromContent } from './search.js';
+import { createNoteVersionConflictError, MissingNoteVersionError, parseNoteVersion } from './write-conflict.js';
 
 const SNAPSHOT_CONTENT_PREVIEW_MAX_LENGTH = 240;
 
@@ -77,6 +78,7 @@ interface NoteSnapshotDeps {
             layout: NoteLayout;
             tagIds?: number[];
             properties?: SnapshotNoteProperty[];
+            expectedUpdatedAt: string;
         },
     ) => Promise<NoteRecord>;
 }
@@ -103,6 +105,11 @@ interface TagRecord {
 interface ResolvedRestoredSnapshotTags {
     content: string;
     tagIds: number[];
+}
+
+interface RestoredSnapshotPropertyTargetDeps {
+    findDefinitionByKey: (key: string) => Promise<{ id: number; valueType: PropertyValueType } | null>;
+    findOptionByValue: (definitionId: number, value: string) => Promise<{ id: number } | null>;
 }
 
 interface ResolveRestoredSnapshotTagsDeps {
@@ -218,6 +225,39 @@ const serializePayload = (note: NoteRecord): string => {
 
 const hasSameSnapshotPayload = (snapshot: NoteSnapshotRecord | null, payload: string) => {
     return snapshot?.payload === payload;
+};
+
+export const resolveRestoredSnapshotPropertyTarget = async (
+    property: Pick<SnapshotNoteProperty, 'key' | 'valueType' | 'optionValue'>,
+    deps: RestoredSnapshotPropertyTargetDeps,
+) => {
+    const definition = await deps.findDefinitionByKey(property.key);
+
+    if (!definition || definition.valueType !== property.valueType) {
+        return null;
+    }
+
+    if (property.valueType !== 'select') {
+        return {
+            propertyDefinitionId: definition.id,
+            optionId: null,
+        };
+    }
+
+    if (!property.optionValue) {
+        return null;
+    }
+
+    const option = await deps.findOptionByValue(definition.id, property.optionValue);
+
+    if (!option) {
+        return null;
+    }
+
+    return {
+        propertyDefinitionId: definition.id,
+        optionId: option.id,
+    };
 };
 
 const parsePayload = (payload: string): NoteSnapshotPayload => {
@@ -635,7 +675,7 @@ export const createNoteSnapshotService = (deps: NoteSnapshotDeps) => ({
         });
     },
 
-    restoreSnapshot: async (snapshotId: number, options?: { meta?: string }) => {
+    restoreSnapshot: async (snapshotId: number, options: { expectedUpdatedAt: string; meta?: string }) => {
         await deps.purgeExpiredSnapshots(createRetentionCutoff(SNAPSHOT_RETENTION_DAYS), RECOVERY_CLEANUP_BATCH_LIMIT);
 
         const snapshot = await deps.findSnapshotById(snapshotId);
@@ -648,6 +688,23 @@ export const createNoteSnapshotService = (deps: NoteSnapshotDeps) => ({
 
         if (!note) {
             return null;
+        }
+
+        if (!note.updatedAt) {
+            throw new Error('Note update time is required to restore a snapshot.');
+        }
+
+        const expectedTimestamp = parseNoteVersion(options.expectedUpdatedAt);
+
+        if (expectedTimestamp === null) {
+            throw new MissingNoteVersionError();
+        }
+
+        if (note.updatedAt.getTime() !== expectedTimestamp) {
+            throw createNoteVersionConflictError({
+                expectedUpdatedAt: expectedTimestamp,
+                currentUpdatedAt: note.updatedAt.getTime(),
+            });
         }
 
         const payload = parsePayload(snapshot.payload);
@@ -678,6 +735,7 @@ export const createNoteSnapshotService = (deps: NoteSnapshotDeps) => ({
         const restoredNote = await deps.updateNote(snapshot.noteId, {
             ...restoredPayload,
             ...(restoredTagIds !== undefined ? { tagIds: restoredTagIds } : {}),
+            expectedUpdatedAt: options.expectedUpdatedAt,
         });
 
         await deps.trimOverflowSnapshots(note.id, SNAPSHOT_MAX_PER_NOTE, RECOVERY_CLEANUP_BATCH_LIMIT);
@@ -806,77 +864,82 @@ export const defaultNoteSnapshotService = createNoteSnapshotService({
         });
     },
     updateNote: async (id, input) => {
-        const { tagIds, properties, ...noteInput } = input;
+        const { tagIds, properties, expectedUpdatedAt, ...noteInput } = input;
+        const expectedTimestamp = parseNoteVersion(expectedUpdatedAt);
 
-        return models.$transaction(async (tx) => {
-            const note = await tx.note.update({
-                where: { id },
-                data: {
-                    ...noteInput,
-                    ...buildNoteSearchProjection({
-                        title: noteInput.title,
-                        content: noteInput.content,
-                    }),
-                    ...(tagIds !== undefined ? { tags: { set: tagIds.map((tagId) => ({ id: tagId })) } } : {}),
-                },
+        if (expectedTimestamp === null) {
+            throw new MissingNoteVersionError();
+        }
+
+        try {
+            return await models.$transaction(async (tx) => {
+                const note = await tx.note.update({
+                    where: { id, updatedAt: new Date(expectedTimestamp) },
+                    data: {
+                        ...noteInput,
+                        ...buildNoteSearchProjection({
+                            title: noteInput.title,
+                            content: noteInput.content,
+                        }),
+                        ...(tagIds !== undefined ? { tags: { set: tagIds.map((tagId) => ({ id: tagId })) } } : {}),
+                    },
+                });
+
+                if (properties !== undefined) {
+                    await tx.noteProperty.deleteMany({ where: { noteId: id } });
+
+                    for (const property of properties) {
+                        const target = await resolveRestoredSnapshotPropertyTarget(property, {
+                            findDefinitionByKey: (key) => tx.propertyDefinition.findUnique({ where: { key } }),
+                            findOptionByValue: (propertyDefinitionId, value) =>
+                                tx.propertyOption.findUnique({
+                                    where: {
+                                        propertyDefinitionId_value: {
+                                            propertyDefinitionId,
+                                            value,
+                                        },
+                                    },
+                                }),
+                        });
+
+                        if (!target) {
+                            continue;
+                        }
+
+                        await tx.noteProperty.create({
+                            data: {
+                                noteId: id,
+                                propertyDefinitionId: target.propertyDefinitionId,
+                                optionId: target.optionId,
+                                textValue: property.textValue ?? null,
+                                textValueNormalized: property.textValueNormalized ?? null,
+                                numberValue: property.numberValue ?? null,
+                                dateValue: property.dateValue ? new Date(property.dateValue) : null,
+                                boolValue: property.boolValue ?? null,
+                            },
+                        });
+                    }
+                }
+
+                return note;
             });
+        } catch (error) {
+            if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
+                const currentNote = await models.note.findUnique({
+                    where: { id },
+                    select: { updatedAt: true },
+                });
 
-            if (properties !== undefined) {
-                await tx.noteProperty.deleteMany({ where: { noteId: id } });
-
-                for (const property of properties) {
-                    const definition = await tx.propertyDefinition.upsert({
-                        where: { key: property.key },
-                        create: {
-                            key: property.key,
-                            name: property.name,
-                            valueType: property.valueType,
-                        },
-                        update: {
-                            name: property.name,
-                            valueType: property.valueType,
-                        },
-                    });
-
-                    const option =
-                        property.valueType === 'select' && property.optionValue
-                            ? await tx.propertyOption.upsert({
-                                  where: {
-                                      propertyDefinitionId_value: {
-                                          propertyDefinitionId: definition.id,
-                                          value: property.optionValue,
-                                      },
-                                  },
-                                  create: {
-                                      propertyDefinitionId: definition.id,
-                                      value: property.optionValue,
-                                      label: property.optionLabel ?? property.optionValue,
-                                      color: property.optionColor ?? null,
-                                  },
-                                  update: {
-                                      label: property.optionLabel ?? property.optionValue,
-                                      color: property.optionColor ?? null,
-                                  },
-                              })
-                            : null;
-
-                    await tx.noteProperty.create({
-                        data: {
-                            noteId: id,
-                            propertyDefinitionId: definition.id,
-                            optionId: option?.id ?? null,
-                            textValue: property.textValue ?? null,
-                            textValueNormalized: property.textValueNormalized ?? null,
-                            numberValue: property.numberValue ?? null,
-                            dateValue: property.dateValue ? new Date(property.dateValue) : null,
-                            boolValue: property.boolValue ?? null,
-                        },
+                if (currentNote && currentNote.updatedAt.getTime() !== expectedTimestamp) {
+                    throw createNoteVersionConflictError({
+                        expectedUpdatedAt: expectedTimestamp,
+                        currentUpdatedAt: currentNote.updatedAt.getTime(),
                     });
                 }
             }
 
-            return note;
-        });
+            throw error;
+        }
     },
 });
 
@@ -909,7 +972,10 @@ export const diffNoteSnapshot = async (
     return defaultNoteSnapshotService.diffSnapshot(snapshotId, options);
 };
 
-export const restoreNoteSnapshot = async (snapshotId: number, options?: { meta?: string }) => {
+export const restoreNoteSnapshot = async (
+    snapshotId: number,
+    options: { expectedUpdatedAt: string; meta?: string },
+) => {
     return defaultNoteSnapshotService.restoreSnapshot(snapshotId, options);
 };
 


### PR DESCRIPTION
## :dart: Goal
- Prevent snapshot restore from overwriting a note that changed after the restore dialog was opened.
- Keep historical snapshot metadata from recreating or mutating the current shared property schema.
- Prevent deleting a property definition while a saved View still depends on it.

## :hammer_and_wrench: Core Changes
- Require the current note `updatedAt` for snapshot restore and enforce it both before the safety snapshot and in the database update condition.
- Return the existing note-version conflict contract when a concurrent write wins the race.
- Restore only property values whose current definition and select option still exist and have a compatible type.
- Reject property-definition deletion when an exact saved View filter references the key.
- Pass the accepted server version from the note editor after pending writes drain.

## :brain: Key Decisions
- The restore mutation now requires `expectedUpdatedAt`; this intentionally makes restore fail closed for stale or old clients instead of permitting a destructive overwrite.
- Historical property names, types, colors, and options are treated as note snapshot data, not authority over the current workspace schema.
- Referenced property deletion is blocked instead of silently removing the View filter, because removing the filter could broaden a saved View to unrelated notes.

## :test_tube: Verification Guide
### How to verify
1. Run `pnpm lint`, `pnpm type-check`, and `pnpm check:encoding`.
2. Run server and client `test:ci` suites.
3. Restore a snapshot after another write and confirm `NOTE_UPDATE_CONFLICT` is returned.
4. Restore a snapshot containing removed property definitions/options and confirm the shared schema stays unchanged.
5. Try deleting a property referenced by a saved View and confirm deletion is rejected.

### Expected result
- Stale restores never overwrite the latest note, historical snapshots cannot mutate shared property schema, and saved Views cannot retain broken property references.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (not needed; behavior is covered by release notes and tests)
