### PR TITLE
🐛 Preserve restore schemas and refresh note views

### DIFF
--- a/packages/client/src/hooks/resource/useNoteMutate.spec.tsx
+++ b/packages/client/src/hooks/resource/useNoteMutate.spec.tsx
@@ -88,6 +88,7 @@ describe('useNoteMutate', () => {
         } as never);
 
         const queryClient = createTestQueryClient();
+        const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries').mockResolvedValue(undefined);
         const { Wrapper } = createQueryClientWrapper(queryClient);
         const { result } = renderHook(() => useNoteMutate(), { wrapper: Wrapper });
 
@@ -102,6 +103,14 @@ describe('useNoteMutate', () => {
         expect(mockNavigate).toHaveBeenCalledWith({
             to: NOTE_ROUTE,
             params: { id: 'note-1' },
+        });
+        expect(invalidateSpy).toHaveBeenCalledWith({
+            queryKey: queryKeys.notes.tagNameListAll(),
+            exact: false,
+        });
+        expect(invalidateSpy).toHaveBeenCalledWith({
+            queryKey: queryKeys.views.sectionNotesAll(),
+            exact: false,
         });
     });
 
@@ -197,7 +206,11 @@ describe('useNoteMutate', () => {
                 exact: false,
             });
             expect(invalidateSpy).toHaveBeenCalledWith({
-                queryKey: ['calendar'],
+                queryKey: queryKeys.calendar.all(),
+                exact: false,
+            });
+            expect(invalidateSpy).toHaveBeenCalledWith({
+                queryKey: queryKeys.views.sectionNotesAll(),
                 exact: false,
             });
         });

--- a/packages/client/src/hooks/resource/useNoteMutate.tsx
+++ b/packages/client/src/hooks/resource/useNoteMutate.tsx
@@ -8,6 +8,7 @@ import { useConfirm, useToast } from '~/components/ui';
 import type { Note, NoteLayout } from '~/models/note.model';
 import { replaceFixedPlaceholder } from '~/modules/fixed-placeholder';
 import { queryKeys } from '~/modules/query-key-factory';
+import { invalidateQueriesForNoteChange, invalidateQueriesForNoteDelete } from '~/modules/server-event-invalidation';
 import { NOTE_ROUTE } from '~/modules/url';
 
 const MOVE_TO_TRASH_REFERENCE_WARNING = {
@@ -43,6 +44,7 @@ const useNoteMutate = () => {
             toast(response.errors[0].message);
             return null;
         }
+        void invalidateQueriesForNoteChange(queryClient);
         navigate({
             to: NOTE_ROUTE,
             params: { id: response.createNote.id },
@@ -57,20 +59,7 @@ const useNoteMutate = () => {
                 toast(response.errors[0].message);
                 return;
             }
-            await Promise.all([
-                queryClient.invalidateQueries({
-                    queryKey: queryKeys.notes.listAll(),
-                    exact: false,
-                }),
-                queryClient.invalidateQueries({
-                    queryKey: queryKeys.notes.tagListAll(),
-                    exact: false,
-                }),
-                queryClient.invalidateQueries({
-                    queryKey: queryKeys.notes.pinned(),
-                    exact: true,
-                }),
-            ]);
+            await invalidateQueriesForNoteChange(queryClient);
             callback?.();
         } catch {
             toast('Failed to update note pin status');
@@ -83,28 +72,7 @@ const useNoteMutate = () => {
             toast(response.errors[0].message);
             return;
         }
-        await Promise.all([
-            queryClient.invalidateQueries({
-                queryKey: queryKeys.notes.all(),
-                exact: false,
-            }),
-            queryClient.invalidateQueries({
-                queryKey: queryKeys.tags.all(),
-                exact: false,
-            }),
-            queryClient.invalidateQueries({
-                queryKey: queryKeys.reminders.all(),
-                exact: false,
-            }),
-            queryClient.invalidateQueries({
-                queryKey: queryKeys.images.all(),
-                exact: false,
-            }),
-            queryClient.invalidateQueries({
-                queryKey: ['calendar'],
-                exact: false,
-            }),
-        ]);
+        await invalidateQueriesForNoteDelete(queryClient);
         toast('The note has been moved to trash.');
         callback?.();
     };

--- a/packages/client/src/hooks/useNoteEditorSession.ts
+++ b/packages/client/src/hooks/useNoteEditorSession.ts
@@ -23,6 +23,7 @@ import {
 } from '~/modules/note-external-change';
 import { compareNoteVersions, toNoteVersionTime } from '~/modules/note-version';
 import { queryKeys } from '~/modules/query-key-factory';
+import { invalidateQueriesForNoteChange } from '~/modules/server-event-invalidation';
 import { publishClientNoteUpdatedEvent, subscribeServerEvent } from '~/modules/server-events';
 import { useNoteNavigationGuard } from './useNoteNavigationGuard';
 import { useNoteSaveController } from './useNoteSaveController';
@@ -152,6 +153,7 @@ export function useNoteEditorSession({ noteId, navigateToNote, notify }: UseNote
                 updatedAt,
                 editSessionId: editSessionIdRef.current,
             });
+            void invalidateQueriesForNoteChange(queryClient);
             return true;
         },
         [commitAcceptedVersion, noteId, queryClient],
@@ -445,13 +447,8 @@ export function useNoteEditorSession({ noteId, navigateToNote, notify }: UseNote
             }
 
             setIsPinned(nextPinned);
-            await Promise.all([
-                queryClient.invalidateQueries({ queryKey: queryKeys.notes.listAll(), exact: false }),
-                queryClient.invalidateQueries({ queryKey: queryKeys.notes.tagListAll(), exact: false }),
-                queryClient.invalidateQueries({ queryKey: queryKeys.notes.pinned(), exact: true }),
-            ]);
         });
-    }, [applyAcceptedWrite, executeWrite, flushPendingSave, isPinned, noteId, notify, queryClient]);
+    }, [applyAcceptedWrite, executeWrite, flushPendingSave, isPinned, noteId, notify]);
 
     const getExportMetadata = useCallback(
         () => ({

--- a/packages/client/src/hooks/useNoteSaveController.spec.tsx
+++ b/packages/client/src/hooks/useNoteSaveController.spec.tsx
@@ -226,6 +226,51 @@ describe('useNoteSaveController', () => {
         });
     });
 
+    it('invalidates every note-derived collection after a same-tab save', async () => {
+        const queryClient = createQueryClient();
+        const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
+        vi.mocked(updateNote).mockResolvedValue({
+            type: 'success',
+            updateNote: {
+                id: '7',
+                title: 'Saved draft',
+                updatedAt: '1770000001000',
+            },
+        } as never);
+        const { result } = renderHook(
+            () =>
+                useNoteSaveController({
+                    noteId: '7',
+                    initialContent: 'initial',
+                    initialUpdatedAt: '1770000000000',
+                    editSessionIdRef: { current: 'session-1' },
+                    getContent: () => 'content',
+                    onSaved: vi.fn(),
+                    onConflict: vi.fn(),
+                    onError: vi.fn(),
+                }),
+            { wrapper: createWrapper(queryClient) },
+        );
+
+        await act(async () => {
+            result.current.queueSave(result.current.buildDraft('Saved draft'));
+            await result.current.flushPendingSave();
+        });
+
+        expect(invalidateQueries).toHaveBeenCalledWith({
+            queryKey: queryKeys.notes.tagNameListAll(),
+            exact: false,
+        });
+        expect(invalidateQueries).toHaveBeenCalledWith({
+            queryKey: queryKeys.views.sectionNotesAll(),
+            exact: false,
+        });
+        expect(invalidateQueries).toHaveBeenCalledWith({
+            queryKey: queryKeys.tags.all(),
+            exact: false,
+        });
+    });
+
     it('uses an explicit force flag when overwriting a conflict', async () => {
         vi.mocked(updateNote).mockResolvedValue({
             type: 'success',

--- a/packages/client/src/hooks/useNoteSaveController.ts
+++ b/packages/client/src/hooks/useNoteSaveController.ts
@@ -10,6 +10,7 @@ import {
     writeLocalNoteDraft,
 } from '~/modules/note-draft-storage';
 import { queryKeys } from '~/modules/query-key-factory';
+import { invalidateQueriesForNoteChange } from '~/modules/server-event-invalidation';
 import { publishClientNoteUpdatedEvent } from '~/modules/server-events';
 import type { NoteWriteExecutor } from './useNoteWriteCoordinator';
 
@@ -285,27 +286,15 @@ export function useNoteSaveController({
                         clearLocalNoteDraft(noteId);
                     }
 
+                    if (!pendingDraftRef.current) {
+                        void invalidateQueriesForNoteChange(queryClient);
+                    }
+
                     if (shouldNotifySave) {
                         if (pendingDraftRef.current) {
                             setSaveStatus('pending');
                         } else {
                             setSaveStatus('saved');
-                            void queryClient.invalidateQueries({
-                                queryKey: queryKeys.notes.listAll(),
-                                exact: false,
-                            });
-                            void queryClient.invalidateQueries({
-                                queryKey: queryKeys.notes.tagListAll(),
-                                exact: false,
-                            });
-                            void queryClient.invalidateQueries({
-                                queryKey: queryKeys.notes.backReferencesAll(),
-                                exact: false,
-                            });
-                            void queryClient.invalidateQueries({
-                                queryKey: queryKeys.notes.graph(),
-                                exact: true,
-                            });
                         }
                     }
 

--- a/packages/client/src/modules/server-event-invalidation.spec.ts
+++ b/packages/client/src/modules/server-event-invalidation.spec.ts
@@ -102,15 +102,7 @@ describe('server-event-invalidation', () => {
 
         // Assert
         expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
-            queryKey: queryKeys.notes.trashAll(),
-            exact: false,
-        });
-        expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
-            queryKey: queryKeys.notes.tagNameListAll(),
-            exact: false,
-        });
-        expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
-            queryKey: queryKeys.notes.propertyKeysAll(),
+            queryKey: queryKeys.notes.all(),
             exact: false,
         });
         expect(queryClient.invalidateQueries).toHaveBeenCalledWith({

--- a/packages/client/src/modules/server-event-invalidation.ts
+++ b/packages/client/src/modules/server-event-invalidation.ts
@@ -45,10 +45,16 @@ const propertyKeysInvalidation: QueryInvalidation = {
 };
 
 const noteDeleteInvalidations: QueryInvalidation[] = [
-    ...noteChangeInvalidations,
-    propertyKeysInvalidation,
     {
-        queryKey: queryKeys.notes.trashAll(),
+        queryKey: queryKeys.notes.all(),
+        exact: false,
+    },
+    {
+        queryKey: queryKeys.views.sectionNotesAll(),
+        exact: false,
+    },
+    {
+        queryKey: queryKeys.tags.all(),
         exact: false,
     },
     {
@@ -69,17 +75,25 @@ const invalidateMany = async (queryClient: QueryClient, invalidations: QueryInva
     await Promise.all(invalidations.map((invalidation) => queryClient.invalidateQueries(invalidation)));
 };
 
+export const invalidateQueriesForNoteChange = async (queryClient: QueryClient) => {
+    await invalidateMany(queryClient, noteChangeInvalidations);
+};
+
+export const invalidateQueriesForNoteDelete = async (queryClient: QueryClient) => {
+    await invalidateMany(queryClient, noteDeleteInvalidations);
+};
+
 export const invalidateQueriesForServerEvent = async (queryClient: QueryClient, event: ServerEvent) => {
     switch (event.type) {
         case 'mcp.note.created':
         case 'web.note.updated':
-            await invalidateMany(queryClient, noteChangeInvalidations);
+            await invalidateQueriesForNoteChange(queryClient);
             return;
         case 'mcp.note.updated':
             await invalidateMany(queryClient, [...noteChangeInvalidations, propertyKeysInvalidation]);
             return;
         case 'mcp.note.deleted':
-            await invalidateMany(queryClient, noteDeleteInvalidations);
+            await invalidateQueriesForNoteDelete(queryClient);
             return;
     }
 };

--- a/packages/client/src/pages/Note.external-change.spec.tsx
+++ b/packages/client/src/pages/Note.external-change.spec.tsx
@@ -612,7 +612,8 @@ describe('<NoteContent /> external change handling', () => {
                 properties: [{ ...property, value: 'Navigation-safe summary', updatedAt: '1779700001000' }],
             },
         });
-        renderNote(initialNote);
+        const queryClient = renderNote(initialNote);
+        const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
 
         const propertyInput = await screen.findByRole('textbox', { name: 'Property value' });
         await user.clear(propertyInput);
@@ -645,6 +646,14 @@ describe('<NoteContent /> external change handling', () => {
             deleteKeys: [],
             editSessionId: expect.any(String),
             expectedUpdatedAt: initialNote.updatedAt,
+        });
+        expect(invalidateQueries).toHaveBeenCalledWith({
+            queryKey: queryKeys.views.sectionNotesAll(),
+            exact: false,
+        });
+        expect(invalidateQueries).toHaveBeenCalledWith({
+            queryKey: queryKeys.notes.tagNameListAll(),
+            exact: false,
         });
     });
 

--- a/packages/client/src/pages/setting/trash.spec.tsx
+++ b/packages/client/src/pages/setting/trash.spec.tsx
@@ -130,6 +130,24 @@ describe('<Trash />', () => {
         expect(screen.getByText(/Second line/)).toBeInTheDocument();
     });
 
+    it('refreshes live note collections and trash data after restoring a note', async () => {
+        const { invalidateSpy } = renderPage();
+
+        await userEvent.click(await screen.findByRole('button', { name: /restore/i }));
+
+        await waitFor(() => {
+            expect(restoreTrashedNote).toHaveBeenCalledWith('7', expect.anything());
+            expect(invalidateSpy).toHaveBeenCalledWith({
+                queryKey: queryKeys.notes.all(),
+                exact: false,
+            });
+            expect(invalidateSpy).toHaveBeenCalledWith({
+                queryKey: queryKeys.views.sectionNotesAll(),
+                exact: false,
+            });
+        });
+    });
+
     it('permanently deletes a trashed note after basic confirmation when there are no back references', async () => {
         vi.mocked(purgeTrashedNote).mockResolvedValue({
             type: 'success',

--- a/packages/client/src/pages/setting/trash.tsx
+++ b/packages/client/src/pages/setting/trash.tsx
@@ -17,6 +17,7 @@ import { Button, Empty, Modal, PageLayout, Pagination, Skeleton, SurfaceCard } f
 import { Text, useConfirm, useToast } from '~/components/ui';
 import type { Note } from '~/models/note.model';
 import { queryKeys } from '~/modules/query-key-factory';
+import { invalidateQueriesForNoteDelete } from '~/modules/server-event-invalidation';
 import { NOTE_ROUTE, SETTINGS_TRASH_ROUTE } from '~/modules/url';
 
 const PAGE_SIZE = 25;
@@ -176,28 +177,7 @@ const TrashContent = () => {
                 throw response;
             }
 
-            await Promise.all([
-                queryClient.invalidateQueries({
-                    queryKey: queryKeys.notes.all(),
-                    exact: false,
-                }),
-                queryClient.invalidateQueries({
-                    queryKey: queryKeys.tags.all(),
-                    exact: false,
-                }),
-                queryClient.invalidateQueries({
-                    queryKey: queryKeys.reminders.all(),
-                    exact: false,
-                }),
-                queryClient.invalidateQueries({
-                    queryKey: queryKeys.images.all(),
-                    exact: false,
-                }),
-                queryClient.invalidateQueries({
-                    queryKey: queryKeys.calendar.all(),
-                    exact: false,
-                }),
-            ]);
+            await invalidateQueriesForNoteDelete(queryClient);
 
             toast('The note has been restored.');
             navigate({

--- a/packages/server/src/features/note/services/property-restore.test.ts
+++ b/packages/server/src/features/note/services/property-restore.test.ts
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { resolveRestoredPropertyTarget } from './property-restore.js';
+
+test('property restore keeps only values compatible with the current shared schema', async () => {
+    const definitions = new Map([
+        ['memo', { id: 10, valueType: 'text' as const }],
+        ['state', { id: 20, valueType: 'select' as const }],
+    ]);
+    const options = new Map([['20:doing', { id: 30 }]]);
+    const dependencies = {
+        findDefinitionByKey: async (key: string) => definitions.get(key) ?? null,
+        findOptionByValue: async (definitionId: number, value: string) =>
+            options.get(`${definitionId}:${value}`) ?? null,
+    };
+
+    assert.deepEqual(
+        await resolveRestoredPropertyTarget({ key: 'memo', valueType: 'text', optionValue: null }, dependencies),
+        { propertyDefinitionId: 10, optionId: null },
+    );
+    assert.deepEqual(
+        await resolveRestoredPropertyTarget({ key: 'state', valueType: 'select', optionValue: 'doing' }, dependencies),
+        { propertyDefinitionId: 20, optionId: 30 },
+    );
+    assert.equal(
+        await resolveRestoredPropertyTarget({ key: 'removed', valueType: 'text', optionValue: null }, dependencies),
+        null,
+    );
+    assert.equal(
+        await resolveRestoredPropertyTarget({ key: 'memo', valueType: 'number', optionValue: null }, dependencies),
+        null,
+    );
+    assert.equal(
+        await resolveRestoredPropertyTarget(
+            { key: 'state', valueType: 'select', optionValue: 'removed-option' },
+            dependencies,
+        ),
+        null,
+    );
+});

--- a/packages/server/src/features/note/services/property-restore.ts
+++ b/packages/server/src/features/note/services/property-restore.ts
@@ -1,0 +1,45 @@
+import type { PropertyValueType } from '~/models.js';
+
+interface RestoredPropertyIdentity {
+    key: string;
+    valueType: PropertyValueType;
+    optionValue?: string | null;
+}
+
+interface RestoredPropertyTargetDeps {
+    findDefinitionByKey: (key: string) => Promise<{ id: number; valueType: PropertyValueType } | null>;
+    findOptionByValue: (definitionId: number, value: string) => Promise<{ id: number } | null>;
+}
+
+export const resolveRestoredPropertyTarget = async (
+    property: RestoredPropertyIdentity,
+    deps: RestoredPropertyTargetDeps,
+) => {
+    const definition = await deps.findDefinitionByKey(property.key);
+
+    if (!definition || definition.valueType !== property.valueType) {
+        return null;
+    }
+
+    if (property.valueType !== 'select') {
+        return {
+            propertyDefinitionId: definition.id,
+            optionId: null,
+        };
+    }
+
+    if (!property.optionValue) {
+        return null;
+    }
+
+    const option = await deps.findOptionByValue(definition.id, property.optionValue);
+
+    if (!option) {
+        return null;
+    }
+
+    return {
+        propertyDefinitionId: definition.id,
+        optionId: option.id,
+    };
+};

--- a/packages/server/src/features/note/services/snapshot.test.ts
+++ b/packages/server/src/features/note/services/snapshot.test.ts
@@ -1,11 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import {
-    createNoteSnapshotService,
-    resolveRestoredSnapshotPropertyTarget,
-    resolveRestoredSnapshotTags,
-} from './snapshot.js';
+import { createNoteSnapshotService, resolveRestoredSnapshotTags } from './snapshot.js';
 import { isNoteVersionConflictError } from './write-conflict.js';
 
 test('captureBaseline stores one snapshot per note edit session', async () => {
@@ -255,55 +251,6 @@ test('restoreSnapshot rejects a stale note version before creating a safety snap
     );
     assert.equal(createSnapshotCallCount, 0);
     assert.equal(updateNoteCallCount, 0);
-});
-
-test('snapshot property restore keeps only values compatible with the current shared schema', async () => {
-    const definitions = new Map([
-        ['memo', { id: 10, valueType: 'text' as const }],
-        ['state', { id: 20, valueType: 'select' as const }],
-    ]);
-    const options = new Map([['20:doing', { id: 30 }]]);
-    const dependencies = {
-        findDefinitionByKey: async (key: string) => definitions.get(key) ?? null,
-        findOptionByValue: async (definitionId: number, value: string) =>
-            options.get(`${definitionId}:${value}`) ?? null,
-    };
-
-    assert.deepEqual(
-        await resolveRestoredSnapshotPropertyTarget(
-            { key: 'memo', valueType: 'text', optionValue: null },
-            dependencies,
-        ),
-        { propertyDefinitionId: 10, optionId: null },
-    );
-    assert.deepEqual(
-        await resolveRestoredSnapshotPropertyTarget(
-            { key: 'state', valueType: 'select', optionValue: 'doing' },
-            dependencies,
-        ),
-        { propertyDefinitionId: 20, optionId: 30 },
-    );
-    assert.equal(
-        await resolveRestoredSnapshotPropertyTarget(
-            { key: 'removed', valueType: 'text', optionValue: null },
-            dependencies,
-        ),
-        null,
-    );
-    assert.equal(
-        await resolveRestoredSnapshotPropertyTarget(
-            { key: 'memo', valueType: 'number', optionValue: null },
-            dependencies,
-        ),
-        null,
-    );
-    assert.equal(
-        await resolveRestoredSnapshotPropertyTarget(
-            { key: 'state', valueType: 'select', optionValue: 'removed-option' },
-            dependencies,
-        ),
-        null,
-    );
 });
 
 test('restoreSnapshot reapplies payload and stores the current state first', async () => {

--- a/packages/server/src/features/note/services/snapshot.ts
+++ b/packages/server/src/features/note/services/snapshot.ts
@@ -10,6 +10,7 @@ import {
     SNAPSHOT_RETENTION_DAYS,
 } from '~/modules/recovery-retention.js';
 import { calculateMarkdownSha256 } from './markdown-patch.js';
+import { resolveRestoredPropertyTarget } from './property-restore.js';
 import { buildNoteSearchProjection, extractVisibleSearchTextFromContent } from './search.js';
 import { createNoteVersionConflictError, MissingNoteVersionError, parseNoteVersion } from './write-conflict.js';
 
@@ -105,11 +106,6 @@ interface TagRecord {
 interface ResolvedRestoredSnapshotTags {
     content: string;
     tagIds: number[];
-}
-
-interface RestoredSnapshotPropertyTargetDeps {
-    findDefinitionByKey: (key: string) => Promise<{ id: number; valueType: PropertyValueType } | null>;
-    findOptionByValue: (definitionId: number, value: string) => Promise<{ id: number } | null>;
 }
 
 interface ResolveRestoredSnapshotTagsDeps {
@@ -225,39 +221,6 @@ const serializePayload = (note: NoteRecord): string => {
 
 const hasSameSnapshotPayload = (snapshot: NoteSnapshotRecord | null, payload: string) => {
     return snapshot?.payload === payload;
-};
-
-export const resolveRestoredSnapshotPropertyTarget = async (
-    property: Pick<SnapshotNoteProperty, 'key' | 'valueType' | 'optionValue'>,
-    deps: RestoredSnapshotPropertyTargetDeps,
-) => {
-    const definition = await deps.findDefinitionByKey(property.key);
-
-    if (!definition || definition.valueType !== property.valueType) {
-        return null;
-    }
-
-    if (property.valueType !== 'select') {
-        return {
-            propertyDefinitionId: definition.id,
-            optionId: null,
-        };
-    }
-
-    if (!property.optionValue) {
-        return null;
-    }
-
-    const option = await deps.findOptionByValue(definition.id, property.optionValue);
-
-    if (!option) {
-        return null;
-    }
-
-    return {
-        propertyDefinitionId: definition.id,
-        optionId: option.id,
-    };
 };
 
 const parsePayload = (payload: string): NoteSnapshotPayload => {
@@ -889,7 +852,7 @@ export const defaultNoteSnapshotService = createNoteSnapshotService({
                     await tx.noteProperty.deleteMany({ where: { noteId: id } });
 
                     for (const property of properties) {
-                        const target = await resolveRestoredSnapshotPropertyTarget(property, {
+                        const target = await resolveRestoredPropertyTarget(property, {
                             findDefinitionByKey: (key) => tx.propertyDefinition.findUnique({ where: { key } }),
                             findOptionByValue: (propertyDefinitionId, value) =>
                                 tx.propertyOption.findUnique({

--- a/packages/server/src/features/note/services/trash.ts
+++ b/packages/server/src/features/note/services/trash.ts
@@ -4,6 +4,7 @@ import {
     RECOVERY_CLEANUP_BATCH_LIMIT,
     TRASH_RETENTION_DAYS,
 } from '~/modules/recovery-retention.js';
+import { resolveRestoredPropertyTarget } from './property-restore.js';
 import { buildNoteSearchProjection, extractVisibleSearchTextFromContent } from './search.js';
 
 const TRASHED_NOTE_CONTENT_PREVIEW_MAX_LENGTH = 240;
@@ -489,46 +490,28 @@ const noteTrashService = createNoteTrashService({
             });
 
             for (const property of deletedNote.properties ?? []) {
-                const definition = await tx.propertyDefinition.upsert({
-                    where: { key: property.key },
-                    create: {
-                        key: property.key,
-                        name: property.name,
-                        valueType: property.valueType,
-                    },
-                    update: {
-                        name: property.name,
-                        valueType: property.valueType,
-                    },
+                const target = await resolveRestoredPropertyTarget(property, {
+                    findDefinitionByKey: (key) => tx.propertyDefinition.findUnique({ where: { key } }),
+                    findOptionByValue: (propertyDefinitionId, value) =>
+                        tx.propertyOption.findUnique({
+                            where: {
+                                propertyDefinitionId_value: {
+                                    propertyDefinitionId,
+                                    value,
+                                },
+                            },
+                        }),
                 });
 
-                const option =
-                    property.valueType === 'select' && property.optionValue
-                        ? await tx.propertyOption.upsert({
-                              where: {
-                                  propertyDefinitionId_value: {
-                                      propertyDefinitionId: definition.id,
-                                      value: property.optionValue,
-                                  },
-                              },
-                              create: {
-                                  propertyDefinitionId: definition.id,
-                                  value: property.optionValue,
-                                  label: property.optionLabel ?? property.optionValue,
-                                  color: property.optionColor,
-                              },
-                              update: {
-                                  label: property.optionLabel ?? property.optionValue,
-                                  color: property.optionColor,
-                              },
-                          })
-                        : null;
+                if (!target) {
+                    continue;
+                }
 
                 await tx.noteProperty.create({
                     data: {
                         noteId: note.id,
-                        propertyDefinitionId: definition.id,
-                        optionId: option?.id ?? null,
+                        propertyDefinitionId: target.propertyDefinitionId,
+                        optionId: target.optionId,
                         textValue: property.textValue,
                         textValueNormalized: property.textValueNormalized,
                         numberValue: property.numberValue,


### PR DESCRIPTION
## :dart: Goal

Keep Trash restores aligned with the current shared property schema and refresh every derived note view after same-tab writes before the 0.9.0 release.

## :hammer_and_wrench: Core Changes

- Reuse a current-schema property target resolver for snapshot and Trash restores.
- Skip restored values whose property definition, value type, or select option no longer exists instead of recreating historical global schema.
- Centralize note-change and note-delete query invalidations for same-tab create, save, property, pin, delete, and restore flows.
- Refresh saved View results, tag-based lists, reminders, images, calendar data, and all note caches where the lifecycle operation requires it.
- Add regression coverage for property restore compatibility and same-tab cache refresh paths.

## :brain: Key Decisions

- The current shared property schema is authoritative. Restoring one note must not rename definitions, change their types, or resurrect removed select options globally.
- Incompatible historical property values are skipped during restore. The note itself and all compatible values are still restored.
- Delete and Trash restore invalidate the full notes query namespace because those operations affect live details, Trash state, property keys, and list membership together.
- Normal note writes keep the note detail cache managed locally and invalidate only derived collections, avoiding editor refetch conflicts.

## :test_tube: Verification Guide

### How to verify

1. Delete a note that has text and select properties.
2. Remove one property definition or select option, then restore the note.
3. Create, edit, pin, delete, and restore notes while a saved View and tag-filtered list are open.
4. Run `pnpm test`, `pnpm lint`, `pnpm type-check`, `pnpm check:encoding`, and `pnpm build`.

### Expected result

- Existing compatible property values return without changing the current schema.
- Removed or type-incompatible properties and options are not recreated.
- Saved Views, tag lists, Trash, reminders, images, and calendar data no longer stay stale after same-tab mutations.
- CLI, server, and client checks pass.

## :white_check_mark: Checklist

- [x] Added regression tests before the implementation changes.
- [x] Verified 29 CLI tests, 400 server tests, and 340 client tests.
- [x] Verified lint, type checking, encoding, and production builds.
- [x] Reviewed compatibility and data-loss tradeoffs for Trash restores.
