### PR TITLE
🔒 Patch vulnerable seroval runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     ],
     "overrides": {
       "@hono/node-server": "2.0.11",
-      "esbuild": "0.28.1"
+      "esbuild": "0.28.1",
+      "seroval": "1.5.6"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,6 +61,7 @@ catalogs:
 overrides:
   '@hono/node-server': 2.0.11
   esbuild: 0.28.1
+  seroval: 1.5.6
 
 importers:
 
@@ -4998,10 +4999,10 @@ packages:
     resolution: {integrity: sha512-EAHqADIQondwRZIdeW2I636zgsODzoBDwb3PT/+7TLDWyw1Dy/Xv7iGUIEXXav7usHDE9HVhOU61irI3EnyyHA==}
     engines: {node: '>=10'}
     peerDependencies:
-      seroval: ^1.0
+      seroval: 1.5.6
 
-  seroval@1.5.0:
-    resolution: {integrity: sha512-OE4cvmJ1uSPrKorFIH9/w/Qwuvi/IMcGbv5RKgcJ/zjA/IohDLU6SVaxFN9FwajbP7nsX0dQqMDes1whk3y+yw==}
+  seroval@1.5.6:
+    resolution: {integrity: sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA==}
     engines: {node: '>=10'}
 
   serve-static@2.2.1:
@@ -7879,8 +7880,8 @@ snapshots:
       '@tanstack/history': 1.161.4
       '@tanstack/store': 0.9.2
       cookie-es: 2.0.0
-      seroval: 1.5.0
-      seroval-plugins: 1.5.0(seroval@1.5.0)
+      seroval: 1.5.6
+      seroval-plugins: 1.5.0(seroval@1.5.6)
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
 
@@ -10749,11 +10750,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  seroval-plugins@1.5.0(seroval@1.5.0):
+  seroval-plugins@1.5.0(seroval@1.5.6):
     dependencies:
-      seroval: 1.5.0
+      seroval: 1.5.6
 
-  seroval@1.5.0: {}
+  seroval@1.5.6: {}
 
   serve-static@2.2.1:
     dependencies:


### PR DESCRIPTION
## :dart: Goal

Remove the critical runtime dependency vulnerability reported as GHSA-mv8w-475r-vwqw before Ocean Brain 0.9.0.

## :hammer_and_wrench: Core Changes

- Add a pnpm override from the transitive `seroval@1.5.0` dependency to `seroval@1.5.6`.
- Regenerate the lockfile so TanStack Router and `seroval-plugins` resolve the patched runtime consistently.

## :brain: Key Decisions

- Use a focused transitive override instead of upgrading the full TanStack Router stack during release stabilization.
- Select `1.5.6`, the current patch release, which is newer than the advisory's first patched version `1.5.3` and remains compatible with the plugin's `^1.0` peer range.
- Keep this as a patch release change because it changes no public Ocean Brain API or feature contract.

## :test_tube: Verification Guide

### How to verify

1. Run `pnpm why seroval -r` and confirm the only resolved version is `1.5.6`.
2. Run `pnpm audit --prod --audit-level critical`.
3. Run `pnpm test`, `pnpm lint`, `pnpm type-check`, `pnpm check:encoding`, and `pnpm build`.

### Expected result

- No `seroval` version in the vulnerable `<=1.5.2` range remains.
- The production audit reports no known vulnerabilities.
- Router-focused tests and all workspace checks pass.

## :white_check_mark: Checklist

- [x] Confirmed the alert affects the runtime dependency graph.
- [x] Confirmed `seroval@1.5.6` is the only resolved version.
- [x] Verified 29 CLI tests, 400 server tests, and 340 client tests.
- [x] Verified lint, type checking, encoding, production builds, and production audit.
