### PR TITLE
🐛 Align Views sorting and reorder controls

### DIFF
--- a/packages/client/src/components/view/ViewSectionCard.tsx
+++ b/packages/client/src/components/view/ViewSectionCard.tsx
@@ -22,10 +22,20 @@ interface ViewSectionCardProps {
     onEdit: () => void;
     onDuplicate: () => void;
     onDelete: () => void;
+    onMoveUp?: () => void;
+    onMoveDown?: () => void;
     dragHandle?: React.ReactNode;
 }
 
-export default function ViewSectionCard({ section, onEdit, onDuplicate, onDelete, dragHandle }: ViewSectionCardProps) {
+export default function ViewSectionCard({
+    section,
+    onEdit,
+    onDuplicate,
+    onDelete,
+    onMoveUp,
+    onMoveDown,
+    dragHandle,
+}: ViewSectionCardProps) {
     const queryClient = useQueryClient();
     const toast = useToast();
     const [isSortPending, setIsSortPending] = useState(false);
@@ -141,6 +151,9 @@ export default function ViewSectionCard({ section, onEdit, onDuplicate, onDelete
                 <Dropdown
                     button={<MoreButton label="Section actions" />}
                     items={[
+                        ...(onMoveUp ? [{ name: 'Move up', onClick: onMoveUp }] : []),
+                        ...(onMoveDown ? [{ name: 'Move down', onClick: onMoveDown }] : []),
+                        ...(onMoveUp || onMoveDown ? [{ type: 'separator' as const }] : []),
                         {
                             name: 'Edit section',
                             onClick: onEdit,

--- a/packages/client/src/components/view/ViewTabBar.tsx
+++ b/packages/client/src/components/view/ViewTabBar.tsx
@@ -1,7 +1,12 @@
 import type { DragEndEvent } from '@dnd-kit/core';
-import { closestCenter, DndContext, MouseSensor, useSensor, useSensors } from '@dnd-kit/core';
+import { closestCenter, DndContext, KeyboardSensor, MouseSensor, useSensor, useSensors } from '@dnd-kit/core';
 import { restrictToHorizontalAxis } from '@dnd-kit/modifiers';
-import { horizontalListSortingStrategy, SortableContext, useSortable } from '@dnd-kit/sortable';
+import {
+    horizontalListSortingStrategy,
+    SortableContext,
+    sortableKeyboardCoordinates,
+    useSortable,
+} from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import classNames from 'classnames';
 
@@ -73,7 +78,10 @@ interface ViewTabBarProps {
 }
 
 export default function ViewTabBar({ tabs, activeTabId, onSelectTab, onReorderTabs, onCreateTab }: ViewTabBarProps) {
-    const sensors = useSensors(useSensor(MouseSensor, { activationConstraint: { distance: 8 } }));
+    const sensors = useSensors(
+        useSensor(MouseSensor, { activationConstraint: { distance: 8 } }),
+        useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+    );
 
     return (
         <div className="-mx-1 rounded-[16px] border border-border-subtle/75 bg-subtle/50 p-1 sm:mx-0">

--- a/packages/client/src/modules/local-demo/plugins/views.spec.ts
+++ b/packages/client/src/modules/local-demo/plugins/views.spec.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Note } from '~/models/note.model';
+import type { ViewSection } from '~/models/view.model';
+import type { LocalDemoState } from '../types';
+import { viewsLocalPlugin } from './views';
+
+const createNote = (id: string, title: string, createdAt: string, updatedAt: string): Note => ({
+    id,
+    title,
+    content: '',
+    pinned: false,
+    order: 0,
+    layout: 'wide',
+    tags: [],
+    properties: [],
+    createdAt,
+    updatedAt,
+});
+
+const createState = (section: ViewSection): LocalDemoState => ({
+    version: 5,
+    notes: [
+        createNote('note-2', 'Beta', '1710000002000', '1710000001000'),
+        createNote('note-1', 'Alpha', '1710000001000', '1710000002000'),
+        createNote('note-3', 'Gamma', '1710000003000', '1710000003000'),
+    ],
+    trashedNotes: [],
+    tags: [],
+    reminders: [],
+    placeholders: [],
+    images: [],
+    cache: {},
+    propertyDefinitions: [],
+    mcp: {
+        enabled: false,
+        hasActiveToken: false,
+        token: null,
+    },
+    viewWorkspace: {
+        activeTabId: 'tab-1',
+        tabs: [{ id: 'tab-1', title: 'Views', order: 0, sections: [section] }],
+    },
+});
+
+const createSection = (sortBy: ViewSection['sortBy'], sortOrder: ViewSection['sortOrder']): ViewSection => ({
+    id: 'section-1',
+    tabId: 'tab-1',
+    title: 'All notes',
+    displayType: 'list',
+    displayOptions: { tableColumns: ['title'] },
+    tagNames: [],
+    mode: 'and',
+    propertyFilters: [],
+    sortBy,
+    sortOrder,
+    limit: 5,
+    order: 0,
+});
+
+describe('viewsLocalPlugin', () => {
+    it.each([
+        ['title', 'asc', ['note-1', 'note-2', 'note-3']],
+        ['createdAt', 'desc', ['note-3', 'note-2', 'note-1']],
+        ['updatedAt', 'asc', ['note-2', 'note-1', 'note-3']],
+    ] as const)('sorts section notes by %s %s like the server', (sortBy, sortOrder, expectedIds) => {
+        const handler = viewsLocalPlugin.graphHandlers?.FetchViewSectionNotes;
+        const response = handler?.({
+            state: createState(createSection(sortBy, sortOrder)),
+            variables: { id: 'section-1', pagination: { limit: 5, offset: 0 } },
+            save: () => undefined,
+        });
+        const result = response?.viewSectionNotes as { notes: Note[] } | undefined;
+
+        expect(result?.notes.map((note) => note.id)).toEqual(expectedIds);
+    });
+});

--- a/packages/client/src/modules/local-demo/plugins/views.ts
+++ b/packages/client/src/modules/local-demo/plugins/views.ts
@@ -1,7 +1,17 @@
+import type { Note } from '~/models/note.model';
 import type { ViewSection } from '~/models/view.model';
 import { localError, success } from '../response';
 import type { LocalDemoPlugin } from '../types';
 import { applyPropertyFilters, createLocalId, listNotesByTags, paginate } from '../utils';
+
+const sortSectionNotes = (notes: Note[], section: ViewSection) => {
+    const direction = section.sortOrder === 'asc' ? 1 : -1;
+
+    return [...notes].sort((left, right) => {
+        const comparison = left[section.sortBy].localeCompare(right[section.sortBy]) * direction;
+        return comparison || left.id.localeCompare(right.id);
+    });
+};
 
 export const viewsLocalPlugin: LocalDemoPlugin = {
     name: 'views',
@@ -18,7 +28,13 @@ export const viewsLocalPlugin: LocalDemoPlugin = {
                 .flatMap((tab) => tab.sections)
                 .find((item) => item.id === String(variables.id));
             const notes = section
-                ? applyPropertyFilters(listNotesByTags(state, section.tagNames, section.mode), section.propertyFilters)
+                ? sortSectionNotes(
+                      applyPropertyFilters(
+                          listNotesByTags(state, section.tagNames, section.mode),
+                          section.propertyFilters,
+                      ),
+                      section,
+                  )
                 : [];
             return success({ viewSectionNotes: { totalCount: notes.length, notes: paginate(notes, variables) } });
         },

--- a/packages/client/src/modules/view-dashboard.spec.ts
+++ b/packages/client/src/modules/view-dashboard.spec.ts
@@ -9,6 +9,8 @@ import {
     getViewTableColumnLabel,
     getViewTagMatchLabel,
     getViewTagMatchToken,
+    moveViewSectionInWorkspace,
+    moveViewTabInWorkspace,
     normalizeViewTableColumns,
     normalizeViewTagNames,
     reorderViewSectionsInWorkspace,
@@ -148,6 +150,45 @@ describe('view-dashboard helpers', () => {
                 'section-1',
             ).tabs[0]?.sections.map((section) => section.id),
         ).toEqual(['section-3', 'section-1', 'section-2']);
+    });
+
+    it('moves tabs and sections one position for non-drag reorder controls', () => {
+        const sectionOne = createSection({
+            id: 'section-1',
+            tabId: 'tab-1',
+            title: 'One',
+            tagNames: [],
+            mode: 'and',
+            limit: 5,
+            order: 0,
+        });
+        const sectionTwo = createSection({
+            id: 'section-2',
+            tabId: 'tab-1',
+            title: 'Two',
+            tagNames: [],
+            mode: 'and',
+            limit: 5,
+            order: 1,
+        });
+        const workspace = {
+            activeTabId: 'tab-1',
+            tabs: [
+                { id: 'tab-1', title: 'Now', order: 0, sections: [sectionOne, sectionTwo] },
+                { id: 'tab-2', title: 'Later', order: 1, sections: [] },
+            ],
+        };
+
+        expect(moveViewTabInWorkspace(workspace, 'tab-1', 'next').tabs.map((tab) => tab.id)).toEqual([
+            'tab-2',
+            'tab-1',
+        ]);
+        expect(
+            moveViewSectionInWorkspace(workspace, 'tab-1', 'section-2', 'previous').tabs[0]?.sections.map(
+                (section) => section.id,
+            ),
+        ).toEqual(['section-2', 'section-1']);
+        expect(moveViewTabInWorkspace(workspace, 'tab-1', 'previous')).toBe(workspace);
     });
 
     it('returns clear labels and short conjunction tokens for tag matching', () => {

--- a/packages/client/src/modules/view-dashboard.ts
+++ b/packages/client/src/modules/view-dashboard.ts
@@ -56,6 +56,19 @@ const reorderArrayItems = <TValue extends { id: string }>(items: TValue[], activ
     return nextItems;
 };
 
+export type ViewMoveDirection = 'previous' | 'next';
+
+const getAdjacentItemId = <TValue extends { id: string }>(
+    items: TValue[],
+    itemId: string,
+    direction: ViewMoveDirection,
+) => {
+    const currentIndex = items.findIndex((item) => item.id === itemId);
+    const nextIndex = currentIndex + (direction === 'previous' ? -1 : 1);
+
+    return currentIndex >= 0 && nextIndex >= 0 && nextIndex < items.length ? items[nextIndex]?.id : undefined;
+};
+
 export const normalizeViewTagNames = (values: unknown[]) => {
     const normalizedTagNames = values.flatMap((value) => {
         if (typeof value === 'string') {
@@ -116,6 +129,28 @@ export const reorderViewSectionsInWorkspace = (
             : tab,
     ),
 });
+
+export const moveViewTabInWorkspace = (
+    workspace: ViewsWorkspace,
+    tabId: string,
+    direction: ViewMoveDirection,
+): ViewsWorkspace => {
+    const adjacentTabId = getAdjacentItemId(workspace.tabs, tabId, direction);
+    return adjacentTabId ? reorderViewTabsInWorkspace(workspace, tabId, adjacentTabId) : workspace;
+};
+
+export const moveViewSectionInWorkspace = (
+    workspace: ViewsWorkspace,
+    tabId: string,
+    sectionId: string,
+    direction: ViewMoveDirection,
+): ViewsWorkspace => {
+    const sections = workspace.tabs.find((tab) => tab.id === tabId)?.sections ?? [];
+    const adjacentSectionId = getAdjacentItemId(sections, sectionId, direction);
+    return adjacentSectionId
+        ? reorderViewSectionsInWorkspace(workspace, tabId, sectionId, adjacentSectionId)
+        : workspace;
+};
 
 export const getViewTagMatchLabel = (mode: ViewTagMatchMode) => {
     return mode === 'or' ? 'OR — any selected tag' : 'AND — all selected tags';

--- a/packages/client/src/pages/Views.spec.tsx
+++ b/packages/client/src/pages/Views.spec.tsx
@@ -1,12 +1,18 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
 
 import { fetchNotePropertyKeys } from '~/apis/note.api';
 import { fetchTags } from '~/apis/tag.api';
-import { fetchViewWorkspace } from '~/apis/view.api';
+import { fetchViewSectionNotes, fetchViewWorkspace, reorderViewSections, reorderViewTabs } from '~/apis/view.api';
 import { ConfirmProvider, ToastProvider } from '~/components/ui';
 import { createQueryClientWrapper } from '~/test/test-utils';
 
 import Views from './Views';
+
+vi.mock('@tanstack/react-router', () => ({
+    Link: ({ children }: { children: ReactNode }) => <a href="#">{children}</a>,
+}));
 
 vi.mock('~/apis/note.api', () => ({ fetchNotePropertyKeys: vi.fn() }));
 vi.mock('~/apis/tag.api', () => ({ fetchTags: vi.fn() }));
@@ -16,6 +22,7 @@ vi.mock('~/apis/view.api', () => ({
     deleteViewSection: vi.fn(),
     deleteViewTab: vi.fn(),
     fetchViewWorkspace: vi.fn(),
+    fetchViewSectionNotes: vi.fn(),
     reorderViewSections: vi.fn(),
     reorderViewTabs: vi.fn(),
     setActiveViewTab: vi.fn(),
@@ -62,5 +69,88 @@ describe('<Views />', () => {
 
         expect(await screen.findByText('Create your first view tab')).toBeInTheDocument();
         expect(screen.getByRole('button', { name: 'Create first tab' })).toBeInTheDocument();
+    });
+
+    it('offers menu fallbacks for moving tabs and sections without dragging', async () => {
+        vi.mocked(fetchViewWorkspace).mockResolvedValue({
+            type: 'success',
+            viewWorkspace: {
+                activeTabId: 'tab-1',
+                tabs: [
+                    {
+                        id: 'tab-1',
+                        title: 'Work',
+                        order: 0,
+                        sections: [
+                            {
+                                id: 'section-1',
+                                tabId: 'tab-1',
+                                title: 'First section',
+                                displayType: 'list',
+                                displayOptions: { tableColumns: ['title'] },
+                                tagNames: [],
+                                mode: 'and',
+                                propertyFilters: [],
+                                sortBy: 'updatedAt',
+                                sortOrder: 'desc',
+                                limit: 5,
+                                order: 0,
+                            },
+                            {
+                                id: 'section-2',
+                                tabId: 'tab-1',
+                                title: 'Second section',
+                                displayType: 'list',
+                                displayOptions: { tableColumns: ['title'] },
+                                tagNames: [],
+                                mode: 'and',
+                                propertyFilters: [],
+                                sortBy: 'updatedAt',
+                                sortOrder: 'desc',
+                                limit: 5,
+                                order: 1,
+                            },
+                        ],
+                    },
+                    {
+                        id: 'tab-2',
+                        title: 'Later',
+                        order: 1,
+                        sections: [],
+                    },
+                ],
+            },
+        } as never);
+        vi.mocked(fetchViewSectionNotes).mockResolvedValue({
+            type: 'success',
+            viewSectionNotes: { totalCount: 0, notes: [] },
+        } as never);
+        vi.mocked(reorderViewSections).mockResolvedValue({ type: 'success', reorderViewSections: [] } as never);
+        vi.mocked(reorderViewTabs).mockResolvedValue({ type: 'success', reorderViewTabs: [] } as never);
+        const { Wrapper: QueryWrapper } = createQueryClientWrapper();
+        const Wrapper = ({ children }: { children: React.ReactNode }) => (
+            <QueryWrapper>
+                <ToastProvider>
+                    <ConfirmProvider>{children}</ConfirmProvider>
+                </ToastProvider>
+            </QueryWrapper>
+        );
+
+        render(<Views />, { wrapper: Wrapper });
+
+        const actionButtons = await screen.findAllByRole('button', { name: 'Section actions' });
+        await userEvent.click(actionButtons[0]);
+        await userEvent.click(await screen.findByRole('menuitem', { name: 'Move down' }));
+
+        await waitFor(() => {
+            expect(reorderViewSections).toHaveBeenCalledWith('tab-1', ['section-2', 'section-1']);
+        });
+
+        await userEvent.click(screen.getByRole('button', { name: 'View tab actions' }));
+        await userEvent.click(await screen.findByRole('menuitem', { name: 'Move tab right' }));
+
+        await waitFor(() => {
+            expect(reorderViewTabs).toHaveBeenCalledWith(['tab-2', 'tab-1']);
+        });
     });
 });

--- a/packages/client/src/pages/Views.tsx
+++ b/packages/client/src/pages/Views.tsx
@@ -42,9 +42,12 @@ import {
     buildViewSectionInput,
     EMPTY_VIEWS_WORKSPACE,
     getActiveViewTab,
+    moveViewSectionInWorkspace,
+    moveViewTabInWorkspace,
     reorderViewSectionsInWorkspace,
     reorderViewTabsInWorkspace,
     setActiveViewTabInWorkspace,
+    type ViewMoveDirection,
 } from '~/modules/view-dashboard';
 
 const pageDescription = 'Save reusable note queries with tags, shared properties, and sorting.';
@@ -60,9 +63,18 @@ interface SortableViewSectionProps {
     onEdit: () => void;
     onDuplicate: () => void;
     onDelete: () => void;
+    onMoveUp?: () => void;
+    onMoveDown?: () => void;
 }
 
-const SortableViewSection = ({ section, onEdit, onDuplicate, onDelete }: SortableViewSectionProps) => {
+const SortableViewSection = ({
+    section,
+    onEdit,
+    onDuplicate,
+    onDelete,
+    onMoveUp,
+    onMoveDown,
+}: SortableViewSectionProps) => {
     const { attributes, listeners, setNodeRef, setActivatorNodeRef, transform, transition, isDragging } = useSortable({
         id: section.id,
     });
@@ -81,6 +93,8 @@ const SortableViewSection = ({ section, onEdit, onDuplicate, onDelete }: Sortabl
                 onEdit={onEdit}
                 onDuplicate={onDuplicate}
                 onDelete={onDelete}
+                onMoveUp={onMoveUp}
+                onMoveDown={onMoveDown}
                 dragHandle={
                     <button
                         type="button"
@@ -125,6 +139,7 @@ export default function Views() {
 
     const workspace = workspaceData ?? EMPTY_VIEWS_WORKSPACE;
     const activeTab = getActiveViewTab(workspace);
+    const activeTabIndex = activeTab ? workspace.tabs.findIndex((tab) => tab.id === activeTab.id) : -1;
 
     const { data: tagData, isPending: isTagsLoading } = useQuery({
         queryKey: queryKeys.tags.list({ limit: 200 }),
@@ -172,14 +187,7 @@ export default function Views() {
         });
     };
 
-    const handleTabDragEnd = async ({ active, over }: DragEndEvent) => {
-        if (!over || active.id === over.id) {
-            return;
-        }
-
-        const previousWorkspace = queryClient.getQueryData<ViewsWorkspace>(queryKeys.views.workspace()) ?? workspace;
-        const nextWorkspace = reorderViewTabsInWorkspace(previousWorkspace, String(active.id), String(over.id));
-
+    const persistTabOrder = async (previousWorkspace: ViewsWorkspace, nextWorkspace: ViewsWorkspace) => {
         syncWorkspace(nextWorkspace);
 
         const response = await reorderViewTabs(nextWorkspace.tabs.map((tab) => tab.id));
@@ -191,6 +199,29 @@ export default function Views() {
         }
 
         await invalidateViews();
+    };
+
+    const handleTabDragEnd = async ({ active, over }: DragEndEvent) => {
+        if (!over || active.id === over.id) {
+            return;
+        }
+
+        const previousWorkspace = queryClient.getQueryData<ViewsWorkspace>(queryKeys.views.workspace()) ?? workspace;
+        const nextWorkspace = reorderViewTabsInWorkspace(previousWorkspace, String(active.id), String(over.id));
+        await persistTabOrder(previousWorkspace, nextWorkspace);
+    };
+
+    const handleMoveActiveTab = async (direction: ViewMoveDirection) => {
+        if (!activeTab) {
+            return;
+        }
+
+        const previousWorkspace = queryClient.getQueryData<ViewsWorkspace>(queryKeys.views.workspace()) ?? workspace;
+        const nextWorkspace = moveViewTabInWorkspace(previousWorkspace, activeTab.id, direction);
+
+        if (nextWorkspace !== previousWorkspace) {
+            await persistTabOrder(previousWorkspace, nextWorkspace);
+        }
     };
 
     const handleSelectTab = async (tab: ViewTab) => {
@@ -210,18 +241,10 @@ export default function Views() {
         syncWorkspace(response.setActiveViewTab);
     };
 
-    const handleSectionDragEnd = async ({ active, over }: DragEndEvent) => {
-        if (!activeTab || !over || active.id === over.id) {
+    const persistSectionOrder = async (previousWorkspace: ViewsWorkspace, nextWorkspace: ViewsWorkspace) => {
+        if (!activeTab) {
             return;
         }
-
-        const previousWorkspace = queryClient.getQueryData<ViewsWorkspace>(queryKeys.views.workspace()) ?? workspace;
-        const nextWorkspace = reorderViewSectionsInWorkspace(
-            previousWorkspace,
-            activeTab.id,
-            String(active.id),
-            String(over.id),
-        );
 
         syncWorkspace(nextWorkspace);
 
@@ -237,6 +260,34 @@ export default function Views() {
         }
 
         await invalidateViews();
+    };
+
+    const handleSectionDragEnd = async ({ active, over }: DragEndEvent) => {
+        if (!activeTab || !over || active.id === over.id) {
+            return;
+        }
+
+        const previousWorkspace = queryClient.getQueryData<ViewsWorkspace>(queryKeys.views.workspace()) ?? workspace;
+        const nextWorkspace = reorderViewSectionsInWorkspace(
+            previousWorkspace,
+            activeTab.id,
+            String(active.id),
+            String(over.id),
+        );
+        await persistSectionOrder(previousWorkspace, nextWorkspace);
+    };
+
+    const handleMoveSection = async (sectionId: string, direction: ViewMoveDirection) => {
+        if (!activeTab) {
+            return;
+        }
+
+        const previousWorkspace = queryClient.getQueryData<ViewsWorkspace>(queryKeys.views.workspace()) ?? workspace;
+        const nextWorkspace = moveViewSectionInWorkspace(previousWorkspace, activeTab.id, sectionId, direction);
+
+        if (nextWorkspace !== previousWorkspace) {
+            await persistSectionOrder(previousWorkspace, nextWorkspace);
+        }
     };
 
     const handleCreateTab = async (title: string) => {
@@ -426,6 +477,23 @@ export default function Views() {
                                         <Dropdown
                                             button={<MoreButton label="View tab actions" />}
                                             items={[
+                                                ...(activeTabIndex > 0
+                                                    ? [
+                                                          {
+                                                              name: 'Move tab left',
+                                                              onClick: () => void handleMoveActiveTab('previous'),
+                                                          },
+                                                      ]
+                                                    : []),
+                                                ...(activeTabIndex >= 0 && activeTabIndex < workspace.tabs.length - 1
+                                                    ? [
+                                                          {
+                                                              name: 'Move tab right',
+                                                              onClick: () => void handleMoveActiveTab('next'),
+                                                          },
+                                                      ]
+                                                    : []),
+                                                ...(workspace.tabs.length > 1 ? [{ type: 'separator' as const }] : []),
                                                 {
                                                     name: 'Rename tab',
                                                     onClick: () => setTabDialogState({ mode: 'edit', tab: activeTab }),
@@ -459,7 +527,7 @@ export default function Views() {
                                                 strategy={verticalListSortingStrategy}
                                             >
                                                 <div className="flex flex-col gap-4">
-                                                    {activeTab.sections.map((section) => (
+                                                    {activeTab.sections.map((section, index) => (
                                                         <SortableViewSection
                                                             key={section.id}
                                                             section={section}
@@ -468,6 +536,17 @@ export default function Views() {
                                                             }
                                                             onDuplicate={() => void handleDuplicateSection(section)}
                                                             onDelete={() => void handleDeleteSection(section.id)}
+                                                            onMoveUp={
+                                                                index > 0
+                                                                    ? () =>
+                                                                          void handleMoveSection(section.id, 'previous')
+                                                                    : undefined
+                                                            }
+                                                            onMoveDown={
+                                                                index < activeTab.sections.length - 1
+                                                                    ? () => void handleMoveSection(section.id, 'next')
+                                                                    : undefined
+                                                            }
                                                         />
                                                     ))}
                                                 </div>


### PR DESCRIPTION
## :dart: Goal

Make saved Views behave consistently in local demo mode and remain reorderable without relying on pointer drag before Ocean Brain 0.9.0.

## :hammer_and_wrench: Core Changes

- Apply each saved section's `title`, `createdAt`, or `updatedAt` sort and direction in the local demo adapter before pagination.
- Add adjacent move helpers shared by tab and section non-drag reorder controls.
- Add Move left/right actions for the active tab and Move up/down actions to each section menu.
- Add keyboard drag support to the tab bar while preserving the existing mouse drag path.
- Add local adapter, reorder helper, and rendered menu regression tests.

## :brain: Key Decisions

- Keep the server ordering contract unchanged; the bug was isolated to the local demo adapter.
- Reuse the existing reorder mutations and optimistic rollback behavior for menu actions, so drag and non-drag paths persist exactly the same order.
- Keep Calendar as a model-compatibility value but do not expose it in the create/edit UI while its renderer is unsupported.
- Do not add a new live query-preview server contract during release stabilization. Saved section cards already show displayed and total matching counts.

## :test_tube: Verification Guide

### How to verify

1. In local demo mode, create a View section and switch between title, created, and updated sorting in both directions.
2. Use the active tab menu to move a tab left or right.
3. Use a section actions menu to move a section up or down without dragging.
4. Focus a tab and use the sortable keyboard interaction.
5. Run `pnpm test`, `pnpm lint`, `pnpm type-check`, `pnpm check:encoding`, and `pnpm build`.

### Expected result

- Local demo results use the same saved sort semantics as server-backed Views.
- Tab and section orders persist through menu actions and roll back on API failure.
- Boundary items omit impossible move actions.
- All workspace checks pass.

## :white_check_mark: Checklist

- [x] Added failing regression tests before implementation.
- [x] Verified 29 CLI tests, 400 server tests, and 345 client tests.
- [x] Verified lint, type checking, encoding, and production builds.
- [x] Reviewed unsupported preview and Calendar scope for 0.9.0.
