### PR TITLE
🔖 Restore version to 0.8.2

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ocean-brain",
-    "version": "0.9.0",
+    "version": "0.8.2",
     "license": "MIT",
     "type": "module",
     "repository": {


### PR DESCRIPTION
## :dart: Goal
Restore the CLI package to the currently published `0.8.2` version after the premature `0.9.0` version-only PR was merged.

## :hammer_and_wrench: Core Changes
- Change `packages/cli/package.json` from `0.9.0` back to `0.8.2`.
- Keep `oceanBrain.mcpCompatibilityVersion` at its intentionally selected `0.9.0` compatibility line.
- Do not change runtime behavior, release artifacts, or application code.

## :brain: Key Decisions
- The expected package state after this PR is `0.8.2`, matching the currently published npm version.
- This PR has no tag plan and must not trigger a release.
- Create the real `0.9.0` bump as a dedicated release PR only after all intended feature and bug-fix PRs are merged.
- Require both E2E and CLI_SMOKE to pass on that future release PR before merging and explicitly tagging `v0.9.0`.

## :test_tube: Verification Guide
- `pnpm check:encoding` passes.
- `pnpm check:deps` passes.
- `pnpm --filter ocean-brain type-check` passes.
- `pnpm --filter ocean-brain test:ci` passes with 29 tests.
- `pnpm --filter ocean-brain build` passes.
- Required PR CI and CodeQL pass.
- E2E and CLI_SMOKE are expected to skip because this is intentionally not a `chore/release-v*` branch.
- Confirm there is no remote `v0.9.0` tag, no GitHub `v0.9.0` release, and npm still publishes `ocean-brain@0.8.2`.

## :white_check_mark: Checklist
- [x] Only the premature package version change is reverted.
- [x] MCP compatibility metadata is preserved.
- [x] No tag or deployment is created.
- [x] Changed-scope local validation passes.
- [x] Required PR CI and CodeQL pass.
- [x] Release-only E2E and CLI_SMOKE remain reserved for the actual release PR.