### PR TITLE
🐛 Use glibc Docker runtime for sqlite-vec

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,48 +1,6 @@
-# sqlite-vec's published Linux binaries target glibc. Build the same pinned
-# extension for Alpine's musl libc in a disposable stage instead of enlarging
-# the runtime image with a second libc or a compiler toolchain.
-FROM alpine:3.24 AS sqlite-vec-build
-
-# Keep this source revision aligned with the sqlite-vec version in the npm package.
-ARG SQLITE_VEC_COMMIT=e9f598abfa0c06b328d8fe5da9c3760cce74be10
-ARG SQLITE_VEC_SOURCE_SHA256=ee2eb0be751c02286d5a6c6c113dd9e754f0ac29973b01aba35a2d736e35ed3b
-ARG SQLITE_AMALGAMATION_SHA256=ea170e73e447703e8359308ca2e4366a3ae0c4304a8665896f068c736781c651
-
-RUN apk add --no-cache build-base curl gettext-envsubst unzip \
-    && mkdir -p /tmp/sqlite-vec \
-    && curl -fsSL \
-        "https://github.com/asg017/sqlite-vec/archive/${SQLITE_VEC_COMMIT}.tar.gz" \
-        -o /tmp/sqlite-vec.tar.gz \
-    && echo "${SQLITE_VEC_SOURCE_SHA256}  /tmp/sqlite-vec.tar.gz" | sha256sum -c - \
-    && tar -xzf /tmp/sqlite-vec.tar.gz --strip-components=1 -C /tmp/sqlite-vec \
-    && curl -fsSL \
-        https://www.sqlite.org/2024/sqlite-amalgamation-3450300.zip \
-        -o /tmp/sqlite-amalgamation.zip \
-    && echo "${SQLITE_AMALGAMATION_SHA256}  /tmp/sqlite-amalgamation.zip" | sha256sum -c - \
-    && mkdir -p /tmp/sqlite-vec/vendor \
-    && unzip -q /tmp/sqlite-amalgamation.zip -d /tmp \
-    && mv /tmp/sqlite-amalgamation-3450300/* /tmp/sqlite-vec/vendor/ \
-    && cd /tmp/sqlite-vec \
-    && sqlite_vec_version="$(cat VERSION)" \
-    && sqlite_vec_major="$(echo "${sqlite_vec_version}" | cut -d. -f1)" \
-    && sqlite_vec_minor="$(echo "${sqlite_vec_version}" | cut -d. -f2)" \
-    && sqlite_vec_patch="$(echo "${sqlite_vec_version}" | cut -d. -f3 | cut -d- -f1)" \
-    && mkdir -p dist \
-    && VERSION="${sqlite_vec_version}" \
-        DATE="$(date -u +%FT%TZ)" \
-        SOURCE="${SQLITE_VEC_COMMIT}" \
-        VERSION_MAJOR="${sqlite_vec_major}" \
-        VERSION_MINOR="${sqlite_vec_minor}" \
-        VERSION_PATCH="${sqlite_vec_patch}" \
-        envsubst < sqlite-vec.h.tmpl > sqlite-vec.h \
-    && cc -fPIC -shared -Wall -Wextra -Ivendor/ -O3 -include sys/types.h -lm sqlite-vec.c -o dist/vec0.so \
-    && strip --strip-unneeded /tmp/sqlite-vec/dist/vec0.so \
-    && test -s /tmp/sqlite-vec/dist/vec0.so
-
-FROM node:22-alpine AS install
+FROM node:22-trixie-slim@sha256:e6d9a389d34ff9678438af985c9913fbd1eb6ed36e80fea56644f4b4f6dd70ba AS install
 
 ARG VERSION=latest
-ARG TARGETARCH
 RUN npm i -g --omit=dev --no-audit --no-fund ocean-brain@${VERSION} \
     && APP_ROOT="$(npm root -g)/ocean-brain" \
     && find "$APP_ROOT" -type f \( \
@@ -50,35 +8,20 @@ RUN npm i -g --omit=dev --no-audit --no-fund ocean-brain@${VERSION} \
         -name '*.d.ts' -o \
         -name '*.d.mts' -o \
         -name '*.d.cts' \
-    \) -delete
+    \) -delete \
+    && mkdir -p /runtime/data /runtime/assets/images
 
-COPY --from=sqlite-vec-build /tmp/sqlite-vec/dist/vec0.so /tmp/vec0.so
+# Keep the current root-user behavior so existing host bind mounts remain writable.
+# The distroless runtime still removes the shell and package manager.
+FROM gcr.io/distroless/nodejs22-debian13:latest@sha256:4693a48bdba4a676bf3f0c0a66c106c242ba3167fbc97d5008171c37d96dee12
 
-RUN case "${TARGETARCH}" in \
-        amd64) SQLITE_VEC_PACKAGE=sqlite-vec-linux-x64 ;; \
-        arm64) SQLITE_VEC_PACKAGE=sqlite-vec-linux-arm64 ;; \
-        *) echo "Unsupported Docker architecture: ${TARGETARCH}" >&2; exit 1 ;; \
-    esac \
-    && SQLITE_VEC_PATH="/usr/local/lib/node_modules/ocean-brain/node_modules/${SQLITE_VEC_PACKAGE}/vec0.so" \
-    && test -f "${SQLITE_VEC_PATH}" \
-    && cp /tmp/vec0.so "${SQLITE_VEC_PATH}" \
-    && rm /tmp/vec0.so \
-    && cd /usr/local/lib/node_modules/ocean-brain \
-    && node --input-type=module -e 'import sqlite3 from "sqlite3"; import { getLoadablePath } from "sqlite-vec"; const database = new sqlite3.Database(":memory:"); database.loadExtension(getLoadablePath(), (error) => { if (error) { console.error(error); process.exitCode = 1; } database.close(); });'
-
-FROM alpine:3.24
-
-RUN apk add --no-cache libgcc libstdc++ openssl
-
-COPY --from=install /usr/local/bin/node /usr/local/bin/node
 COPY --from=install /usr/local/lib/node_modules/ocean-brain /usr/local/lib/node_modules/ocean-brain
-
-RUN ln -s ../lib/node_modules/ocean-brain/dist/index.js /usr/local/bin/ocean-brain \
-    && mkdir -p /data /assets/images
+COPY --from=install /runtime/data /data
+COPY --from=install /runtime/assets /assets
 
 ENV OCEAN_BRAIN_DATA_DIR=/data
 ENV OCEAN_BRAIN_IMAGE_DIR=/assets/images
 ENV DATABASE_URL="file:/data/db.sqlite3"
 
 EXPOSE 6683
-CMD ["ocean-brain", "serve"]
+CMD ["/usr/local/lib/node_modules/ocean-brain/dist/index.js", "serve"]

--- a/scripts/ci/smoke-docker-image.mjs
+++ b/scripts/ci/smoke-docker-image.mjs
@@ -137,6 +137,42 @@ async function assertGraphql() {
     }
 }
 
+function assertSqliteVectorExtension() {
+    const appModules = '/usr/local/lib/node_modules/ocean-brain/node_modules';
+    const script = `
+        const sqlite3 = require('${appModules}/sqlite3');
+        const { getLoadablePath } = require('${appModules}/sqlite-vec');
+        const database = new sqlite3.Database(':memory:');
+
+        database.loadExtension(getLoadablePath(), loadError => {
+            if (loadError) throw loadError;
+
+            database.get(
+                "SELECT vec_version() AS version, vec_distance_cosine('[1,0]', '[0,1]') AS distance",
+                (queryError, row) => {
+                    if (queryError) throw queryError;
+                    if (!row.version || row.distance !== 1) {
+                        throw new Error('Unexpected sqlite-vec result: ' + JSON.stringify(row));
+                    }
+
+                    console.log('sqlite-vec verification passed: ' + JSON.stringify(row));
+                    database.close(closeError => {
+                        if (closeError) throw closeError;
+                    });
+                }
+            );
+        });
+    `;
+
+    run('docker', [
+        'run',
+        '--rm',
+        '--entrypoint', '/nodejs/bin/node',
+        image,
+        '-e', script
+    ]);
+}
+
 function cleanup() {
     spawnSync('docker', ['logs', containerName], { stdio: 'inherit' });
     spawnSync('docker', ['rm', '-f', containerName], { stdio: 'ignore' });
@@ -151,6 +187,7 @@ async function main() {
     await pullWithRetry();
 
     try {
+        assertSqliteVectorExtension();
         run('docker', [
             'run',
             '--rm',


### PR DESCRIPTION
## :dart: Goal

- Make the Docker image load the published `sqlite-vec` native extension reliably on both amd64 and arm64.
- Keep existing 0.8 bind-mounted databases and images writable and readable after upgrading to 0.9.

## :hammer_and_wrench: Core Changes

- Replace the Alpine source-build path with a pinned Node 22 Debian 13 installer stage and a pinned distroless Node 22 Debian 13 runtime.
- Copy only the installed application and the required empty data/image directories into the runtime image.
- Add a Docker smoke assertion that loads `sqlite-vec` and runs a cosine-distance query.

## :brain: Key Decisions

- Use a glibc runtime because the published `sqlite-vec` Linux artifacts already target glibc. This removes the Alpine-only compiler, downloaded source archives, checksum maintenance, and native replacement logic.
- Keep the runtime as root. The official 0.8.2 image and the new runtime both run with `uid=0, gid=0`, preserving existing host bind-mount behavior for `/data` and `/assets`.
- Keep extension verification in the Docker smoke test instead of embedding test-only JavaScript in the Dockerfile.
- Expected release version: `0.9.0`.
- Tag plan: `v0.9.0`.

## :test_tube: Verification Guide

### How to verify

1. Run the repository checks:
   ```sh
   pnpm check:encoding
   pnpm lint
   pnpm type-check
   pnpm test:ci
   pnpm build
   ```
2. Build the release package and run the CLI smoke test:
   ```sh
   node scripts/release/prepublish.mjs
   pnpm --dir packages/cli pack --pack-destination ../..
   env -u PORT CLI_SMOKE_PORT=16690 node scripts/ci/smoke-cli-npx.mjs ocean-brain-0.8.2.tgz
   ```
3. Build the Docker candidate, create notes and a PNG with `baealex/ocean-brain:0.8.2`, then start the candidate with the same `/data` and `/assets` mounts. Configure a local OpenAI-compatible embedding endpoint, rebuild the index, run a semantic-only query, and restart the container.

### Expected result

- Encoding, lint, type-check, tests, build, and `CLI_SMOKE` pass.
- Current test totals: CLI 29, server 397, and client 358 passed.
- The Docker extension check returns sqlite-vec `v0.1.9` and cosine distance `1` on amd64 and arm64.
- The local arm64 upgrade test keeps both 0.8 notes and the uploaded PNG byte-for-byte, reports no pending migrations, indexes 2 notes into 2 chunks, returns the intended note first for a semantic-only query with no lexical overlap, and remains ready after restart.
- Existing bind mounts remain writable because the runtime UID/GID contract is unchanged.

## :white_check_mark: Checklist

- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (not needed; no user-facing command or configuration changed)
