### PR TITLE
💥 Remove hash tag compatibility

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -53,6 +53,6 @@
         "zod": "^3.25.76"
     },
     "oceanBrain": {
-        "mcpCompatibilityVersion": "0.9.0"
+        "mcpCompatibilityVersion": "0.10.0"
     }
 }

--- a/packages/cli/src/mcp-intent-write-tools.ts
+++ b/packages/cli/src/mcp-intent-write-tools.ts
@@ -180,7 +180,7 @@ export const registerIntentWriteTools = (
             id: z.string().describe('Note ID to append to'),
             ...markdownWriteBaselineFields,
             intent: z.string().describe('Human-readable reason for the append.'),
-            insertion: z.string().describe('Markdown to append. Tags are body tokens such as [@tag] or [#tag].'),
+            insertion: z.string().describe('Markdown to append. Tags are body tokens such as [@tag].'),
             placement: markdownAppendPlacementSchema.optional().describe('Default is end. after_heading requires one unique matching heading.'),
             separator: z.enum(['\n\n', '\n']).optional().describe('Separator inserted around appended markdown. Defaults to a blank line.'),
             policy: markdownWritePolicySchema
@@ -235,7 +235,7 @@ export const registerIntentWriteTools = (
             id: z.string().describe('Note ID to replace'),
             ...markdownWriteBaselineFields,
             intent: z.string().describe('Human-readable reason for the full replace.'),
-            replacement: z.string().describe('Complete replacement markdown body. Tags are body tokens such as [@tag] or [#tag].'),
+            replacement: z.string().describe('Complete replacement markdown body. Tags are body tokens such as [@tag].'),
             policy: markdownWritePolicySchema
         },
         async ({ id, expectedUpdatedAt, baseMarkdownSha256, intent, replacement, policy }) => {

--- a/packages/cli/src/mcp.ts
+++ b/packages/cli/src/mcp.ts
@@ -94,11 +94,15 @@ const propertyFilterSchema = z.object({
     value: z.string().nullable().optional().describe('Filter value. Required unless operator is exists or notExists. select=option.value, date=YYYY-MM-DD, boolean=true/false, number=finite, url=http(s).')
 });
 
-const normalizeOceanBrainTagName = (name: string) => {
+export const normalizeOceanBrainTagName = (name: string) => {
     const trimmedName = name.trim();
 
     if (!trimmedName) {
         throw new Error('Tag name is required.');
+    }
+
+    if (trimmedName.startsWith('#')) {
+        throw new Error('Ocean Brain tags use @, not #. Example: @project');
     }
 
     const normalizedName = trimmedName.startsWith('@')
@@ -332,7 +336,7 @@ const registerMcpTools = (
         'Create an Ocean Brain note from markdown. Search/read first to avoid duplicates; prefer patching an existing note when the intent is a local change.',
         {
             title: z.string().describe('Note title'),
-            markdown: z.string().optional().default('').describe('Markdown body for the new note. In MCP markdown, tags must use [@tag] or [#tag]. Defaults to an empty note body.'),
+            markdown: z.string().optional().default('').describe('Markdown body for the new note. In MCP markdown, tags must use [@tag]. Defaults to an empty note body.'),
             layout: noteLayoutSchema.optional().describe('Optional note layout: narrow, wide, or full. Prefer wide for most notes unless the user explicitly wants narrow or full.')
         },
         async ({ title, markdown, layout }) => {
@@ -615,7 +619,7 @@ const registerMcpTools = (
         'Call ocean_brain_list_properties first. Requires >=1 propertyFilter; use search/recent for broad lists. Use key/valueType from the property definition. Values are strings: select=option.value, date=YYYY-MM-DD, boolean=true/false, number=finite, url=http(s). exists/notExists need no value. Property filters use AND; tagNames use mode. Summaries are returned by default; use propertyKeys for needed property details.',
         {
             propertyFilters: z.array(propertyFilterSchema).min(1).max(10).describe('Required property filters. Multiple property filters are combined with AND.'),
-            tagNames: z.array(z.string()).optional().default([]).describe('Optional tag filters. You can pass @project, #project, or project.'),
+            tagNames: z.array(z.string()).optional().default([]).describe('Optional tag filters. You can pass @project or project.'),
             mode: tagMatchModeSchema.optional().default('and').describe('Tag match mode for tagNames only. Property filters are always combined with AND.'),
             sortBy: viewSortBySchema.optional().default('updatedAt').describe('Sort field (default: updatedAt)'),
             sortOrder: viewSortOrderSchema.optional().default('desc').describe('Sort order (default: desc)'),
@@ -626,6 +630,7 @@ const registerMcpTools = (
         },
         async ({ propertyFilters, tagNames, mode, sortBy, sortOrder, includeProperties, propertyKeys, limit, offset }) => {
             const shouldIncludeProperties = includeProperties || propertyKeys.length > 0;
+            const normalizedTagNames = normalizeOceanBrainTagNames(tagNames);
             const data = await graphql(serverUrl, token, `
                 query ($input: NotesByPropertiesInput!, $pagination: PaginationInput, $includeProperties: Boolean!) {
                     notesByProperties(input: $input, pagination: $pagination) {
@@ -642,7 +647,7 @@ const registerMcpTools = (
                 }
             `, {
                 input: {
-                    tagNames,
+                    tagNames: normalizedTagNames,
                     mode,
                     propertyFilters,
                     sortBy,
@@ -658,7 +663,7 @@ const registerMcpTools = (
                 result,
                 query: {
                     propertyFilters,
-                    tagNames,
+                    tagNames: normalizedTagNames,
                     mode,
                     sortBy,
                     sortOrder,
@@ -783,6 +788,7 @@ const registerMcpTools = (
         },
         async ({ name }) => {
             const writeToken = requireWriteToken(token, OCEAN_BRAIN_MCP_TOOLS.createTag);
+            const normalizedName = normalizeOceanBrainTagName(name);
             const result = await jsonRequest<{
                 created: boolean;
                 normalizedName: string;
@@ -793,7 +799,7 @@ const registerMcpTools = (
                     updatedAt: string;
                 };
             }>(serverUrl, writeToken, '/api/mcp/tags/create', {
-                name
+                name: normalizedName
             });
 
             return createMcpJsonToolResult(result);

--- a/packages/cli/test/mcp.test.ts
+++ b/packages/cli/test/mcp.test.ts
@@ -3,6 +3,7 @@ import test from 'node:test';
 
 import {
     createMcpRequestHeaders,
+    normalizeOceanBrainTagName,
     OCEAN_BRAIN_MCP_CLIENT_VERSION_HEADER,
     OCEAN_BRAIN_MCP_COMPATIBILITY_VERSION,
     OCEAN_BRAIN_MCP_COMPATIBILITY_VERSION_HEADER,
@@ -14,8 +15,14 @@ test('createMcpRequestHeaders includes MCP compatibility and client version head
 
     assert.equal(headers['Content-Type'], 'application/json');
     assert.equal(headers.Authorization, 'Bearer token-a');
-    assert.equal(OCEAN_BRAIN_MCP_COMPATIBILITY_VERSION, '0.9.0');
+    assert.equal(OCEAN_BRAIN_MCP_COMPATIBILITY_VERSION, '0.10.0');
     assert.equal(headers[OCEAN_BRAIN_MCP_VERSION_HEADER], OCEAN_BRAIN_MCP_COMPATIBILITY_VERSION);
     assert.equal(headers[OCEAN_BRAIN_MCP_COMPATIBILITY_VERSION_HEADER], OCEAN_BRAIN_MCP_COMPATIBILITY_VERSION);
     assert.match(headers[OCEAN_BRAIN_MCP_CLIENT_VERSION_HEADER], /^\d+\.\d+\.\d+/);
+});
+
+test('normalizeOceanBrainTagName rejects hash-prefixed tags', () => {
+    assert.throws(() => normalizeOceanBrainTagName('#project'), /use @, not #/);
+    assert.equal(normalizeOceanBrainTagName('project'), '@project');
+    assert.equal(normalizeOceanBrainTagName('@project'), '@project');
 });

--- a/packages/client/src/modules/local-demo/plugins/notes.spec.ts
+++ b/packages/client/src/modules/local-demo/plugins/notes.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import type { Note } from '~/models/note.model';
 import type { LocalDemoState } from '../types';
+import { normalizeTagName } from '../utils';
 import { notesLocalPlugin } from './notes';
 
 const createNote = (input: Pick<Note, 'id' | 'title' | 'tags'>): Note => ({
@@ -61,6 +62,10 @@ const createState = (): LocalDemoState => {
 };
 
 describe('notesLocalPlugin', () => {
+    it('rejects hash-prefixed tags instead of normalizing them', () => {
+        expect(() => normalizeTagName('#guide')).toThrow('use @, not #');
+    });
+
     it('filters tagged notes by tag id for the tag notes page', () => {
         const handler = notesLocalPlugin.graphHandlers?.FetchTagNotes;
         expect(handler).toBeDefined();

--- a/packages/client/src/modules/local-demo/utils.ts
+++ b/packages/client/src/modules/local-demo/utils.ts
@@ -59,7 +59,12 @@ export const findNote = (state: LocalDemoState, noteId: unknown) => {
 export const normalizeTagName = (name: string) => {
     const trimmed = name.trim();
     if (!trimmed) return '';
-    return `@${trimmed.replace(/^[@#]+/, '')}`;
+
+    if (trimmed.startsWith('#')) {
+        throw new Error('Tag names must use @, not #.');
+    }
+
+    return trimmed.startsWith('@') ? trimmed : `@${trimmed}`;
 };
 
 export const ensureTag = (state: LocalDemoState, name: string) => {

--- a/packages/client/src/modules/view-dashboard.spec.ts
+++ b/packages/client/src/modules/view-dashboard.spec.ts
@@ -38,8 +38,8 @@ const createSection = (section: {
 });
 
 describe('view-dashboard helpers', () => {
-    it('normalizes hash-prefixed or plain tags to the canonical @ form', () => {
-        expect(normalizeViewTagNames([' project ', '#doing', '@todo', ''])).toEqual(['@project', '@doing', '@todo']);
+    it('normalizes plain or @-prefixed tags and ignores hash-prefixed tags', () => {
+        expect(normalizeViewTagNames([' project ', '#doing', '@todo', ''])).toEqual(['@project', '@todo']);
     });
 
     it('returns the first tab when the active id is missing', () => {

--- a/packages/client/src/modules/view-dashboard.ts
+++ b/packages/client/src/modules/view-dashboard.ts
@@ -32,7 +32,7 @@ const normalizeTagName = (value: string) => {
     }
 
     if (trimmedValue.startsWith('#')) {
-        return `@${trimmedValue.slice(1)}`;
+        return '';
     }
 
     return `@${trimmedValue}`;

--- a/packages/server/src/features/mcp-admin/http/handlers.test.ts
+++ b/packages/server/src/features/mcp-admin/http/handlers.test.ts
@@ -182,8 +182,8 @@ test('POST /api/mcp-admin/enabled toggles enabled state for authenticated sessio
         version?: unknown;
     };
     assert.equal(typeof serverInfo.version, 'string');
-    assert.equal(serverInfo.mcpVersionRequirement, '0.9.x');
-    assert.equal(serverInfo.mcp?.compatibilityRequirement, '0.9.x');
+    assert.equal(serverInfo.mcpVersionRequirement, '0.10.x');
+    assert.equal(serverInfo.mcp?.compatibilityRequirement, '0.10.x');
 });
 
 test('POST /api/mcp-admin/token/revoke revokes active token for authenticated session', async (t) => {

--- a/packages/server/src/features/tag/services/organization.test.ts
+++ b/packages/server/src/features/tag/services/organization.test.ts
@@ -8,8 +8,9 @@ test('normalizeTagName trims input and prefixes Ocean Brain tags with @', () => 
     assert.equal(normalizeTagName('  @project  '), '@project');
 });
 
-test('normalizeTagName rejects empty or multi-token tag names', () => {
+test('normalizeTagName rejects empty, hash-prefixed, or multi-token tag names', () => {
     assert.throws(() => normalizeTagName('   '), InvalidTagNameError);
+    assert.throws(() => normalizeTagName('#project'), InvalidTagNameError);
     assert.throws(() => normalizeTagName('project alpha'), InvalidTagNameError);
 });
 

--- a/packages/server/src/features/tag/services/organization.ts
+++ b/packages/server/src/features/tag/services/organization.ts
@@ -37,6 +37,10 @@ export const normalizeTagName = (name: string) => {
         throw new InvalidTagNameError('A tag name is required.');
     }
 
+    if (trimmedName.startsWith('#')) {
+        throw new InvalidTagNameError('Tag names must use @, not #. Example: @project.');
+    }
+
     const normalizedName = trimmedName.startsWith('@') ? trimmedName : `@${trimmedName}`;
 
     if (normalizedName === '@' || /\s/.test(normalizedName.slice(1))) {

--- a/packages/server/src/features/view/services/workspace.test.ts
+++ b/packages/server/src/features/view/services/workspace.test.ts
@@ -19,19 +19,23 @@ import {
     type ViewSectionRecord,
 } from './workspace.js';
 
-test('normalizeViewTagNames trims values and canonicalizes plain or hash-prefixed tags', () => {
-    assert.deepEqual(normalizeViewTagNames([' project ', '#doing', '@todo', '', '@todo']), [
+test('normalizeViewTagNames trims values and canonicalizes plain or @-prefixed tags', () => {
+    assert.deepEqual(normalizeViewTagNames([' project ', '@doing', '@todo', '', '@todo']), [
         '@project',
         '@doing',
         '@todo',
     ]);
 });
 
+test('normalizeViewTagNames rejects hash-prefixed tags', () => {
+    assert.throws(() => normalizeViewTagNames(['#doing']), /use @, not #/);
+});
+
 test('normalizeViewSectionInput derives a default title and clamps invalid limits', () => {
     assert.deepEqual(
         normalizeViewSectionInput({
             title: '   ',
-            tagNames: ['project', '#review'],
+            tagNames: ['project', '@review'],
             mode: 'or',
             limit: 999,
         }),
@@ -151,7 +155,7 @@ test('normalizeViewPropertyFilters validates typed filter values', () => {
 test('normalizeViewNotesQueryInput normalizes property query filters without section-only fields', () => {
     assert.deepEqual(
         normalizeViewNotesQueryInput({
-            tagNames: ['project', '#doing'],
+            tagNames: ['project', '@doing'],
             mode: 'or',
             propertyFilters: [{ key: ' State ', valueType: 'select', operator: 'equals', value: 'doing' }],
             sortBy: 'title',

--- a/packages/server/src/features/view/services/workspace.ts
+++ b/packages/server/src/features/view/services/workspace.ts
@@ -153,7 +153,7 @@ const normalizeTagName = (value: string) => {
     }
 
     if (trimmedValue.startsWith('#')) {
-        return `@${trimmedValue.slice(1)}`;
+        throw new Error('View tag names must use @, not #.');
     }
 
     return `@${trimmedValue}`;

--- a/packages/server/src/modules/app-version.test.ts
+++ b/packages/server/src/modules/app-version.test.ts
@@ -46,7 +46,7 @@ test('resolveMcpCompatibilityVersion reads explicit package compatibility metada
             }),
         );
 
-        assert.equal(resolveMcpCompatibilityVersion(), '0.9.0');
+        assert.equal(resolveMcpCompatibilityVersion(), '0.10.0');
         assert.equal(resolveMcpCompatibilityVersionFromPaths([packageJsonPath]), '0.8.0');
     } finally {
         fs.rmSync(tempDir, { recursive: true, force: true });

--- a/packages/server/src/modules/blocknote.ts
+++ b/packages/server/src/modules/blocknote.ts
@@ -291,7 +291,7 @@ function restoreTagPlaceholdersInMarkdown(markdown: string, placeholderToTag: Ma
 function preprocessMarkdownExplicitTags(markdown: string) {
     const placeholderToTag = new Map<string, string>();
     let nextPlaceholderIndex = 0;
-    const preprocessedMarkdown = markdown.replace(/\[([@#][^\s[\]]+)\]/g, (_match, tagToken: string) => {
+    const preprocessedMarkdown = markdown.replace(/\[(@[^\s[\]]+)\]/g, (_match, tagToken: string) => {
         const placeholder = createTagPlaceholder(nextPlaceholderIndex++);
         placeholderToTag.set(placeholder, tagToken);
         return placeholder;
@@ -1237,15 +1237,14 @@ async function restoreCustomInlineContent(
     const noteByIdCache = new Map<string, Promise<{ id: string; title: string } | null>>();
 
     const getTag = (token: string) => {
-        const normalizedToken = token.startsWith('#') ? `@${token.slice(1)}` : token;
-        let existing = tagCache.get(normalizedToken);
+        let existing = tagCache.get(token);
 
         if (!existing) {
-            existing = deps.ensureTag(normalizedToken.slice(1)).then((result) => ({
+            existing = deps.ensureTag(token.slice(1)).then((result) => ({
                 id: 'tag' in result ? result.tag.id : result.id,
                 tag: 'tag' in result ? result.tag.name : result.name,
             }));
-            tagCache.set(normalizedToken, existing);
+            tagCache.set(token, existing);
         }
 
         return existing;

--- a/packages/server/test/blocknote.test.ts
+++ b/packages/server/test/blocknote.test.ts
@@ -582,11 +582,12 @@ test('markdownToBlocksJson restores custom tag and reference inline content from
     ]);
 });
 
-test('markdownToBlocksJson restores custom tag and reference inline content from explicit # tags', async () => {
+test('markdownToBlocksJson leaves explicit # tag syntax as text', async () => {
+    let ensureTagCalls = 0;
     const contentJson = await markdownToBlocksJson('[#project] [[Reference Note]]', {
         ensureTag: async () => ({
-            id: '12',
-            name: '@project',
+            id: String(++ensureTagCalls),
+            name: '@should-not-exist',
         }),
         findNotesByTitle: async (title) => {
             if (title === 'Reference Note') {
@@ -604,17 +605,11 @@ test('markdownToBlocksJson restores custom tag and reference inline content from
 
     const blocks = JSON.parse(contentJson);
 
+    assert.equal(ensureTagCalls, 0);
     assert.deepEqual(blocks[0].content, [
         {
-            type: 'tag',
-            props: {
-                id: '12',
-                tag: '@project',
-            },
-        },
-        {
             type: 'text',
-            text: ' ',
+            text: '[#project] ',
             styles: {},
         },
         {

--- a/packages/server/test/mcp-auth.test.ts
+++ b/packages/server/test/mcp-auth.test.ts
@@ -347,8 +347,8 @@ test('mcp version guard blocks compatibility minor version differences', async (
     assert.equal(body.mcpCompatibilityVersion, createIncompatibleMcpVersion());
     assert.equal(body.mcpClientVersion, resolveOceanBrainVersion());
     assert.equal(body.serverVersion, resolveOceanBrainVersion());
-    assert.equal(body.requiredMcpVersion, '0.9.x');
-    assert.equal(body.requiredMcpCompatibilityVersion, '0.9.x');
+    assert.equal(body.requiredMcpVersion, '0.10.x');
+    assert.equal(body.requiredMcpCompatibilityVersion, '0.10.x');
     assert.match(String(body.message), /Please update Ocean Brain MCP/);
     assert.match(String(body.message), /https:\/\/github\.com\/baealex\/ocean-brain\/releases/);
 });


### PR DESCRIPTION
## :dart: Goal
- Remove the deprecated `[#tag]` compatibility path so Ocean Brain accepts canonical `[@tag]` syntax only.
- Publish the breaking MCP contract change as the planned pre-1.0 `0.10.0` release.

## :hammer_and_wrench: Core Changes
- Parse only `[@tag]` as Markdown tag content; preserve `[#tag]` as ordinary text.
- Reject hash-prefixed tags in MCP, server, saved-view, and local-demo normalization paths.
- Update MCP tool guidance and compatibility requirement to `0.10.0` / `0.10.x`.

## :brain: Key Decisions
- `#` inputs now fail or remain literal rather than silently converting to `@`, preventing a deprecated syntax from creating tags.
- Bare tag names remain accepted where they were already supported and normalize to `@name`.
- The source PR is labelled `release: major` because it removes a public MCP contract; the project remains pre-1.0, so the release workflow will prepare version `0.10.0` and tag `v0.10.0`.

## :test_tube: Verification Guide
### How to verify
1. Run `pnpm check:encoding`, `pnpm lint`, `pnpm type-check`, and `pnpm --filter ocean-brain type-check`.
2. Run `pnpm test:ci` and `pnpm build`, then `pnpm --filter ocean-brain build`.
3. Send `[@project]` and `[#project]` through Markdown import and MCP tag inputs.

### Expected result
- `[@project]` creates/uses `@project`; `[#project]` stays text in Markdown and is rejected by MCP/server tag validation.
- MCP compatibility response/header requires `0.10.x`; all local checks above pass.
- Expected release: `0.10.0`; tag plan: `v0.10.0`; `CLI_SMOKE` will be required and recorded on the dedicated release PR before tagging.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)