### PR TITLE
✨ Add MCP semantic search

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -53,6 +53,6 @@
         "zod": "^3.25.76"
     },
     "oceanBrain": {
-        "mcpCompatibilityVersion": "0.10.0"
+        "mcpCompatibilityVersion": "0.11.0"
     }
 }

--- a/packages/cli/src/mcp.ts
+++ b/packages/cli/src/mcp.ts
@@ -60,6 +60,13 @@ const propertyValueTypeSchema = z.enum(['text', 'url', 'number', 'date', 'boolea
 const propertyFilterOperatorSchema = z.enum(['equals', 'before', 'after', 'exists', 'notExists']);
 const viewSortBySchema = z.enum(['updatedAt', 'createdAt', 'title']);
 const viewSortOrderSchema = z.enum(['asc', 'desc']);
+const searchModeSchema = z.enum(['hybrid', 'lexical', 'semantic']);
+
+const graphqlSearchModes = {
+    hybrid: 'HYBRID',
+    lexical: 'LEXICAL',
+    semantic: 'SEMANTIC',
+} as const;
 
 interface McpGraphqlErrorShape {
     message: string;
@@ -222,23 +229,78 @@ const requireWriteToken = (token: string | undefined, toolName: string) => {
     throw new Error(`${toolName} requires an MCP bearer token. Set --token or --token-file.`);
 };
 
-const registerMcpTools = (
+interface McpSearchNote {
+    id: string;
+    title: string;
+    updatedAt: string;
+    tags: Array<{ id: string; name: string }>;
+    contentAsMarkdown: string;
+}
+
+const formatMcpSearchNotes = (notes: McpSearchNote[]) => notes.map((note) => ({
+    id: note.id,
+    title: note.title,
+    updatedAt: note.updatedAt,
+    tags: note.tags.map((t) => t.name),
+    preview: note.contentAsMarkdown.slice(0, 100),
+}));
+
+export const registerMcpTools = (
     server: McpServer,
     serverUrl: string,
     token?: string
 ) => {
     server.tool(
         OCEAN_BRAIN_MCP_TOOLS.searchNotes,
-        'Search Ocean Brain notes by keyword. Returns matching note titles and tags. Use ocean_brain_read_note to get full content for a specific note.',
+        'Search Ocean Brain notes by keyword or meaning. Hybrid search combines both; use lexical for exact terms and semantic for meaning-based recall. Returns matching note titles, tags, previews, and search status. Use ocean_brain_read_note to get full content for a specific note.',
         {
-            query: z.string().describe('Search keyword'),
+            query: z.string().describe('Search words or a natural-language description'),
             limit: z.number().optional().default(10).describe('Max results (default: 10)'),
+            mode: searchModeSchema.optional().describe('Optional search mode: hybrid or semantic enables meaning search; omit for the legacy keyword search'),
         },
-        async ({ query, limit }) => {
+        async ({ query, limit, mode }) => {
+            if (!mode || mode === 'lexical') {
+                const data = await graphql(serverUrl, token, `
+                    query ($searchFilter: SearchFilterInput, $pagination: PaginationInput) {
+                        allNotes(searchFilter: $searchFilter, pagination: $pagination) {
+                            totalCount
+                            notes {
+                                id
+                                title
+                                updatedAt
+                                tags { id name }
+                                contentAsMarkdown
+                            }
+                        }
+                    }
+                `, {
+                    searchFilter: { query, sortBy: 'updatedAt', sortOrder: 'desc' },
+                    pagination: { limit, offset: 0 },
+                });
+
+                const result = data?.allNotes as {
+                    totalCount: number;
+                    notes: McpSearchNote[];
+                };
+
+                return createMcpJsonToolResult({
+                    totalCount: result.totalCount,
+                    notes: formatMcpSearchNotes(result.notes),
+                });
+            }
+
             const data = await graphql(serverUrl, token, `
-                query ($searchFilter: SearchFilterInput, $pagination: PaginationInput) {
-                    allNotes(searchFilter: $searchFilter, pagination: $pagination) {
+                query ($query: String!, $mode: SearchMode!, $pagination: PaginationInput!) {
+                    searchNotes(query: $query, mode: $mode, pagination: $pagination) {
                         totalCount
+                        semanticAvailable
+                        semanticUsed
+                        semanticError
+                        matches {
+                            noteId
+                            lexical
+                            semantic
+                        }
                         notes {
                             id
                             title
@@ -249,30 +311,32 @@ const registerMcpTools = (
                     }
                 }
             `, {
-                searchFilter: { query, sortBy: 'updatedAt', sortOrder: 'desc' },
+                query,
+                mode: graphqlSearchModes[mode],
                 pagination: { limit, offset: 0 },
             });
 
-            const result = data?.allNotes as {
+            const result = data?.searchNotes as {
                 totalCount: number;
-                notes: Array<{
-                    id: string;
-                    title: string;
-                    updatedAt: string;
-                    tags: Array<{ id: string; name: string }>;
-                    contentAsMarkdown: string;
+                semanticAvailable: boolean;
+                semanticUsed: boolean;
+                semanticError: string | null;
+                matches: Array<{
+                    noteId: string;
+                    lexical: boolean;
+                    semantic: boolean;
                 }>;
+                notes: McpSearchNote[];
             };
 
-            const notes = result.notes.map((note) => ({
-                id: note.id,
-                title: note.title,
-                updatedAt: note.updatedAt,
-                tags: note.tags.map((t) => t.name),
-                preview: note.contentAsMarkdown.slice(0, 100),
-            }));
-
-            return createMcpJsonToolResult({ totalCount: result.totalCount, notes });
+            return createMcpJsonToolResult({
+                totalCount: result.totalCount,
+                semanticAvailable: result.semanticAvailable,
+                semanticUsed: result.semanticUsed,
+                semanticError: result.semanticError,
+                matches: result.matches,
+                notes: formatMcpSearchNotes(result.notes),
+            });
         },
     );
 

--- a/packages/cli/src/mcp.ts
+++ b/packages/cli/src/mcp.ts
@@ -235,8 +235,7 @@ interface McpSearchNote {
     title: string;
     updatedAt: string;
     tags: Array<{ id: string; name: string }>;
-    contentAsMarkdown?: string;
-    contentPreview?: string;
+    contentPreview: string;
 }
 
 const formatMcpSearchNotes = (notes: McpSearchNote[]) => notes.map((note) => ({
@@ -244,9 +243,7 @@ const formatMcpSearchNotes = (notes: McpSearchNote[]) => notes.map((note) => ({
     title: note.title,
     updatedAt: note.updatedAt,
     tags: note.tags.map((t) => t.name),
-    preview: typeof note.contentPreview === 'string'
-        ? note.contentPreview
-        : note.contentAsMarkdown?.slice(0, 100) ?? '',
+    preview: note.contentPreview,
 }));
 
 interface RegisterMcpToolsOptions {
@@ -260,76 +257,17 @@ export const registerMcpTools = (
     options: RegisterMcpToolsOptions = {},
 ) => {
     const graphqlRequest = options.graphqlRequest ?? graphql;
-    let noteContentPreviewSupport: Promise<boolean> | undefined;
-    const supportsNoteContentPreview = () => {
-        if (!noteContentPreviewSupport) {
-            noteContentPreviewSupport = graphqlRequest(serverUrl, token, `
-                query {
-                    __type(name: "Note") {
-                        fields { name }
-                    }
-                }
-            `).then((data) => {
-                const noteType = data?.__type;
-                if (!noteType || typeof noteType !== 'object') {
-                    return false;
-                }
-
-                const fields = (noteType as { fields?: unknown }).fields;
-                return Array.isArray(fields) && fields.some((field) => (
-                    field !== null &&
-                    typeof field === 'object' &&
-                    (field as { name?: unknown }).name === 'contentPreview'
-                ));
-            });
-        }
-
-        return noteContentPreviewSupport;
-    };
 
     server.tool(
         OCEAN_BRAIN_MCP_TOOLS.searchNotes,
-        'Search Ocean Brain notes by keyword or meaning. Lexical uses words only, hybrid combines words and meaning, and semantic uses meaning only. Omit mode to keep the legacy keyword behavior and response. Explicit modes return one ranked result shape with match and semantic-search status. Use ocean_brain_read_note to get full content for a specific note.',
+        'Search Ocean Brain notes by keyword or meaning. Lexical uses words only, hybrid combines words and meaning, and semantic uses meaning only. Results use one ranked result shape with match and semantic-search status. Use ocean_brain_read_note to get full content for a specific note.',
         {
             query: z.string().describe('Search words or a natural-language description'),
-            limit: z.number().optional().default(10).describe('Results per page. Explicit modes return at most 50 per page. (default: 10)'),
+            limit: z.number().optional().default(10).describe('Results per page. Search returns at most 50 per page. (default: 10)'),
             offset: z.number().int().min(0).optional().default(0).describe('Results to skip for pagination (default: 0)'),
-            mode: searchModeSchema.optional().describe('Optional mode. Omit for the legacy keyword request and response; explicit modes use the unified ranked result contract'),
+            mode: searchModeSchema.default('hybrid').describe('Search mode. Defaults to hybrid.'),
         },
         async ({ query, limit, offset, mode }) => {
-            if (!mode) {
-                const data = await graphqlRequest(serverUrl, token, `
-                    query ($searchFilter: SearchFilterInput, $pagination: PaginationInput) {
-                        allNotes(searchFilter: $searchFilter, pagination: $pagination) {
-                            totalCount
-                            notes {
-                                id
-                                title
-                                updatedAt
-                                tags { id name }
-                                contentAsMarkdown
-                            }
-                        }
-                    }
-                `, {
-                    searchFilter: { query, sortBy: 'updatedAt', sortOrder: 'desc' },
-                    pagination: { limit, offset },
-                });
-
-                const result = data?.allNotes as {
-                    totalCount: number;
-                    notes: McpSearchNote[];
-                };
-
-                return createMcpJsonToolResult({
-                    totalCount: result.totalCount,
-                    notes: formatMcpSearchNotes(result.notes),
-                });
-            }
-
-            const previewField = await supportsNoteContentPreview()
-                ? 'contentPreview'
-                : 'contentAsMarkdown';
             const data = await graphqlRequest(serverUrl, token, `
                 query ($query: String!, $mode: SearchMode!, $pagination: PaginationInput!) {
                     searchNotes(query: $query, mode: $mode, pagination: $pagination) {
@@ -347,7 +285,7 @@ export const registerMcpTools = (
                             title
                             updatedAt
                             tags { id name }
-                            ${previewField}
+                            contentPreview
                         }
                     }
                 }

--- a/packages/cli/src/mcp.ts
+++ b/packages/cli/src/mcp.ts
@@ -132,9 +132,10 @@ const normalizeOceanBrainTagNames = (names: string[]) => {
 const fetchOceanBrainTags = async (
     serverUrl: string,
     token: string | undefined,
-    query: string
+    query: string,
+    graphqlRequest: typeof graphql = graphql,
 ) => {
-    const data = await graphql(serverUrl, token, `
+    const data = await graphqlRequest(serverUrl, token, `
         query ($searchFilter: SearchFilterInput, $pagination: PaginationInput) {
             allTags(searchFilter: $searchFilter, pagination: $pagination) {
                 totalCount
@@ -234,7 +235,8 @@ interface McpSearchNote {
     title: string;
     updatedAt: string;
     tags: Array<{ id: string; name: string }>;
-    contentAsMarkdown: string;
+    contentAsMarkdown?: string;
+    contentPreview?: string;
 }
 
 const formatMcpSearchNotes = (notes: McpSearchNote[]) => notes.map((note) => ({
@@ -242,25 +244,61 @@ const formatMcpSearchNotes = (notes: McpSearchNote[]) => notes.map((note) => ({
     title: note.title,
     updatedAt: note.updatedAt,
     tags: note.tags.map((t) => t.name),
-    preview: note.contentAsMarkdown.slice(0, 100),
+    preview: typeof note.contentPreview === 'string'
+        ? note.contentPreview
+        : note.contentAsMarkdown?.slice(0, 100) ?? '',
 }));
+
+interface RegisterMcpToolsOptions {
+    graphqlRequest?: typeof graphql;
+}
 
 export const registerMcpTools = (
     server: McpServer,
     serverUrl: string,
-    token?: string
+    token?: string,
+    options: RegisterMcpToolsOptions = {},
 ) => {
+    const graphqlRequest = options.graphqlRequest ?? graphql;
+    let noteContentPreviewSupport: Promise<boolean> | undefined;
+    const supportsNoteContentPreview = () => {
+        if (!noteContentPreviewSupport) {
+            noteContentPreviewSupport = graphqlRequest(serverUrl, token, `
+                query {
+                    __type(name: "Note") {
+                        fields { name }
+                    }
+                }
+            `).then((data) => {
+                const noteType = data?.__type;
+                if (!noteType || typeof noteType !== 'object') {
+                    return false;
+                }
+
+                const fields = (noteType as { fields?: unknown }).fields;
+                return Array.isArray(fields) && fields.some((field) => (
+                    field !== null &&
+                    typeof field === 'object' &&
+                    (field as { name?: unknown }).name === 'contentPreview'
+                ));
+            });
+        }
+
+        return noteContentPreviewSupport;
+    };
+
     server.tool(
         OCEAN_BRAIN_MCP_TOOLS.searchNotes,
-        'Search Ocean Brain notes by keyword or meaning. Hybrid search combines both; use lexical for exact terms and semantic for meaning-based recall. Returns matching note titles, tags, previews, and search status. Use ocean_brain_read_note to get full content for a specific note.',
+        'Search Ocean Brain notes by keyword or meaning. Lexical uses words only, hybrid combines words and meaning, and semantic uses meaning only. Omit mode to keep the legacy keyword behavior and response. Explicit modes return one ranked result shape with match and semantic-search status. Use ocean_brain_read_note to get full content for a specific note.',
         {
             query: z.string().describe('Search words or a natural-language description'),
-            limit: z.number().optional().default(10).describe('Max results (default: 10)'),
-            mode: searchModeSchema.optional().describe('Optional search mode: hybrid or semantic enables meaning search; omit for the legacy keyword search'),
+            limit: z.number().optional().default(10).describe('Results per page. Explicit modes return at most 50 per page. (default: 10)'),
+            offset: z.number().int().min(0).optional().default(0).describe('Results to skip for pagination (default: 0)'),
+            mode: searchModeSchema.optional().describe('Optional mode. Omit for the legacy keyword request and response; explicit modes use the unified ranked result contract'),
         },
-        async ({ query, limit, mode }) => {
-            if (!mode || mode === 'lexical') {
-                const data = await graphql(serverUrl, token, `
+        async ({ query, limit, offset, mode }) => {
+            if (!mode) {
+                const data = await graphqlRequest(serverUrl, token, `
                     query ($searchFilter: SearchFilterInput, $pagination: PaginationInput) {
                         allNotes(searchFilter: $searchFilter, pagination: $pagination) {
                             totalCount
@@ -275,7 +313,7 @@ export const registerMcpTools = (
                     }
                 `, {
                     searchFilter: { query, sortBy: 'updatedAt', sortOrder: 'desc' },
-                    pagination: { limit, offset: 0 },
+                    pagination: { limit, offset },
                 });
 
                 const result = data?.allNotes as {
@@ -289,7 +327,10 @@ export const registerMcpTools = (
                 });
             }
 
-            const data = await graphql(serverUrl, token, `
+            const previewField = await supportsNoteContentPreview()
+                ? 'contentPreview'
+                : 'contentAsMarkdown';
+            const data = await graphqlRequest(serverUrl, token, `
                 query ($query: String!, $mode: SearchMode!, $pagination: PaginationInput!) {
                     searchNotes(query: $query, mode: $mode, pagination: $pagination) {
                         totalCount
@@ -306,14 +347,14 @@ export const registerMcpTools = (
                             title
                             updatedAt
                             tags { id name }
-                            contentAsMarkdown
+                            ${previewField}
                         }
                     }
                 }
             `, {
                 query,
                 mode: graphqlSearchModes[mode],
-                pagination: { limit, offset: 0 },
+                pagination: { limit, offset },
             });
 
             const result = data?.searchNotes as {
@@ -348,7 +389,7 @@ export const registerMcpTools = (
             maxLength: z.number().optional().default(1000).describe('Max content length in characters. 0 for full content. (default: 1000)'),
         },
         async ({ id, maxLength }) => {
-            const data = await graphql(serverUrl, token, `
+            const data = await graphqlRequest(serverUrl, token, `
                 query ($id: ID!) {
                     note(id: $id) {
                         id
@@ -437,7 +478,7 @@ export const registerMcpTools = (
         'List Ocean Brain tags with their note counts.',
         {},
         async () => {
-            const data = await graphql(serverUrl, token, `
+            const data = await graphqlRequest(serverUrl, token, `
                 query ($searchFilter: SearchFilterInput, $pagination: PaginationInput) {
                     allTags(searchFilter: $searchFilter, pagination: $pagination) {
                         totalCount
@@ -471,7 +512,7 @@ export const registerMcpTools = (
             offset: z.number().optional().default(0).describe('Pagination offset (default: 0)')
         },
         async ({ query, limit, offset }) => {
-            const data = await graphql(serverUrl, token, `
+            const data = await graphqlRequest(serverUrl, token, `
                 query ($query: String, $pagination: PaginationInput) {
                     notePropertyKeys(query: $query, pagination: $pagination) {
                         totalCount
@@ -525,7 +566,7 @@ export const registerMcpTools = (
         },
         async ({ tag, limit, offset }) => {
             const normalizedTag = normalizeOceanBrainTagName(tag);
-            const tagResult = await fetchOceanBrainTags(serverUrl, token, normalizedTag);
+            const tagResult = await fetchOceanBrainTags(serverUrl, token, normalizedTag, graphqlRequest);
             const exactMatches = tagResult.tags.filter((item) => item.name === normalizedTag);
 
             if (exactMatches.length === 0) {
@@ -539,7 +580,7 @@ export const registerMcpTools = (
             }
 
             const selectedTag = exactMatches[0];
-            const notesData = await graphql(serverUrl, token, `
+            const notesData = await graphqlRequest(serverUrl, token, `
                 query ($searchFilter: SearchFilterInput, $pagination: PaginationInput) {
                     tagNotes(searchFilter: $searchFilter, pagination: $pagination) {
                         totalCount
@@ -596,7 +637,7 @@ export const registerMcpTools = (
             const normalizedTags = normalizeOceanBrainTagNames(tags);
             const tagResults = await Promise.all(
                 normalizedTags.map(async (normalizedTag) => {
-                    const result = await fetchOceanBrainTags(serverUrl, token, normalizedTag);
+                    const result = await fetchOceanBrainTags(serverUrl, token, normalizedTag, graphqlRequest);
                     const exactMatches = result.tags.filter((item) => item.name === normalizedTag);
 
                     return {
@@ -639,7 +680,7 @@ export const registerMcpTools = (
                 (mode === 'and' && missingTags.length === 0)
                 || (mode === 'or' && matchedTags.length > 0)
             ) {
-                const notesData = await graphql(serverUrl, token, `
+                const notesData = await graphqlRequest(serverUrl, token, `
                     query ($tagNames: [String!]!, $mode: TagMatchMode!, $pagination: PaginationInput) {
                         notesByTagNames(tagNames: $tagNames, mode: $mode, pagination: $pagination) {
                             totalCount
@@ -695,7 +736,7 @@ export const registerMcpTools = (
         async ({ propertyFilters, tagNames, mode, sortBy, sortOrder, includeProperties, propertyKeys, limit, offset }) => {
             const shouldIncludeProperties = includeProperties || propertyKeys.length > 0;
             const normalizedTagNames = normalizeOceanBrainTagNames(tagNames);
-            const data = await graphql(serverUrl, token, `
+            const data = await graphqlRequest(serverUrl, token, `
                 query ($input: NotesByPropertiesInput!, $pagination: PaginationInput, $includeProperties: Boolean!) {
                     notesByProperties(input: $input, pagination: $pagination) {
                         totalCount
@@ -747,7 +788,7 @@ export const registerMcpTools = (
             limit: z.number().optional().default(10).describe('Max results (default: 10)'),
         },
         async ({ limit }) => {
-            const data = await graphql(serverUrl, token, `
+            const data = await graphqlRequest(serverUrl, token, `
                 query ($searchFilter: SearchFilterInput, $pagination: PaginationInput) {
                     allNotes(searchFilter: $searchFilter, pagination: $pagination) {
                         totalCount
@@ -799,7 +840,7 @@ export const registerMcpTools = (
                 .split(/[,\s]+/)
                 .map((keyword) => keyword.trim())
                 .filter(Boolean);
-            const data = await graphql(serverUrl, token, `
+            const data = await graphqlRequest(serverUrl, token, `
                 query ($query: String, $pagination: PaginationInput) {
                     noteCleanupCandidates(query: $query, pagination: $pagination) {
                         id

--- a/packages/cli/test/mcp-tool-contract.test.ts
+++ b/packages/cli/test/mcp-tool-contract.test.ts
@@ -185,7 +185,7 @@ describe('Ocean Brain MCP stdio contract', () => {
             assert.equal(property(OCEAN_BRAIN_MCP_TOOLS.searchNotes, 'limit').default, 10);
             assert.equal(property(OCEAN_BRAIN_MCP_TOOLS.searchNotes, 'offset').default, 0);
             assert.equal(property(OCEAN_BRAIN_MCP_TOOLS.searchNotes, 'offset').minimum, 0);
-            assert.equal(property(OCEAN_BRAIN_MCP_TOOLS.searchNotes, 'mode').default, undefined);
+            assert.equal(property(OCEAN_BRAIN_MCP_TOOLS.searchNotes, 'mode').default, 'hybrid');
             assert.deepEqual(property(OCEAN_BRAIN_MCP_TOOLS.searchNotes, 'mode').enum, [
                 'hybrid',
                 'lexical',

--- a/packages/cli/test/mcp-tool-contract.test.ts
+++ b/packages/cli/test/mcp-tool-contract.test.ts
@@ -48,7 +48,7 @@ const EXPECTED_TOOL_ORDER = [
 ];
 
 const EXPECTED_SCHEMA_KEYS: Record<string, string[]> = {
-    [OCEAN_BRAIN_MCP_TOOLS.searchNotes]: ['limit', 'query'],
+    [OCEAN_BRAIN_MCP_TOOLS.searchNotes]: ['limit', 'mode', 'query'],
     [OCEAN_BRAIN_MCP_TOOLS.readNote]: ['id', 'maxLength'],
     [OCEAN_BRAIN_MCP_TOOLS.createNote]: ['layout', 'markdown', 'title'],
     [OCEAN_BRAIN_MCP_TOOLS.patchNoteMarkdown]: [
@@ -183,6 +183,12 @@ describe('Ocean Brain MCP stdio contract', () => {
             };
 
             assert.equal(property(OCEAN_BRAIN_MCP_TOOLS.searchNotes, 'limit').default, 10);
+            assert.equal(property(OCEAN_BRAIN_MCP_TOOLS.searchNotes, 'mode').default, undefined);
+            assert.deepEqual(property(OCEAN_BRAIN_MCP_TOOLS.searchNotes, 'mode').enum, [
+                'hybrid',
+                'lexical',
+                'semantic',
+            ]);
             assert.equal(property(OCEAN_BRAIN_MCP_TOOLS.readNote, 'maxLength').default, 1000);
             assert.equal(property(OCEAN_BRAIN_MCP_TOOLS.createNote, 'markdown').default, '');
             assert.deepEqual(property(OCEAN_BRAIN_MCP_TOOLS.createNote, 'layout').enum, ['narrow', 'wide', 'full']);

--- a/packages/cli/test/mcp-tool-contract.test.ts
+++ b/packages/cli/test/mcp-tool-contract.test.ts
@@ -48,7 +48,7 @@ const EXPECTED_TOOL_ORDER = [
 ];
 
 const EXPECTED_SCHEMA_KEYS: Record<string, string[]> = {
-    [OCEAN_BRAIN_MCP_TOOLS.searchNotes]: ['limit', 'mode', 'query'],
+    [OCEAN_BRAIN_MCP_TOOLS.searchNotes]: ['limit', 'mode', 'offset', 'query'],
     [OCEAN_BRAIN_MCP_TOOLS.readNote]: ['id', 'maxLength'],
     [OCEAN_BRAIN_MCP_TOOLS.createNote]: ['layout', 'markdown', 'title'],
     [OCEAN_BRAIN_MCP_TOOLS.patchNoteMarkdown]: [
@@ -183,6 +183,8 @@ describe('Ocean Brain MCP stdio contract', () => {
             };
 
             assert.equal(property(OCEAN_BRAIN_MCP_TOOLS.searchNotes, 'limit').default, 10);
+            assert.equal(property(OCEAN_BRAIN_MCP_TOOLS.searchNotes, 'offset').default, 0);
+            assert.equal(property(OCEAN_BRAIN_MCP_TOOLS.searchNotes, 'offset').minimum, 0);
             assert.equal(property(OCEAN_BRAIN_MCP_TOOLS.searchNotes, 'mode').default, undefined);
             assert.deepEqual(property(OCEAN_BRAIN_MCP_TOOLS.searchNotes, 'mode').enum, [
                 'hybrid',

--- a/packages/cli/test/mcp.test.ts
+++ b/packages/cli/test/mcp.test.ts
@@ -1,5 +1,8 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import {
     createMcpRequestHeaders,
@@ -8,6 +11,8 @@ import {
     OCEAN_BRAIN_MCP_COMPATIBILITY_VERSION,
     OCEAN_BRAIN_MCP_COMPATIBILITY_VERSION_HEADER,
     OCEAN_BRAIN_MCP_VERSION_HEADER,
+    OCEAN_BRAIN_MCP_TOOLS,
+    registerMcpTools,
 } from '../src/mcp.js';
 
 test('createMcpRequestHeaders includes MCP compatibility and client version headers', () => {
@@ -25,4 +30,156 @@ test('normalizeOceanBrainTagName rejects hash-prefixed tags', () => {
     assert.throws(() => normalizeOceanBrainTagName('#project'), /use @, not #/);
     assert.equal(normalizeOceanBrainTagName('project'), '@project');
     assert.equal(normalizeOceanBrainTagName('@project'), '@project');
+});
+
+test('MCP note search forwards the unified search mode and exposes semantic status', async () => {
+    const requests: Array<{ query: string; variables: Record<string, unknown> }> = [];
+    const originalFetch = globalThis.fetch;
+
+    globalThis.fetch = (async (_input, init) => {
+        requests.push(JSON.parse(String(init?.body)) as (typeof requests)[number]);
+
+        return new Response(JSON.stringify({
+            data: {
+                searchNotes: {
+                    totalCount: 1,
+                    semanticAvailable: true,
+                    semanticUsed: true,
+                    semanticError: null,
+                    matches: [{ noteId: '17', lexical: false, semantic: true }],
+                    notes: [{
+                        id: '17',
+                        title: 'Deployment decision',
+                        updatedAt: '2026-07-26T00:00:00.000Z',
+                        tags: [{ id: '1', name: '@project' }],
+                        contentAsMarkdown: 'Use the hybrid search path.',
+                    }],
+                },
+            },
+        }), {
+            headers: { 'content-type': 'application/json' },
+        });
+    }) as typeof fetch;
+
+    const server = new McpServer({ name: 'ocean-brain-test', version: '0.0.0' });
+    const client = new Client({ name: 'ocean-brain-test-client', version: '0.0.0' });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+    try {
+        registerMcpTools(server, 'http://localhost:6683', 'test-token');
+        await Promise.all([
+            server.connect(serverTransport),
+            client.connect(clientTransport),
+        ]);
+
+        const result = await client.callTool({
+            name: OCEAN_BRAIN_MCP_TOOLS.searchNotes,
+            arguments: { query: 'deployment decision', mode: 'semantic' },
+        });
+
+        assert.equal(requests.length, 1);
+        assert.match(requests[0].query, /searchNotes\(query: \$query, mode: \$mode, pagination: \$pagination\)/);
+        assert.deepEqual(requests[0].variables, {
+            query: 'deployment decision',
+            mode: 'SEMANTIC',
+            pagination: { limit: 10, offset: 0 },
+        });
+
+        const content = result.content[0];
+        assert.equal(content?.type, 'text');
+        if (content?.type !== 'text') {
+            throw new Error('Expected a text MCP result.');
+        }
+
+        assert.deepEqual(JSON.parse(content.text), {
+            totalCount: 1,
+            semanticAvailable: true,
+            semanticUsed: true,
+            semanticError: null,
+            matches: [{ noteId: '17', lexical: false, semantic: true }],
+            notes: [{
+                id: '17',
+                title: 'Deployment decision',
+                updatedAt: '2026-07-26T00:00:00.000Z',
+                tags: ['@project'],
+                preview: 'Use the hybrid search path.',
+            }],
+        });
+    } finally {
+        await client.close();
+        await server.close();
+        globalThis.fetch = originalFetch;
+    }
+});
+
+test('MCP note search keeps the legacy lexical path when mode is omitted', async () => {
+    const requests: Array<{ query: string; variables: Record<string, unknown> }> = [];
+    const originalFetch = globalThis.fetch;
+
+    globalThis.fetch = (async (_input, init) => {
+        requests.push(JSON.parse(String(init?.body)) as (typeof requests)[number]);
+
+        return new Response(JSON.stringify({
+            data: {
+                allNotes: {
+                    totalCount: 1,
+                    notes: [{
+                        id: '23',
+                        title: 'Legacy search',
+                        updatedAt: '2026-07-26T00:00:00.000Z',
+                        tags: [{ id: '2', name: '@legacy' }],
+                        contentAsMarkdown: 'Keep the old search behavior.',
+                    }],
+                },
+            },
+        }), {
+            headers: { 'content-type': 'application/json' },
+        });
+    }) as typeof fetch;
+
+    const server = new McpServer({ name: 'ocean-brain-test', version: '0.0.0' });
+    const client = new Client({ name: 'ocean-brain-test-client', version: '0.0.0' });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+    try {
+        registerMcpTools(server, 'http://localhost:6683', 'test-token');
+        await Promise.all([
+            server.connect(serverTransport),
+            client.connect(clientTransport),
+        ]);
+
+        const result = await client.callTool({
+            name: OCEAN_BRAIN_MCP_TOOLS.searchNotes,
+            arguments: { query: 'legacy search' },
+        });
+
+        assert.equal(requests.length, 1);
+        assert.match(requests[0].query, /allNotes\(searchFilter: \$searchFilter, pagination: \$pagination\)/);
+        assert.doesNotMatch(requests[0].query, /searchNotes/);
+        assert.deepEqual(requests[0].variables, {
+            searchFilter: { query: 'legacy search', sortBy: 'updatedAt', sortOrder: 'desc' },
+            pagination: { limit: 10, offset: 0 },
+        });
+
+        const content = result.content[0];
+        assert.equal(content?.type, 'text');
+        if (content?.type !== 'text') {
+            throw new Error('Expected a text MCP result.');
+        }
+
+        assert.deepEqual(JSON.parse(content.text), {
+            totalCount: 1,
+            notes: [{
+                id: '23',
+                title: 'Legacy search',
+                updatedAt: '2026-07-26T00:00:00.000Z',
+                tags: ['@legacy'],
+                preview: 'Keep the old search behavior.',
+            }],
+        });
+    } finally {
+        await client.close();
+        await server.close();
+        globalThis.fetch = originalFetch;
+    }
 });

--- a/packages/cli/test/mcp.test.ts
+++ b/packages/cli/test/mcp.test.ts
@@ -20,7 +20,7 @@ test('createMcpRequestHeaders includes MCP compatibility and client version head
 
     assert.equal(headers['Content-Type'], 'application/json');
     assert.equal(headers.Authorization, 'Bearer token-a');
-    assert.equal(OCEAN_BRAIN_MCP_COMPATIBILITY_VERSION, '0.10.0');
+    assert.equal(OCEAN_BRAIN_MCP_COMPATIBILITY_VERSION, '0.11.0');
     assert.equal(headers[OCEAN_BRAIN_MCP_VERSION_HEADER], OCEAN_BRAIN_MCP_COMPATIBILITY_VERSION);
     assert.equal(headers[OCEAN_BRAIN_MCP_COMPATIBILITY_VERSION_HEADER], OCEAN_BRAIN_MCP_COMPATIBILITY_VERSION);
     assert.match(headers[OCEAN_BRAIN_MCP_CLIENT_VERSION_HEADER], /^\d+\.\d+\.\d+/);
@@ -41,14 +41,6 @@ test('MCP note search gives every explicit mode one result contract with paginat
         variables?: Record<string, unknown>,
     ) => {
         requests.push({ query, variables });
-
-        if (query.includes('__type')) {
-            return {
-                __type: {
-                    fields: [{ name: 'contentPreview' }],
-                },
-            };
-        }
 
         return {
             searchNotes: {
@@ -112,17 +104,16 @@ test('MCP note search gives every explicit mode one result contract with paginat
             });
         }
 
-        assert.equal(requests.length, 4);
-        assert.match(requests[0].query, /__type\(name: "Note"\)/);
+        assert.equal(requests.length, 3);
         assert.deepEqual(
-            requests.slice(1).map((request) => request.variables),
+            requests.map((request) => request.variables),
             ['HYBRID', 'LEXICAL', 'SEMANTIC'].map((mode) => ({
                 query: 'deployment decision',
                 mode,
                 pagination: { limit: 20, offset: 5 },
             })),
         );
-        for (const request of requests.slice(1)) {
+        for (const request of requests) {
             assert.match(request.query, /searchNotes\(query: \$query, mode: \$mode, pagination: \$pagination\)/);
             assert.match(request.query, /contentPreview/);
             assert.doesNotMatch(request.query, /contentAsMarkdown/);
@@ -133,8 +124,7 @@ test('MCP note search gives every explicit mode one result contract with paginat
     }
 });
 
-test('MCP note search falls back to Markdown previews for compatible older servers', async () => {
-    const markdown = 'x'.repeat(120);
+test('MCP note search defaults to hybrid mode when mode is omitted', async () => {
     const requests: Array<{ query: string; variables?: Record<string, unknown> }> = [];
     const graphqlRequest = async (
         _serverUrl: string,
@@ -143,14 +133,6 @@ test('MCP note search falls back to Markdown previews for compatible older serve
         variables?: Record<string, unknown>,
     ) => {
         requests.push({ query, variables });
-
-        if (query.includes('__type')) {
-            return {
-                __type: {
-                    fields: [{ name: 'contentAsMarkdown' }],
-                },
-            };
-        }
 
         return {
             searchNotes: {
@@ -158,69 +140,13 @@ test('MCP note search falls back to Markdown previews for compatible older serve
                 semanticAvailable: true,
                 semanticUsed: true,
                 semanticError: null,
-                matches: [{ noteId: '17', lexical: false, semantic: true }],
-                notes: [{
-                    id: '17',
-                    title: 'Older server',
-                    updatedAt: '2026-07-26T00:00:00.000Z',
-                    tags: [],
-                    contentAsMarkdown: markdown,
-                }],
-            },
-        };
-    };
-
-    const server = new McpServer({ name: 'ocean-brain-test', version: '0.0.0' });
-    const client = new Client({ name: 'ocean-brain-test-client', version: '0.0.0' });
-    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
-
-    try {
-        registerMcpTools(server, 'http://localhost:6683', 'test-token', { graphqlRequest });
-        await Promise.all([
-            server.connect(serverTransport),
-            client.connect(clientTransport),
-        ]);
-
-        const result = await client.callTool({
-            name: OCEAN_BRAIN_MCP_TOOLS.searchNotes,
-            arguments: { query: 'older server', mode: 'semantic' },
-        });
-
-        assert.equal(requests.length, 2);
-        assert.match(requests[1].query, /contentAsMarkdown/);
-        assert.doesNotMatch(requests[1].query, /contentPreview/);
-
-        const content = result.content[0];
-        assert.equal(content?.type, 'text');
-        if (content?.type !== 'text') {
-            throw new Error('Expected a text MCP result.');
-        }
-        assert.equal(JSON.parse(content.text).notes[0].preview, 'x'.repeat(100));
-    } finally {
-        await client.close();
-        await server.close();
-    }
-});
-
-test('MCP note search keeps the legacy request and response when mode is omitted', async () => {
-    const requests: Array<{ query: string; variables?: Record<string, unknown> }> = [];
-    const graphqlRequest = async (
-        _serverUrl: string,
-        _token: string | undefined,
-        query: string,
-        variables?: Record<string, unknown>,
-    ) => {
-        requests.push({ query, variables });
-
-        return {
-            allNotes: {
-                totalCount: 1,
+                matches: [{ noteId: '23', lexical: true, semantic: true }],
                 notes: [{
                     id: '23',
-                    title: 'Legacy search',
+                    title: 'Hybrid search',
                     updatedAt: '2026-07-26T00:00:00.000Z',
-                    tags: [{ id: '2', name: '@legacy' }],
-                    contentAsMarkdown: 'Keep the old search behavior.',
+                    tags: [{ id: '2', name: '@search' }],
+                    contentPreview: 'Use the new hybrid search contract.',
                 }],
             },
         };
@@ -239,14 +165,16 @@ test('MCP note search keeps the legacy request and response when mode is omitted
 
         const result = await client.callTool({
             name: OCEAN_BRAIN_MCP_TOOLS.searchNotes,
-            arguments: { query: 'legacy search' },
+            arguments: { query: 'hybrid search' },
         });
 
         assert.equal(requests.length, 1);
-        assert.match(requests[0].query, /allNotes\(searchFilter: \$searchFilter, pagination: \$pagination\)/);
-        assert.doesNotMatch(requests[0].query, /searchNotes/);
+        assert.match(requests[0].query, /searchNotes\(query: \$query, mode: \$mode, pagination: \$pagination\)/);
+        assert.match(requests[0].query, /contentPreview/);
+        assert.doesNotMatch(requests[0].query, /contentAsMarkdown/);
         assert.deepEqual(requests[0].variables, {
-            searchFilter: { query: 'legacy search', sortBy: 'updatedAt', sortOrder: 'desc' },
+            query: 'hybrid search',
+            mode: 'HYBRID',
             pagination: { limit: 10, offset: 0 },
         });
 
@@ -258,12 +186,16 @@ test('MCP note search keeps the legacy request and response when mode is omitted
 
         assert.deepEqual(JSON.parse(content.text), {
             totalCount: 1,
+            semanticAvailable: true,
+            semanticUsed: true,
+            semanticError: null,
+            matches: [{ noteId: '23', lexical: true, semantic: true }],
             notes: [{
                 id: '23',
-                title: 'Legacy search',
+                title: 'Hybrid search',
                 updatedAt: '2026-07-26T00:00:00.000Z',
-                tags: ['@legacy'],
-                preview: 'Keep the old search behavior.',
+                tags: ['@search'],
+                preview: 'Use the new hybrid search contract.',
             }],
         });
     } finally {

--- a/packages/cli/test/mcp.test.ts
+++ b/packages/cli/test/mcp.test.ts
@@ -32,41 +32,150 @@ test('normalizeOceanBrainTagName rejects hash-prefixed tags', () => {
     assert.equal(normalizeOceanBrainTagName('@project'), '@project');
 });
 
-test('MCP note search forwards the unified search mode and exposes semantic status', async () => {
-    const requests: Array<{ query: string; variables: Record<string, unknown> }> = [];
-    const originalFetch = globalThis.fetch;
+test('MCP note search gives every explicit mode one result contract with pagination', async () => {
+    const requests: Array<{ query: string; variables?: Record<string, unknown> }> = [];
+    const graphqlRequest = async (
+        _serverUrl: string,
+        _token: string | undefined,
+        query: string,
+        variables?: Record<string, unknown>,
+    ) => {
+        requests.push({ query, variables });
 
-    globalThis.fetch = (async (_input, init) => {
-        requests.push(JSON.parse(String(init?.body)) as (typeof requests)[number]);
-
-        return new Response(JSON.stringify({
-            data: {
-                searchNotes: {
-                    totalCount: 1,
-                    semanticAvailable: true,
-                    semanticUsed: true,
-                    semanticError: null,
-                    matches: [{ noteId: '17', lexical: false, semantic: true }],
-                    notes: [{
-                        id: '17',
-                        title: 'Deployment decision',
-                        updatedAt: '2026-07-26T00:00:00.000Z',
-                        tags: [{ id: '1', name: '@project' }],
-                        contentAsMarkdown: 'Use the hybrid search path.',
-                    }],
+        if (query.includes('__type')) {
+            return {
+                __type: {
+                    fields: [{ name: 'contentPreview' }],
                 },
+            };
+        }
+
+        return {
+            searchNotes: {
+                totalCount: 1,
+                semanticAvailable: true,
+                semanticUsed: true,
+                semanticError: null,
+                matches: [{ noteId: '17', lexical: false, semantic: true }],
+                notes: [{
+                    id: '17',
+                    title: 'Deployment decision',
+                    updatedAt: '2026-07-26T00:00:00.000Z',
+                    tags: [{ id: '1', name: '@project' }],
+                    contentPreview: 'Use the hybrid search path.',
+                }],
             },
-        }), {
-            headers: { 'content-type': 'application/json' },
-        });
-    }) as typeof fetch;
+        };
+    };
 
     const server = new McpServer({ name: 'ocean-brain-test', version: '0.0.0' });
     const client = new Client({ name: 'ocean-brain-test-client', version: '0.0.0' });
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
 
     try {
-        registerMcpTools(server, 'http://localhost:6683', 'test-token');
+        registerMcpTools(server, 'http://localhost:6683', 'test-token', { graphqlRequest });
+        await Promise.all([
+            server.connect(serverTransport),
+            client.connect(clientTransport),
+        ]);
+
+        for (const mode of ['hybrid', 'lexical', 'semantic'] as const) {
+            const result = await client.callTool({
+                name: OCEAN_BRAIN_MCP_TOOLS.searchNotes,
+                arguments: {
+                    query: 'deployment decision',
+                    mode,
+                    limit: 20,
+                    offset: 5,
+                },
+            });
+
+            const content = result.content[0];
+            assert.equal(content?.type, 'text');
+            if (content?.type !== 'text') {
+                throw new Error('Expected a text MCP result.');
+            }
+
+            assert.deepEqual(JSON.parse(content.text), {
+                totalCount: 1,
+                semanticAvailable: true,
+                semanticUsed: true,
+                semanticError: null,
+                matches: [{ noteId: '17', lexical: false, semantic: true }],
+                notes: [{
+                    id: '17',
+                    title: 'Deployment decision',
+                    updatedAt: '2026-07-26T00:00:00.000Z',
+                    tags: ['@project'],
+                    preview: 'Use the hybrid search path.',
+                }],
+            });
+        }
+
+        assert.equal(requests.length, 4);
+        assert.match(requests[0].query, /__type\(name: "Note"\)/);
+        assert.deepEqual(
+            requests.slice(1).map((request) => request.variables),
+            ['HYBRID', 'LEXICAL', 'SEMANTIC'].map((mode) => ({
+                query: 'deployment decision',
+                mode,
+                pagination: { limit: 20, offset: 5 },
+            })),
+        );
+        for (const request of requests.slice(1)) {
+            assert.match(request.query, /searchNotes\(query: \$query, mode: \$mode, pagination: \$pagination\)/);
+            assert.match(request.query, /contentPreview/);
+            assert.doesNotMatch(request.query, /contentAsMarkdown/);
+        }
+    } finally {
+        await client.close();
+        await server.close();
+    }
+});
+
+test('MCP note search falls back to Markdown previews for compatible older servers', async () => {
+    const markdown = 'x'.repeat(120);
+    const requests: Array<{ query: string; variables?: Record<string, unknown> }> = [];
+    const graphqlRequest = async (
+        _serverUrl: string,
+        _token: string | undefined,
+        query: string,
+        variables?: Record<string, unknown>,
+    ) => {
+        requests.push({ query, variables });
+
+        if (query.includes('__type')) {
+            return {
+                __type: {
+                    fields: [{ name: 'contentAsMarkdown' }],
+                },
+            };
+        }
+
+        return {
+            searchNotes: {
+                totalCount: 1,
+                semanticAvailable: true,
+                semanticUsed: true,
+                semanticError: null,
+                matches: [{ noteId: '17', lexical: false, semantic: true }],
+                notes: [{
+                    id: '17',
+                    title: 'Older server',
+                    updatedAt: '2026-07-26T00:00:00.000Z',
+                    tags: [],
+                    contentAsMarkdown: markdown,
+                }],
+            },
+        };
+    };
+
+    const server = new McpServer({ name: 'ocean-brain-test', version: '0.0.0' });
+    const client = new Client({ name: 'ocean-brain-test-client', version: '0.0.0' });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+    try {
+        registerMcpTools(server, 'http://localhost:6683', 'test-token', { graphqlRequest });
         await Promise.all([
             server.connect(serverTransport),
             client.connect(clientTransport),
@@ -74,75 +183,55 @@ test('MCP note search forwards the unified search mode and exposes semantic stat
 
         const result = await client.callTool({
             name: OCEAN_BRAIN_MCP_TOOLS.searchNotes,
-            arguments: { query: 'deployment decision', mode: 'semantic' },
+            arguments: { query: 'older server', mode: 'semantic' },
         });
 
-        assert.equal(requests.length, 1);
-        assert.match(requests[0].query, /searchNotes\(query: \$query, mode: \$mode, pagination: \$pagination\)/);
-        assert.deepEqual(requests[0].variables, {
-            query: 'deployment decision',
-            mode: 'SEMANTIC',
-            pagination: { limit: 10, offset: 0 },
-        });
+        assert.equal(requests.length, 2);
+        assert.match(requests[1].query, /contentAsMarkdown/);
+        assert.doesNotMatch(requests[1].query, /contentPreview/);
 
         const content = result.content[0];
         assert.equal(content?.type, 'text');
         if (content?.type !== 'text') {
             throw new Error('Expected a text MCP result.');
         }
-
-        assert.deepEqual(JSON.parse(content.text), {
-            totalCount: 1,
-            semanticAvailable: true,
-            semanticUsed: true,
-            semanticError: null,
-            matches: [{ noteId: '17', lexical: false, semantic: true }],
-            notes: [{
-                id: '17',
-                title: 'Deployment decision',
-                updatedAt: '2026-07-26T00:00:00.000Z',
-                tags: ['@project'],
-                preview: 'Use the hybrid search path.',
-            }],
-        });
+        assert.equal(JSON.parse(content.text).notes[0].preview, 'x'.repeat(100));
     } finally {
         await client.close();
         await server.close();
-        globalThis.fetch = originalFetch;
     }
 });
 
-test('MCP note search keeps the legacy lexical path when mode is omitted', async () => {
-    const requests: Array<{ query: string; variables: Record<string, unknown> }> = [];
-    const originalFetch = globalThis.fetch;
+test('MCP note search keeps the legacy request and response when mode is omitted', async () => {
+    const requests: Array<{ query: string; variables?: Record<string, unknown> }> = [];
+    const graphqlRequest = async (
+        _serverUrl: string,
+        _token: string | undefined,
+        query: string,
+        variables?: Record<string, unknown>,
+    ) => {
+        requests.push({ query, variables });
 
-    globalThis.fetch = (async (_input, init) => {
-        requests.push(JSON.parse(String(init?.body)) as (typeof requests)[number]);
-
-        return new Response(JSON.stringify({
-            data: {
-                allNotes: {
-                    totalCount: 1,
-                    notes: [{
-                        id: '23',
-                        title: 'Legacy search',
-                        updatedAt: '2026-07-26T00:00:00.000Z',
-                        tags: [{ id: '2', name: '@legacy' }],
-                        contentAsMarkdown: 'Keep the old search behavior.',
-                    }],
-                },
+        return {
+            allNotes: {
+                totalCount: 1,
+                notes: [{
+                    id: '23',
+                    title: 'Legacy search',
+                    updatedAt: '2026-07-26T00:00:00.000Z',
+                    tags: [{ id: '2', name: '@legacy' }],
+                    contentAsMarkdown: 'Keep the old search behavior.',
+                }],
             },
-        }), {
-            headers: { 'content-type': 'application/json' },
-        });
-    }) as typeof fetch;
+        };
+    };
 
     const server = new McpServer({ name: 'ocean-brain-test', version: '0.0.0' });
     const client = new Client({ name: 'ocean-brain-test-client', version: '0.0.0' });
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
 
     try {
-        registerMcpTools(server, 'http://localhost:6683', 'test-token');
+        registerMcpTools(server, 'http://localhost:6683', 'test-token', { graphqlRequest });
         await Promise.all([
             server.connect(serverTransport),
             client.connect(clientTransport),
@@ -180,6 +269,5 @@ test('MCP note search keeps the legacy lexical path when mode is omitted', async
     } finally {
         await client.close();
         await server.close();
-        globalThis.fetch = originalFetch;
     }
 });

--- a/packages/server/src/features/mcp-admin/http/handlers.test.ts
+++ b/packages/server/src/features/mcp-admin/http/handlers.test.ts
@@ -182,8 +182,8 @@ test('POST /api/mcp-admin/enabled toggles enabled state for authenticated sessio
         version?: unknown;
     };
     assert.equal(typeof serverInfo.version, 'string');
-    assert.equal(serverInfo.mcpVersionRequirement, '0.10.x');
-    assert.equal(serverInfo.mcp?.compatibilityRequirement, '0.10.x');
+    assert.equal(serverInfo.mcpVersionRequirement, '0.11.x');
+    assert.equal(serverInfo.mcp?.compatibilityRequirement, '0.11.x');
 });
 
 test('POST /api/mcp-admin/token/revoke revokes active token for authenticated session', async (t) => {

--- a/packages/server/src/features/note/graphql/note.field.resolver.test.ts
+++ b/packages/server/src/features/note/graphql/note.field.resolver.test.ts
@@ -7,3 +7,7 @@ test('note field resolvers leave date fields on the GraphQL default serializer',
     assert.equal(Object.hasOwn(noteFieldResolvers, 'createdAt'), false);
     assert.equal(Object.hasOwn(noteFieldResolvers, 'updatedAt'), false);
 });
+
+test('note field resolvers expose a bounded content preview', () => {
+    assert.equal(Object.hasOwn(noteFieldResolvers, 'contentPreview'), true);
+});

--- a/packages/server/src/features/note/graphql/note.field.resolver.ts
+++ b/packages/server/src/features/note/graphql/note.field.resolver.ts
@@ -1,5 +1,6 @@
 import type { IResolvers } from '@graphql-tools/utils';
 import { listNoteProperties } from '~/features/note/services/properties.js';
+import { buildNoteContentPreview } from '~/features/note/services/search.js';
 import { renderNoteSnapshotContentAsMarkdown } from '~/features/note/services/snapshot.js';
 import type { Note } from '~/models.js';
 import models from '~/models.js';
@@ -15,6 +16,7 @@ interface NoteSnapshotSource {
 export const noteFieldResolvers: NoteFieldResolvers = {
     tags: async (note: Note) => models.tag.findMany({ where: { notes: { some: { id: note.id } } } }),
     properties: async (note: Note) => listNoteProperties(note.id),
+    contentPreview: (note: Note) => buildNoteContentPreview(note.content),
     contentAsMarkdown: async (note: Note) => {
         const { blocksToMarkdown } = await import('~/modules/blocknote.js');
         return blocksToMarkdown(note.content);

--- a/packages/server/src/features/note/graphql/note.type-defs.ts
+++ b/packages/server/src/features/note/graphql/note.type-defs.ts
@@ -99,6 +99,7 @@ export const noteType = gql`
         id: ID!
         title: String!
         content: String!
+        contentPreview: String!
         contentAsMarkdown: String!
         createdAt: String!
         updatedAt: String!

--- a/packages/server/src/features/note/services/search.test.ts
+++ b/packages/server/src/features/note/services/search.test.ts
@@ -5,6 +5,7 @@ import {
     OCEAN_BRAIN_CUSTOM_INLINE_CONTENT_TYPES,
 } from '../../../../../client/src/components/schema/custom-types.js';
 import {
+    buildNoteContentPreview,
     buildNoteSearchProjection,
     buildNoteSearchText,
     extractVisibleSearchTextFromContent,
@@ -46,6 +47,29 @@ test('buildNoteSearchProjection stores normalized lowercase title and visible co
         searchableText: 'roadmap 123 visible content',
         searchableTextVersion: NOTE_SEARCH_TEXT_SCHEMA_VERSION,
     });
+});
+
+test('buildNoteContentPreview returns bounded visible text without Markdown conversion', () => {
+    const content = JSON.stringify([
+        {
+            id: 'paragraph-1',
+            type: 'paragraph',
+            props: {},
+            content: [
+                {
+                    type: 'text',
+                    text: `Visible ${'content '.repeat(20)}`,
+                    styles: {},
+                },
+            ],
+            children: [],
+        },
+    ]);
+
+    const preview = buildNoteContentPreview(content);
+
+    assert.equal(preview.length, 100);
+    assert.match(preview, /^Visible content/);
 });
 
 test('note search explicitly classifies every Ocean Brain custom BlockNote type', () => {

--- a/packages/server/src/features/note/services/search.ts
+++ b/packages/server/src/features/note/services/search.ts
@@ -207,6 +207,12 @@ export const extractVisibleSearchTextFromContent = (content: string) => {
     }
 };
 
+const NOTE_CONTENT_PREVIEW_MAX_LENGTH = 100;
+
+export const buildNoteContentPreview = (content: string) => {
+    return extractVisibleSearchTextFromContent(content).slice(0, NOTE_CONTENT_PREVIEW_MAX_LENGTH);
+};
+
 export const matchesNoteSearchQuery = (note: SearchableNoteLike, query: string | NoteSearchQuery) => {
     const parsedQuery = typeof query === 'string' ? parseNoteSearchQuery(query) : query;
 

--- a/packages/server/src/modules/app-version.test.ts
+++ b/packages/server/src/modules/app-version.test.ts
@@ -46,7 +46,7 @@ test('resolveMcpCompatibilityVersion reads explicit package compatibility metada
             }),
         );
 
-        assert.equal(resolveMcpCompatibilityVersion(), '0.10.0');
+        assert.equal(resolveMcpCompatibilityVersion(), '0.11.0');
         assert.equal(resolveMcpCompatibilityVersionFromPaths([packageJsonPath]), '0.8.0');
     } finally {
         fs.rmSync(tempDir, { recursive: true, force: true });

--- a/packages/server/test/mcp-auth.test.ts
+++ b/packages/server/test/mcp-auth.test.ts
@@ -347,8 +347,8 @@ test('mcp version guard blocks compatibility minor version differences', async (
     assert.equal(body.mcpCompatibilityVersion, createIncompatibleMcpVersion());
     assert.equal(body.mcpClientVersion, resolveOceanBrainVersion());
     assert.equal(body.serverVersion, resolveOceanBrainVersion());
-    assert.equal(body.requiredMcpVersion, '0.10.x');
-    assert.equal(body.requiredMcpCompatibilityVersion, '0.10.x');
+    assert.equal(body.requiredMcpVersion, '0.11.x');
+    assert.equal(body.requiredMcpCompatibilityVersion, '0.11.x');
     assert.match(String(body.message), /Please update Ocean Brain MCP/);
     assert.match(String(body.message), /https:\/\/github\.com\/baealex\/ocean-brain\/releases/);
 });


### PR DESCRIPTION
## :dart: Goal

Make the new semantic search contract the only MCP search path for 0.11.0 and remove the temporary legacy compatibility branches.

## :hammer_and_wrench: Core Changes

- Route every `ocean_brain_search_notes` call through `searchNotes` with the unified ranked result shape.
- Default an omitted mode to `hybrid`; it no longer returns the old keyword request or response.
- Require the server-provided bounded `contentPreview` field and remove schema introspection and Markdown fallback logic.
- Bump `oceanBrain.mcpCompatibilityVersion` from `0.10.0` to `0.11.0`.
- Update MCP schema, search, version guard, and admin status tests for the 0.11 contract.

## :brain: Key Decisions

- Remove the temporary compatibility path in the same release that introduces the new search contract.
- Keep mode input ergonomic with a hybrid default, while making the output consistently include match and semantic-search status.
- Treat 0.10.x MCP clients and servers as incompatible with this contract; they must be upgraded together with Ocean Brain 0.11.0.

## :test_tube: Verification Guide

### How to verify

1. Run `pnpm test:ci`.
2. Run `pnpm lint`, `pnpm type-check`, `pnpm build`, and `pnpm check:encoding`.

### Expected result

- All CLI, client, and server tests pass.
- Lint, type-check, production build, dependency parity, and encoding checks pass.
- MCP requests require the `0.11.x` compatibility range.

## :white_check_mark: Checklist

- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (MCP schema descriptions and compatibility contract in this PR)