### PR TITLE
🐛 Fix npx direct note routes

### DIFF
--- a/packages/server/src/paths.ts
+++ b/packages/server/src/paths.ts
@@ -15,7 +15,6 @@ const EMBEDDING_API_KEY_PATH = path.resolve(DATA_DIR, 'embedding-api-key');
 export const paths = {
     packageRoot: path.resolve(PACKAGE_ROOT),
     clientDist: path.resolve(PACKAGE_ROOT, 'client/dist'),
-    clientIndex: path.resolve(PACKAGE_ROOT, 'client/dist/index.html'),
     imageDir: path.resolve(IMAGE_DIR),
     searchIndex: path.resolve(SEARCH_INDEX_PATH),
     embeddingApiKey: path.resolve(EMBEDDING_API_KEY_PATH),

--- a/packages/server/src/routes/client.ts
+++ b/packages/server/src/routes/client.ts
@@ -109,5 +109,5 @@ export const createClientRouter = (authConfig: AuthConfig) =>
         .use(createClientRouteCsrfTokenMiddleware(authConfig))
         .use(express.static(paths.clientDist, { extensions: ['html'] }))
         .get(/.*/, (_req, res) => {
-            res.sendFile(paths.clientIndex);
+            res.sendFile('index.html', { root: paths.clientDist });
         });

--- a/packages/server/test/client-route.test.ts
+++ b/packages/server/test/client-route.test.ts
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import type { AddressInfo } from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import test, { type TestContext } from 'node:test';
+import express from 'express';
+
+import { paths } from '../src/paths.js';
+import { createClientRouter } from '../src/routes/client.js';
+
+test('serves direct client routes when the package path contains a dot directory', async (t: TestContext) => {
+    const fixtureRoot = mkdtempSync(path.join(os.tmpdir(), 'ocean-brain-client-route-'));
+    const clientDist = path.join(fixtureRoot, '.npm-cache', 'client', 'dist');
+    const originalClientDist = paths.clientDist;
+
+    mkdirSync(clientDist, { recursive: true });
+    writeFileSync(path.join(clientDist, 'index.html'), '<main id="root">Ocean Brain</main>');
+    paths.clientDist = clientDist;
+
+    t.after(() => {
+        paths.clientDist = originalClientDist;
+        rmSync(fixtureRoot, { recursive: true, force: true });
+    });
+
+    const server = express()
+        .use(createClientRouter({ mode: 'open' }))
+        .listen(0);
+
+    await new Promise<void>((resolve, reject) => {
+        server.once('listening', resolve);
+        server.once('error', reject);
+    });
+
+    t.after(() => server.close());
+
+    const { port } = server.address() as AddressInfo;
+    const response = await fetch(`http://127.0.0.1:${port}/12`);
+
+    assert.equal(response.status, 200);
+    assert.equal(await response.text(), '<main id="root">Ocean Brain</main>');
+});

--- a/scripts/ci/smoke-cli-npx.mjs
+++ b/scripts/ci/smoke-cli-npx.mjs
@@ -383,6 +383,7 @@ async function runScenario(scenario) {
         await waitForReady(child, readyTimeoutMs);
         if (scenario.expectation === 'graphql-open') {
             await assertClientShellLoads('/');
+            await assertClientShellLoads('/12');
             await assertAuthSession({
                 mode: 'open',
                 authRequired: false,


### PR DESCRIPTION
## :dart: Goal
- Fix the 500 response returned when an npx-hosted Ocean Brain instance is opened directly at a note route such as `/12`.
- Ensure the packaged SPA shell works from npm cache paths that contain dot-prefixed directories.

## :hammer_and_wrench: Core Changes
- Serve the SPA fallback relative to the client distribution root.
- Add a direct-route regression test using a dot-prefixed package path.
- Exercise `/12` in the npx CLI smoke scenario.

## :brain: Key Decisions
- Kept Express dotfile protection enabled; only the fallback file is now resolved relative to the known client distribution root.
- Removed the unused absolute client-index path after switching the fallback implementation.

## :test_tube: Verification Guide
### How to verify
1. Run `pnpm check:encoding`.
2. Run `pnpm lint && pnpm type-check && pnpm test:ci && pnpm build`.
3. Run `node scripts/release/prepublish.mjs`, package the CLI, then run `env -u PORT CLI_SMOKE_PORT=6687 node scripts/ci/smoke-cli-npx.mjs .tmp/ocean-brain-0.11.0.tgz`.

### Expected result
- All commands succeed, and the npx smoke output includes a `200` response for `GET /12`.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (not needed)