### PR TITLE
🐛 Reduce demo feedback prompt friction

### DIFF
--- a/packages/client/src/components/demo/DemoSidebarPromo.tsx
+++ b/packages/client/src/components/demo/DemoSidebarPromo.tsx
@@ -21,8 +21,8 @@ const promoItems = [
     },
     {
         tone: 'feedback',
-        title: 'Send Feedback',
-        description: 'Tell us what to improve.',
+        title: 'How was the demo?',
+        description: 'One quick question.',
         href: 'https://tally.so/r/yP7720',
         image: feedbackIllustration,
         imageAlt: 'Speech bubbles, note, and cursor illustration',


### PR DESCRIPTION
## :dart: Goal
- Make the demo feedback invitation feel lightweight instead of presenting it as an improvement task.
- Reduce the perceived effort before a visitor opens the one-question survey.

## :hammer_and_wrench: Core Changes
- Change the feedback card title from Send Feedback to How was the demo?
- Replace Tell us what to improve. with One quick question.
- Keep the existing survey link, illustration, and interaction unchanged.

## :brain: Key Decisions
- Use a conversational question and disclose the small survey size directly.
- Keep this as a copy-only demo adjustment with no unit test that pins the exact wording.
- Classify the PR as release: no-impact because the promo is enabled only for the local demo build variant.

## :test_tube: Verification Guide
### How to verify
1. Run pnpm --filter @ocean-brain/client lint.
2. Run pnpm --filter @ocean-brain/client type-check and pnpm --filter @ocean-brain/client test:ci.
3. Build the demo client and inspect the feedback card in the sidebar.

### Expected result
- The card reads How was the demo? and One quick question.
- The card still opens the existing Tally survey in a new tab.
- Client lint, type-check, 374 tests, and production build pass.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (not needed; copy-only demo change)