### PR TITLE
🐛 Fix responsive modal and layout behavior

### DIFF
--- a/packages/client/src/components/layout/SiteLayout/LayoutShell.tsx
+++ b/packages/client/src/components/layout/SiteLayout/LayoutShell.tsx
@@ -43,12 +43,13 @@ const sidebarClassName = classNames(
     'border-border-subtle',
     'bg-[var(--page-bg)]',
     'pb-20',
-    'md:static',
-    'md:w-auto',
-    'md:translate-x-0',
-    'md:border-r',
-    'md:pb-0',
-    'md:pointer-events-auto',
+    'sm:w-[300px]',
+    'sm:border-r',
+    'min-[1000px]:static',
+    'min-[1000px]:w-auto',
+    'min-[1000px]:translate-x-0',
+    'min-[1000px]:pb-0',
+    'min-[1000px]:pointer-events-auto',
 );
 const sidebarClosedClassName = 'pointer-events-none -translate-x-full';
 const sidebarOpenClassName = 'pointer-events-auto translate-x-0';
@@ -71,13 +72,13 @@ const topClassName = classNames(
     'border-b',
     'border-border-subtle',
     'bg-[var(--page-bg)]',
-    "max-md:after:content-['']",
-    'max-md:after:pointer-events-none',
-    'max-md:after:absolute',
-    'max-md:after:inset-y-0',
-    'max-md:after:right-0',
-    'max-md:after:w-12',
-    'max-md:after:bg-[linear-gradient(to_right,transparent,var(--page-bg))]',
+    "max-[999px]:after:content-['']",
+    'max-[999px]:after:pointer-events-none',
+    'max-[999px]:after:absolute',
+    'max-[999px]:after:inset-y-0',
+    'max-[999px]:after:right-0',
+    'max-[999px]:after:w-12',
+    'max-[999px]:after:bg-[linear-gradient(to_right,transparent,var(--page-bg))]',
 );
 const topContentClassName = classNames(
     'flex',
@@ -98,7 +99,7 @@ const contentClassName = classNames(
     'after:block',
     'after:h-4',
     "after:content-['']",
-    'max-md:after:h-24',
+    'max-[999px]:after:h-24',
 );
 
 interface LayoutShellProps {
@@ -119,7 +120,7 @@ const LayoutShell = ({ sidebar, topNavigation, children }: LayoutShellProps) => 
     return (
         <div className={rootClassName}>
             <GlobalSearchShortcut />
-            <div className="md:hidden">
+            <div className="min-[1000px]:hidden">
                 <button
                     type="button"
                     className={menuButtonClassName}

--- a/packages/client/src/components/reminder/ReminderCard.tsx
+++ b/packages/client/src/components/reminder/ReminderCard.tsx
@@ -51,43 +51,41 @@ export default function ReminderCard({ reminder, onUpdate, onDelete }: ReminderC
     const reminderDateText = formatReminderDate(reminder.reminderDate);
 
     return (
-        <div className="surface-base flex flex-col gap-2.5 px-4 py-3 sm:flex-row sm:items-center sm:gap-4">
-            <div className="flex min-w-0 flex-1 items-start gap-2.5 sm:items-center">
-                <Checkbox
-                    checked={reminder.completed}
-                    onChange={() => onUpdate(reminder.id, noteId, { completed: !reminder.completed })}
-                    size="sm"
-                    aria-label={`Reminder: ${primaryText}`}
-                />
-                <div className="min-w-0 flex-1">
+        <div className="surface-base grid grid-cols-[auto_minmax(0,1fr)_auto] items-start gap-x-2.5 gap-y-2 px-4 py-3 sm:grid-cols-[auto_minmax(0,1fr)_auto_auto] sm:items-center sm:gap-x-4 sm:gap-y-0">
+            <Checkbox
+                checked={reminder.completed}
+                onChange={() => onUpdate(reminder.id, noteId, { completed: !reminder.completed })}
+                size="sm"
+                aria-label={`Reminder: ${primaryText}`}
+            />
+            <div className="min-w-0">
+                <Text
+                    as="p"
+                    variant="body"
+                    weight="semibold"
+                    className={reminder.completed ? 'truncate line-through opacity-45' : 'truncate'}
+                >
+                    {primaryText}
+                </Text>
+                {showNoteTitle && (
                     <Text
-                        as="p"
-                        variant="body"
-                        weight="semibold"
-                        className={reminder.completed ? 'truncate line-through opacity-45' : 'truncate'}
+                        as="div"
+                        variant="meta"
+                        tone="secondary"
+                        className={reminder.completed ? 'mt-0.5 truncate opacity-45' : 'mt-0.5 truncate'}
                     >
-                        {primaryText}
-                    </Text>
-                    {showNoteTitle && (
-                        <Text
-                            as="div"
-                            variant="meta"
-                            tone="secondary"
-                            className={reminder.completed ? 'mt-0.5 truncate opacity-45' : 'mt-0.5 truncate'}
+                        <Link
+                            to={NOTE_ROUTE}
+                            params={{ id: String(reminder.note?.id ?? reminder.noteId) }}
+                            className="transition-colors hover:text-fg-default hover:underline"
                         >
-                            <Link
-                                to={NOTE_ROUTE}
-                                params={{ id: String(reminder.note?.id ?? reminder.noteId) }}
-                                className="transition-colors hover:text-fg-default hover:underline"
-                            >
-                                {noteTitle}
-                            </Link>
-                        </Text>
-                    )}
-                </div>
+                            {noteTitle}
+                        </Link>
+                    </Text>
+                )}
             </div>
 
-            <div className="flex flex-wrap items-center gap-x-2 gap-y-1 sm:shrink-0">
+            <div className="col-start-2 row-start-2 flex flex-wrap items-center gap-x-2 gap-y-1 sm:col-start-auto sm:row-start-auto sm:shrink-0">
                 <span
                     className={`h-3 w-3 shrink-0 rounded-full border border-border-subtle ${priorityToneClassName}`}
                     aria-label={`${priorityLabel} priority`}
@@ -113,7 +111,7 @@ export default function ReminderCard({ reminder, onUpdate, onDelete }: ReminderC
                 </Text>
             </div>
 
-            <div className="flex items-center justify-end gap-1.5 sm:shrink-0">
+            <div className="col-start-3 row-start-1 flex items-center justify-end gap-1.5 sm:col-start-auto sm:row-start-auto sm:shrink-0">
                 <Dropdown
                     button={<MoreButton label="Reminder actions" iconClassName="h-5 w-5 text-current" />}
                     items={[

--- a/packages/client/src/components/search/SearchInput.tsx
+++ b/packages/client/src/components/search/SearchInput.tsx
@@ -79,8 +79,15 @@ const SearchInput = ({
                             <Icon.Close className="h-4 w-4" weight="bold" />
                         </button>
                     )}
-                    <Button type="submit" size="lg" disabled={!value.trim()} className="my-1 px-4 sm:px-5">
-                        Search
+                    <Button
+                        type="submit"
+                        size="lg"
+                        aria-label="Search"
+                        disabled={!value.trim()}
+                        className="my-1 w-11 shrink-0 px-0 sm:w-auto sm:px-5"
+                    >
+                        <Icon.ArrowRight className="h-4 w-4 sm:hidden" weight="bold" aria-hidden="true" />
+                        <span className="hidden sm:inline">Search</span>
                     </Button>
                 </div>
             </div>

--- a/packages/client/src/components/shared/ModalActionRow.tsx
+++ b/packages/client/src/components/shared/ModalActionRow.tsx
@@ -5,5 +5,5 @@ interface ModalActionRowProps {
 }
 
 export default function ModalActionRow({ children }: ModalActionRowProps) {
-    return <div className="flex w-full flex-col-reverse gap-2 sm:flex-row sm:justify-end">{children}</div>;
+    return <div className="flex w-full flex-wrap items-center justify-end gap-3">{children}</div>;
 }

--- a/packages/client/src/components/ui/Confirm/ConfirmProvider.tsx
+++ b/packages/client/src/components/ui/Confirm/ConfirmProvider.tsx
@@ -40,7 +40,7 @@ const AlertModal = ({ open, options, onClose }: AlertComponentProps) => {
         >
             <AlertDialogPrimitive.Portal>
                 <AlertDialogPrimitive.Overlay className={alertDialogOverlayClassName} />
-                <div className="pointer-events-none fixed inset-0 z-[1100] flex items-center justify-center p-4">
+                <div className="pointer-events-none fixed inset-0 z-[1100] flex items-end justify-center p-0 sm:items-center sm:p-4">
                     <AlertDialogPrimitive.Content className={dialogContentVariants({ variant: 'confirm' })}>
                         <div className={dialogBodyVariants({ variant: 'confirm' })}>
                             <AlertDialogPrimitive.Title className={dialogTitleVariants({ variant: 'confirm' })}>
@@ -80,7 +80,7 @@ const ConfirmModal = ({ open, options, onCancel, onConfirm }: ConfirmComponentPr
         >
             <AlertDialogPrimitive.Portal>
                 <AlertDialogPrimitive.Overlay className={alertDialogOverlayClassName} />
-                <div className="pointer-events-none fixed inset-0 z-[1100] flex items-center justify-center p-4">
+                <div className="pointer-events-none fixed inset-0 z-[1100] flex items-end justify-center p-0 sm:items-center sm:p-4">
                     <AlertDialogPrimitive.Content className={dialogContentVariants({ variant: 'confirm' })}>
                         <div className={dialogBodyVariants({ variant: 'confirm' })}>
                             <AlertDialogPrimitive.Title className={dialogTitleVariants({ variant: 'confirm' })}>

--- a/packages/client/src/components/ui/Dialog/Dialog.tsx
+++ b/packages/client/src/components/ui/Dialog/Dialog.tsx
@@ -54,24 +54,26 @@ const DialogContent = forwardRef<
     React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
         variant?: DialogVariant;
     }
->(({ className, children, variant = 'default', ...props }, ref) => (
-    <DialogPortal>
-        <DialogOverlay />
-        <div className="pointer-events-none fixed inset-0 z-[1100] flex items-center justify-center p-4">
-            <DialogPrimitive.Content
-                ref={ref}
-                data-dialog-variant={variant}
-                className={dialogContentVariants({
-                    variant,
-                    className,
-                })}
-                {...props}
-            >
-                <DialogVariantContext.Provider value={variant}>{children}</DialogVariantContext.Provider>
-            </DialogPrimitive.Content>
-        </div>
-    </DialogPortal>
-));
+>(({ className, children, variant = 'default', ...props }, ref) => {
+    return (
+        <DialogPortal>
+            <DialogOverlay />
+            <div className="pointer-events-none fixed inset-0 z-[1100] flex items-end justify-center p-0 sm:items-center sm:p-4">
+                <DialogPrimitive.Content
+                    ref={ref}
+                    data-dialog-variant={variant}
+                    className={dialogContentVariants({
+                        variant,
+                        className,
+                    })}
+                    {...props}
+                >
+                    <DialogVariantContext.Provider value={variant}>{children}</DialogVariantContext.Provider>
+                </DialogPrimitive.Content>
+            </div>
+        </DialogPortal>
+    );
+});
 DialogContent.displayName = DialogPrimitive.Content.displayName;
 
 interface DialogHeaderProps {

--- a/packages/client/src/components/ui/Dialog/variants.ts
+++ b/packages/client/src/components/ui/Dialog/variants.ts
@@ -4,12 +4,13 @@ export const dialogContentVariants = cva(
     [
         'relative',
         'pointer-events-auto',
+        'flex',
+        'min-h-0',
         'w-full',
-        'max-h-[calc(100dvh-2rem)]',
-        'overflow-y-auto',
+        'flex-col',
+        'overflow-hidden',
         'border',
         'border-border-subtle',
-        'overscroll-contain',
         'data-[state=open]:animate-in',
         'data-[state=closed]:animate-out',
         'data-[state=closed]:fade-out-0',
@@ -20,18 +21,22 @@ export const dialogContentVariants = cva(
     {
         variants: {
             variant: {
-                default: 'max-w-[640px] rounded-[20px] bg-elevated shadow-[0_24px_64px_-32px_rgba(15,18,24,0.36)]',
-                compact: 'max-w-[480px] rounded-[18px] bg-surface shadow-[0_18px_44px_-28px_rgba(15,18,24,0.28)]',
-                form: 'max-w-[560px] rounded-[20px] bg-elevated shadow-[0_22px_56px_-30px_rgba(15,18,24,0.32)]',
-                inspect: 'max-w-[640px] rounded-[20px] bg-elevated shadow-[0_24px_64px_-30px_rgba(15,18,24,0.34)]',
-                confirm: 'max-w-[336px] rounded-[18px] bg-surface shadow-[0_16px_36px_-24px_rgba(15,18,24,0.24)]',
+                default:
+                    'max-h-[calc(100dvh-0.75rem)] max-w-none rounded-t-[20px] rounded-b-none border-b-0 bg-elevated shadow-[0_24px_64px_-32px_rgba(15,18,24,0.36)] sm:max-h-[calc(100dvh-2rem)] sm:max-w-[640px] sm:rounded-[20px] sm:border-b',
+                compact:
+                    'max-h-[calc(100dvh-0.75rem)] max-w-none rounded-t-[18px] rounded-b-none border-b-0 bg-surface shadow-[0_18px_44px_-28px_rgba(15,18,24,0.28)] sm:max-h-[calc(100dvh-2rem)] sm:max-w-[480px] sm:rounded-[18px] sm:border-b',
+                form: 'max-h-[calc(100dvh-0.75rem)] max-w-none rounded-t-[20px] rounded-b-none border-b-0 bg-elevated shadow-[0_22px_56px_-30px_rgba(15,18,24,0.32)] sm:max-h-[calc(100dvh-2rem)] sm:max-w-[560px] sm:rounded-[20px] sm:border-b',
+                inspect:
+                    'max-h-[calc(100dvh-0.75rem)] max-w-none rounded-t-[20px] rounded-b-none border-b-0 bg-elevated shadow-[0_24px_64px_-30px_rgba(15,18,24,0.34)] sm:max-h-[calc(100dvh-2rem)] sm:max-w-[640px] sm:rounded-[20px] sm:border-b',
+                confirm:
+                    'max-h-[calc(100dvh-0.75rem)] max-w-none rounded-t-[18px] rounded-b-none border-b-0 bg-surface shadow-[0_16px_36px_-24px_rgba(15,18,24,0.24)] sm:max-h-[calc(100dvh-2rem)] sm:max-w-[336px] sm:rounded-[18px] sm:border-b',
             },
         },
         defaultVariants: { variant: 'default' },
     },
 );
 
-export const dialogHeaderVariants = cva(['flex', 'items-center', 'justify-between'], {
+export const dialogHeaderVariants = cva(['flex', 'shrink-0', 'items-center', 'justify-between'], {
     variants: {
         variant: {
             default: 'border-b border-border-subtle/70 px-4 py-3.5',
@@ -44,7 +49,7 @@ export const dialogHeaderVariants = cva(['flex', 'items-center', 'justify-betwee
     defaultVariants: { variant: 'default' },
 });
 
-export const dialogBodyVariants = cva('', {
+export const dialogBodyVariants = cva('min-h-0 flex-1 overflow-y-auto overscroll-contain', {
     variants: {
         variant: {
             default: 'px-4 py-5 sm:px-5',
@@ -57,7 +62,7 @@ export const dialogBodyVariants = cva('', {
     defaultVariants: { variant: 'default' },
 });
 
-export const dialogFooterVariants = cva(['flex', 'items-center', 'justify-end'], {
+export const dialogFooterVariants = cva(['flex', 'shrink-0', 'items-center', 'justify-end'], {
     variants: {
         variant: {
             default: 'border-t border-border-subtle/70 px-4 py-3.5',

--- a/packages/client/src/components/ui/Select/Select.tsx
+++ b/packages/client/src/components/ui/Select/Select.tsx
@@ -8,6 +8,8 @@ import * as Icon from '~/components/icon';
 const selectTriggerVariants = cva(
     [
         'inline-flex',
+        'min-w-0',
+        'max-w-full',
         'items-center',
         'justify-between',
         'gap-2',
@@ -90,8 +92,10 @@ const Select = ({
                     className,
                 })}
             >
-                <SelectPrimitive.Value className="min-w-0 truncate" placeholder={placeholder} />
-                <SelectPrimitive.Icon>
+                <span className="min-w-0 flex-1 truncate text-left">
+                    <SelectPrimitive.Value placeholder={placeholder} />
+                </span>
+                <SelectPrimitive.Icon className="shrink-0">
                     <Icon.ChevronDown className="w-3.5 h-3.5 opacity-60" />
                 </SelectPrimitive.Icon>
             </SelectPrimitive.Trigger>

--- a/packages/client/src/components/view/ViewSectionDialog.tsx
+++ b/packages/client/src/components/view/ViewSectionDialog.tsx
@@ -28,7 +28,6 @@ import type {
 } from '~/models/view.model';
 import {
     DEFAULT_VIEW_TABLE_COLUMNS,
-    getViewDisplayTypeLabel,
     getViewPropertyOperatorLabel,
     getViewTableColumnLabel,
     getViewTagMatchLabel,
@@ -426,16 +425,11 @@ export default function ViewSectionDialog({
                         />
                     </div>
 
-                    <section className="flex flex-col gap-3 rounded-[18px] border border-border-subtle bg-elevated px-4 py-3">
-                        <div className="flex flex-wrap items-start justify-between gap-3">
-                            <div className="min-w-0">
-                                <Label size="md">Display</Label>
-                                <Text as="p" variant="meta" tone="tertiary" className="mt-1">
-                                    Show the same note set as a list, table, or property board.
-                                </Text>
-                            </div>
-                            <Text as="span" variant="meta" tone="tertiary">
-                                {getViewDisplayTypeLabel(displayType)}
+                    <section className="flex flex-col gap-3 border-b border-border-subtle pb-5">
+                        <div className="min-w-0">
+                            <Label size="md">Display</Label>
+                            <Text as="p" variant="meta" tone="tertiary" className="mt-1">
+                                Show the same note set as a list, table, or property board.
                             </Text>
                         </div>
                         <ToggleGroup
@@ -472,7 +466,7 @@ export default function ViewSectionDialog({
                             </ToggleGroupItem>
                         </ToggleGroup>
                         {displayType === 'table' ? (
-                            <div className="rounded-[16px] border border-border-subtle bg-subtle/45 p-3">
+                            <div className="border-t border-border-subtle/80 pt-3">
                                 <div className="flex flex-wrap items-center justify-between gap-2">
                                     <Label size="sm">Table columns</Label>
                                     <Text as="span" variant="meta" tone="tertiary">
@@ -485,15 +479,12 @@ export default function ViewSectionDialog({
                                               } shown`}
                                     </Text>
                                 </div>
-                                <div className="mt-3 grid gap-2 sm:grid-cols-2">
+                                <div className="mt-3 grid grid-cols-2 gap-2">
                                     {TABLE_COLUMN_OPTIONS.map((column) => {
                                         const label = getViewTableColumnLabel(column);
 
                                         return (
-                                            <div
-                                                key={column}
-                                                className="flex items-center gap-2 rounded-[12px] border border-border-subtle bg-elevated px-3 py-2"
-                                            >
+                                            <div key={column} className="flex items-center gap-2 px-1 py-2">
                                                 <Checkbox
                                                     size="sm"
                                                     checked={tableColumns.includes(column)}
@@ -530,7 +521,7 @@ export default function ViewSectionDialog({
                                             </Text>
                                         </div>
                                         {availableProperties.length > 0 ? (
-                                            <div className="mt-3 grid max-h-48 gap-2 overflow-y-auto pr-1 sm:grid-cols-2">
+                                            <div className="mt-3 grid grid-cols-2 gap-2">
                                                 {availableProperties.map((property) => {
                                                     const isSelected = tablePropertyKeys.includes(property.key);
                                                     const isSelectionFull =
@@ -539,7 +530,7 @@ export default function ViewSectionDialog({
                                                     return (
                                                         <div
                                                             key={property.key}
-                                                            className="flex min-w-0 items-center gap-2 rounded-[12px] border border-border-subtle bg-elevated px-3 py-2"
+                                                            className="flex min-w-0 items-center gap-2 px-1 py-2"
                                                         >
                                                             <Checkbox
                                                                 size="sm"
@@ -576,7 +567,7 @@ export default function ViewSectionDialog({
                             </div>
                         ) : null}
                         {displayType === 'board' ? (
-                            <div className="rounded-[16px] border border-border-subtle bg-subtle/45 p-3">
+                            <div className="border-t border-border-subtle/80 pt-3">
                                 <div className="flex flex-col gap-2">
                                     <Label
                                         id="view-section-board-group-label"
@@ -619,7 +610,7 @@ export default function ViewSectionDialog({
                         ) : null}
                     </section>
 
-                    <section className="flex flex-col gap-3 rounded-[20px] border border-border-subtle bg-subtle/40 p-4">
+                    <section className="flex flex-col gap-3 border-b border-border-subtle pb-5">
                         <div className="flex flex-wrap items-start justify-between gap-3">
                             <div className="min-w-0">
                                 <Label size="md">Filters</Label>
@@ -873,20 +864,23 @@ export default function ViewSectionDialog({
                         </Text>
                     </section>
 
-                    <details className="group rounded-[18px] border border-border-subtle bg-elevated px-4 py-3">
+                    <details className="group pb-1">
                         <summary className="cursor-pointer list-none">
-                            <div className="flex items-center justify-between gap-3">
-                                <div>
-                                    <Text as="span" variant="label" tone="default">
-                                        Sort and page size
-                                    </Text>
-                                    <Text as="p" variant="meta" tone="tertiary" className="mt-1">
-                                        {displayType === 'board'
-                                            ? 'Controls how many cards each board column loads at a time.'
-                                            : 'Controls how many matching notes appear on each section page.'}
-                                    </Text>
-                                </div>
-                                <Text as="span" variant="meta" tone="tertiary">
+                            <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-x-3 gap-y-1">
+                                <Text as="span" variant="label" tone="default">
+                                    Sort and page size
+                                </Text>
+                                <Text as="p" variant="meta" tone="tertiary" className="col-start-1 row-start-2">
+                                    {displayType === 'board'
+                                        ? 'Controls how many cards each board column loads at a time.'
+                                        : 'Controls how many matching notes appear on each section page.'}
+                                </Text>
+                                <Text
+                                    as="span"
+                                    variant="meta"
+                                    tone="tertiary"
+                                    className="col-start-2 row-span-2 row-start-1 whitespace-nowrap"
+                                >
                                     {displayType === 'board' ? `${limit} per column` : `${limit} notes`}
                                 </Text>
                             </div>

--- a/packages/client/src/components/view/ViewSectionTableRenderer.tsx
+++ b/packages/client/src/components/view/ViewSectionTableRenderer.tsx
@@ -234,7 +234,7 @@ export default function ViewSectionTableRenderer({
     const loadingRowClassName = surface === 'card' ? 'bg-elevated' : 'bg-transparent';
     const tableHeadClassName = surface === 'card' ? 'bg-subtle/65' : 'bg-subtle/45';
     const tableBodyClassName = surface === 'card' ? 'bg-elevated' : 'bg-transparent';
-    const stickyCellClassName = surface === 'card' ? 'bg-elevated' : 'bg-surface';
+    const stickyCellBackground = surface === 'card' ? 'var(--elevated)' : 'var(--surface)';
 
     const renderHeaderCell = (column: ResolvedTableColumn) => {
         if (column.kind === 'property') {
@@ -261,8 +261,15 @@ export default function ViewSectionTableRenderer({
                 aria-sort={isActiveSort ? (activeSortOrder === 'asc' ? 'ascending' : 'descending') : undefined}
                 className={classNames(
                     'px-3 py-2.5 text-xs font-semibold text-fg-tertiary',
-                    isTitle && 'sticky left-0 z-20 bg-subtle',
+                    isTitle && 'lg:sticky lg:left-0 lg:z-20',
                 )}
+                style={
+                    isTitle
+                        ? {
+                              background: `linear-gradient(var(--subtle), var(--subtle)), ${stickyCellBackground}`,
+                          }
+                        : undefined
+                }
             >
                 {sortBy ? (
                     <button
@@ -329,12 +336,14 @@ export default function ViewSectionTableRenderer({
                 return (
                     <td
                         key={column.key}
-                        className={classNames(
-                            'sticky left-0 z-10 px-3 py-2.5 align-middle transition-colors group-hover:bg-hover-subtle',
-                            stickyCellClassName,
-                        )}
+                        className="relative px-3 py-2.5 align-middle lg:sticky lg:left-0 lg:z-10"
+                        style={{ background: stickyCellBackground }}
                     >
-                        <div className="flex min-w-0 items-center gap-2">
+                        <span
+                            aria-hidden="true"
+                            className="pointer-events-none absolute inset-0 bg-hover-subtle opacity-0 transition-opacity group-hover:opacity-100"
+                        />
+                        <div className="relative z-10 flex min-w-0 items-center gap-2">
                             {note.pinned ? (
                                 <Icon.Pin
                                     className="size-3.5 shrink-0 text-fg-tertiary"

--- a/packages/client/src/pages/setting/search.tsx
+++ b/packages/client/src/pages/setting/search.tsx
@@ -372,7 +372,7 @@ const SearchSetting = () => {
                                 value={form.baseUrl}
                                 disabled={!hasInitialized || isIndexing || isCheckingProvider}
                                 onChange={(event) => handleBaseUrlChange(event.target.value)}
-                                className="min-w-0 flex-1"
+                                className="w-full min-w-0 sm:flex-1"
                             />
                             <Button
                                 type="button"
@@ -415,7 +415,7 @@ const SearchSetting = () => {
                                     value={apiKeyDraft}
                                     disabled={!hasInitialized || isIndexing || isCheckingProvider || removeSavedApiKey}
                                     onChange={(event) => handleApiKeyChange(event.target.value)}
-                                    className="min-w-0 flex-1"
+                                    className="w-full min-w-0 sm:flex-1"
                                 />
                                 {status?.apiKeyConfigured && (
                                     <Button
@@ -492,7 +492,7 @@ const SearchSetting = () => {
                                         !modelOptions.length || !hasInitialized || isIndexing || isCheckingProvider
                                     }
                                     onValueChange={handleModelChange}
-                                    className="min-w-0 flex-1"
+                                    className="w-full min-w-0 sm:flex-1"
                                 >
                                     {modelOptions.map((model) => (
                                         <SelectItem key={model.id} value={model.id}>


### PR DESCRIPTION
## :dart: Goal
- Make dialogs and dense settings usable on narrow screens without losing actions or context.
- Resolve responsive overflow and overlap issues found while reviewing Views, reminders, and search.

## :hammer_and_wrench: Core Changes
- Present every shared dialog and confirmation as a mobile bottom sheet while keeping desktop dialogs centered; only the body scrolls, with the header and footer fixed.
- Simplify the View section editor hierarchy and keep action rows, selects, reminder metadata, and the search submit control readable on mobile.
- Keep table Title cells opaque during hover, release the sticky Title column on narrow screens, and preserve it on desktop.
- Show the persistent 300px sidebar from 1000px onward; use a full phone panel or 300px tablet drawer below that breakpoint.

## :brain: Key Decisions
- Apply modal behavior through shared Dialog and Confirm primitives so individual screens remain consistent.
- Preserve the existing desktop interaction model and all data/API contracts; this PR has no database or query changes.
- Let each table own horizontal scrolling, and avoid reserving narrow-screen space for a sticky 300px Title column.
- Validate visual layout in a real browser instead of adding brittle CSS or screenshot assertions.

## :test_tube: Verification Guide
### How to verify
1. Run `pnpm --filter @ocean-brain/client lint`, `pnpm --filter @ocean-brain/client type-check`, and `pnpm --filter @ocean-brain/client build`.
2. Run `pnpm --filter @ocean-brain/client exec vitest run src/components/layout/SiteLayout/LayoutShell.spec.tsx src/components/ui/Dialog/Dialog.spec.tsx src/components/ui/Select/Select.spec.tsx src/components/view/ViewSectionDialog.spec.tsx src/components/view/ViewSectionTableRenderer.spec.tsx src/components/reminder/ReminderCard.spec.tsx src/pages/Search.spec.tsx src/pages/setting/search.spec.tsx`.
3. At 390px, open section and confirmation dialogs, inspect search settings/reminders, and horizontally scroll a View table.
4. Compare the shell at 999px and 1000px, then scroll and hover a table row at desktop width.

### Expected result
- Lint, type-check, all 37 focused tests, production build, and the 300 KiB initial-bundle budget pass.
- Mobile dialogs anchor to the bottom with fixed chrome and a scrollable body; controls do not overflow or collide.
- The tablet sidebar is a 300px drawer, the persistent sidebar starts at 1000px, and the main content remains readable.
- Narrow tables can reveal every column; desktop Title cells remain sticky and opaque during hover.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (not needed; no contract or process changes)
