### PR TITLE
✨ Expand reminder management

### DIFF
--- a/packages/client/src/apis/reminder.api.ts
+++ b/packages/client/src/apis/reminder.api.ts
@@ -7,12 +7,60 @@ export interface ReminderPaginationParams {
     offset?: number;
 }
 
+export type ReminderStatus = 'open' | 'completed';
+export type ReminderSortBy = 'reminderDate' | 'updatedAt';
+export type ReminderSortOrder = 'asc' | 'desc';
+
+export interface ReminderListFilter {
+    status: ReminderStatus;
+    priority?: ReminderPriority;
+    start?: string;
+    end?: string;
+    sortBy?: ReminderSortBy;
+    sortOrder?: ReminderSortOrder;
+}
+
+export interface FetchRemindersParams extends ReminderPaginationParams {
+    filter: ReminderListFilter;
+}
+
+export interface FetchOpenReminderOverviewParams {
+    now: string;
+    tomorrow: string;
+    priority?: ReminderPriority;
+    limit?: number;
+}
+
+export interface OpenReminderOverview {
+    overdue: ReminderCollection;
+    today: ReminderCollection;
+    upcoming: ReminderCollection;
+}
+
 const toPaginationInput = (params: ReminderPaginationParams = {}): Pagination => {
     return {
         limit: params.limit ?? 10,
         offset: params.offset ?? 0,
     };
 };
+
+const reminderCollectionSelection = `
+    totalCount
+    reminders {
+        id
+        noteId
+        reminderDate
+        priority
+        content
+        completed
+        createdAt
+        updatedAt
+        note {
+            id
+            title
+        }
+    }
+`;
 
 export const fetchNoteReminders = async (noteId: string, pagination?: ReminderPaginationParams) => {
     return graphQuery<{ noteReminders: ReminderCollection }, { noteId: string; pagination: Pagination }>(
@@ -64,6 +112,88 @@ export const fetchUpcomingReminders = async (pagination?: ReminderPaginationPara
         }
     `,
         { pagination: toPaginationInput(pagination) },
+    );
+};
+
+export const fetchReminders = async ({ filter, limit = 25, offset = 0 }: FetchRemindersParams) => {
+    return graphQuery<{ reminders: ReminderCollection }, { filter: ReminderListFilter; pagination: Pagination }>(
+        `
+        query FetchReminders($filter: ReminderFilterInput!, $pagination: PaginationInput) {
+            reminders(filter: $filter, pagination: $pagination) {
+                ${reminderCollectionSelection}
+            }
+        }
+    `,
+        {
+            filter,
+            pagination: { limit, offset },
+        },
+    );
+};
+
+export const fetchOpenReminderOverview = async ({
+    now,
+    tomorrow,
+    priority,
+    limit = 5,
+}: FetchOpenReminderOverviewParams) => {
+    const baseFilter = {
+        status: 'open' as const,
+        ...(priority ? { priority } : {}),
+    };
+    const overdueFilter: ReminderListFilter = {
+        ...baseFilter,
+        end: now,
+        sortBy: 'reminderDate',
+        sortOrder: 'desc',
+    };
+    const todayFilter: ReminderListFilter = {
+        ...baseFilter,
+        start: now,
+        end: tomorrow,
+        sortBy: 'reminderDate',
+        sortOrder: 'asc',
+    };
+    const upcomingFilter: ReminderListFilter = {
+        ...baseFilter,
+        start: tomorrow,
+        sortBy: 'reminderDate',
+        sortOrder: 'asc',
+    };
+
+    return graphQuery<
+        OpenReminderOverview,
+        {
+            overdueFilter: ReminderListFilter;
+            todayFilter: ReminderListFilter;
+            upcomingFilter: ReminderListFilter;
+            pagination: Pagination;
+        }
+    >(
+        `
+        query FetchOpenReminderOverview(
+            $overdueFilter: ReminderFilterInput!
+            $todayFilter: ReminderFilterInput!
+            $upcomingFilter: ReminderFilterInput!
+            $pagination: PaginationInput
+        ) {
+            overdue: reminders(filter: $overdueFilter, pagination: $pagination) {
+                ${reminderCollectionSelection}
+            }
+            today: reminders(filter: $todayFilter, pagination: $pagination) {
+                ${reminderCollectionSelection}
+            }
+            upcoming: reminders(filter: $upcomingFilter, pagination: $pagination) {
+                ${reminderCollectionSelection}
+            }
+        }
+    `,
+        {
+            overdueFilter,
+            todayFilter,
+            upcomingFilter,
+            pagination: { limit, offset: 0 },
+        },
     );
 };
 

--- a/packages/client/src/components/reminder/ReminderCard.spec.tsx
+++ b/packages/client/src/components/reminder/ReminderCard.spec.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import type { Reminder } from '~/models/reminder.model';
 import ReminderCard from './ReminderCard';
@@ -23,6 +24,19 @@ describe('<ReminderCard />', () => {
     it('labels the completion checkbox with reminder context', () => {
         render(<ReminderCard reminder={createReminder()} onUpdate={vi.fn()} onDelete={vi.fn()} />);
 
-        expect(screen.getByRole('checkbox', { name: 'Reminder: Follow up' })).toBeInTheDocument();
+        expect(screen.getByRole('checkbox', { name: 'Complete reminder: Follow up' })).toBeInTheDocument();
+    });
+
+    it('presents completed reminders as reopenable history', async () => {
+        const user = userEvent.setup();
+        const onUpdate = vi.fn();
+
+        render(<ReminderCard reminder={createReminder({ completed: true })} onUpdate={onUpdate} onDelete={vi.fn()} />);
+
+        expect(screen.getByText('Completed')).toBeInTheDocument();
+
+        await user.click(screen.getByRole('checkbox', { name: 'Reopen reminder: Follow up' }));
+
+        expect(onUpdate).toHaveBeenCalledWith('reminder-1', '1', { completed: false });
     });
 });

--- a/packages/client/src/components/reminder/ReminderCard.tsx
+++ b/packages/client/src/components/reminder/ReminderCard.tsx
@@ -11,9 +11,10 @@ interface ReminderCardProps {
     reminder: Reminder;
     onUpdate: (id: string, noteId: string, data: { completed?: boolean }) => void;
     onDelete: (id: string, noteId: string) => void;
+    onEdit?: (reminder: Reminder) => void;
 }
 
-export default function ReminderCard({ reminder, onUpdate, onDelete }: ReminderCardProps) {
+export default function ReminderCard({ reminder, onUpdate, onDelete, onEdit }: ReminderCardProps) {
     const formatReminderDate = (dateString: string) => {
         const date = dayjs(Number(dateString));
         const now = dayjs();
@@ -38,17 +39,44 @@ export default function ReminderCard({ reminder, onUpdate, onDelete }: ReminderC
         return `${diffHours}h ${diffMinutes}m remaining`;
     };
 
-    const isOverdue = getTimeRemaining(reminder.reminderDate) === 'Overdue';
+    const timeRemaining = reminder.completed ? 'Completed' : getTimeRemaining(reminder.reminderDate);
+    const isOverdue = timeRemaining === 'Overdue';
     const priority = reminder.priority || 'low';
     const priorityLabel = priority === 'high' ? 'High' : priority === 'medium' ? 'Medium' : 'Low';
     const priorityToneClassName = priorityColors[priority];
     const noteId = reminder.noteId.toString();
     const detailToneClassName = isOverdue ? 'text-fg-error' : 'text-fg-tertiary';
-    const primaryText = reminder.content?.trim() || reminder.note?.title || 'Untitled reminder';
+    const reminderContent = reminder.content?.trim();
+    const primaryText = reminderContent || reminder.note?.title || 'Untitled reminder';
     const noteTitle = reminder.note?.title || 'Untitled note';
-    const showNoteTitle = Boolean(reminder.content?.trim() && reminder.note?.title);
-    const timeRemaining = getTimeRemaining(reminder.reminderDate);
+    const showNoteTitle = Boolean(reminderContent && reminder.note?.title);
     const reminderDateText = formatReminderDate(reminder.reminderDate);
+    const managementActions = [
+        ...(!reminder.completed && onEdit
+            ? [
+                  {
+                      name: 'Edit',
+                      onClick: () => onEdit(reminder),
+                  },
+              ]
+            : []),
+        ...(reminder.completed
+            ? [
+                  {
+                      name: 'Reopen',
+                      onClick: () => onUpdate(reminder.id, noteId, { completed: false }),
+                  },
+              ]
+            : []),
+    ];
+    const actionItems = [
+        ...managementActions,
+        ...(managementActions.length > 0 ? [{ type: 'separator' as const, key: 'destructive-actions' }] : []),
+        {
+            name: 'Delete',
+            onClick: () => onDelete(reminder.id, noteId),
+        },
+    ];
 
     return (
         <div className="surface-base grid grid-cols-[auto_minmax(0,1fr)_auto] items-start gap-x-2.5 gap-y-2 px-4 py-3 sm:grid-cols-[auto_minmax(0,1fr)_auto_auto] sm:items-center sm:gap-x-4 sm:gap-y-0">
@@ -56,23 +84,33 @@ export default function ReminderCard({ reminder, onUpdate, onDelete }: ReminderC
                 checked={reminder.completed}
                 onChange={() => onUpdate(reminder.id, noteId, { completed: !reminder.completed })}
                 size="sm"
-                aria-label={`Reminder: ${primaryText}`}
+                aria-label={`${reminder.completed ? 'Reopen' : 'Complete'} reminder: ${primaryText}`}
             />
             <div className="min-w-0">
                 <Text
                     as="p"
                     variant="body"
                     weight="semibold"
-                    className={reminder.completed ? 'truncate line-through opacity-45' : 'truncate'}
+                    className={reminder.completed ? 'truncate text-fg-tertiary line-through' : 'truncate'}
                 >
-                    {primaryText}
+                    {!reminderContent && reminder.note ? (
+                        <Link
+                            to={NOTE_ROUTE}
+                            params={{ id: String(reminder.note.id) }}
+                            className="transition-colors hover:text-fg-default hover:underline"
+                        >
+                            {primaryText}
+                        </Link>
+                    ) : (
+                        primaryText
+                    )}
                 </Text>
                 {showNoteTitle && (
                     <Text
                         as="div"
                         variant="meta"
                         tone="secondary"
-                        className={reminder.completed ? 'mt-0.5 truncate opacity-45' : 'mt-0.5 truncate'}
+                        className={reminder.completed ? 'mt-0.5 truncate text-fg-tertiary' : 'mt-0.5 truncate'}
                     >
                         <Link
                             to={NOTE_ROUTE}
@@ -96,7 +134,7 @@ export default function ReminderCard({ reminder, onUpdate, onDelete }: ReminderC
                     variant="meta"
                     weight="medium"
                     tone="secondary"
-                    className={reminder.completed ? 'opacity-45' : undefined}
+                    className={reminder.completed ? 'text-fg-tertiary' : undefined}
                 >
                     {reminderDateText}
                 </Text>
@@ -105,7 +143,7 @@ export default function ReminderCard({ reminder, onUpdate, onDelete }: ReminderC
                     as="span"
                     variant="label"
                     weight="medium"
-                    className={reminder.completed ? 'opacity-45' : detailToneClassName}
+                    className={reminder.completed ? 'text-accent-success' : detailToneClassName}
                 >
                     {timeRemaining}
                 </Text>
@@ -114,12 +152,7 @@ export default function ReminderCard({ reminder, onUpdate, onDelete }: ReminderC
             <div className="col-start-3 row-start-1 flex items-center justify-end gap-1.5 sm:col-start-auto sm:row-start-auto sm:shrink-0">
                 <Dropdown
                     button={<MoreButton label="Reminder actions" iconClassName="h-5 w-5 text-current" />}
-                    items={[
-                        {
-                            name: 'Delete',
-                            onClick: () => onDelete(reminder.id, noteId),
-                        },
-                    ]}
+                    items={actionItems}
                 />
             </div>
         </div>

--- a/packages/client/src/hooks/resource/useReminderMutate.ts
+++ b/packages/client/src/hooks/resource/useReminderMutate.ts
@@ -29,20 +29,10 @@ export default function useReminderMutate() {
                 return;
             }
 
-            await Promise.all([
-                queryClient.invalidateQueries({
-                    queryKey: queryKeys.reminders.noteAllPages(noteId),
-                    exact: false,
-                }),
-                queryClient.invalidateQueries({
-                    queryKey: queryKeys.reminders.upcomingAllPages(),
-                    exact: false,
-                }),
-                queryClient.invalidateQueries({
-                    queryKey: queryKeys.reminders.inDateRangeAll(),
-                    exact: false,
-                }),
-            ]);
+            await queryClient.invalidateQueries({
+                queryKey: queryKeys.reminders.all(),
+                exact: false,
+            });
 
             if (onSuccess) {
                 onSuccess();
@@ -54,7 +44,7 @@ export default function useReminderMutate() {
     const onUpdate = useCallback(
         async (
             id: string,
-            noteId: string,
+            _noteId: string,
             params: {
                 reminderDate?: Date;
                 completed?: boolean;
@@ -73,20 +63,10 @@ export default function useReminderMutate() {
                 return;
             }
 
-            await Promise.all([
-                queryClient.invalidateQueries({
-                    queryKey: queryKeys.reminders.noteAllPages(noteId),
-                    exact: false,
-                }),
-                queryClient.invalidateQueries({
-                    queryKey: queryKeys.reminders.upcomingAllPages(),
-                    exact: false,
-                }),
-                queryClient.invalidateQueries({
-                    queryKey: queryKeys.reminders.inDateRangeAll(),
-                    exact: false,
-                }),
-            ]);
+            await queryClient.invalidateQueries({
+                queryKey: queryKeys.reminders.all(),
+                exact: false,
+            });
 
             if (onSuccess) {
                 onSuccess();
@@ -96,7 +76,7 @@ export default function useReminderMutate() {
     );
 
     const onDelete = useCallback(
-        async (id: string, noteId: string, onSuccess?: () => void) => {
+        async (id: string, _noteId: string, onSuccess?: () => void) => {
             const response = await deleteReminder(id);
 
             if (response.type === 'error') {
@@ -104,20 +84,10 @@ export default function useReminderMutate() {
                 return;
             }
 
-            await Promise.all([
-                queryClient.invalidateQueries({
-                    queryKey: queryKeys.reminders.noteAllPages(noteId),
-                    exact: false,
-                }),
-                queryClient.invalidateQueries({
-                    queryKey: queryKeys.reminders.upcomingAllPages(),
-                    exact: false,
-                }),
-                queryClient.invalidateQueries({
-                    queryKey: queryKeys.reminders.inDateRangeAll(),
-                    exact: false,
-                }),
-            ]);
+            await queryClient.invalidateQueries({
+                queryKey: queryKeys.reminders.all(),
+                exact: false,
+            });
 
             if (onSuccess) {
                 onSuccess();

--- a/packages/client/src/modules/local-demo/plugins/reminders.ts
+++ b/packages/client/src/modules/local-demo/plugins/reminders.ts
@@ -1,11 +1,73 @@
 import type { Reminder, ReminderPriority } from '~/models/reminder.model';
 import { localError, success } from '../response';
-import type { LocalDemoPlugin } from '../types';
+import type { LocalDemoPlugin, LocalDemoState, LocalGraphVariables } from '../types';
 import { createLocalId, findNote, isInDateRange, now, paginate, toTimestampString } from '../utils';
+
+type LocalReminderFilter = {
+    status?: 'open' | 'completed';
+    priority?: ReminderPriority;
+    start?: string;
+    end?: string;
+    sortBy?: 'reminderDate' | 'updatedAt';
+    sortOrder?: 'asc' | 'desc';
+};
+
+const toTime = (value: string | undefined) => {
+    if (!value) return null;
+
+    const numericValue = Number(value);
+    if (Number.isFinite(numericValue)) return numericValue;
+
+    const parsedValue = Date.parse(value);
+    return Number.isFinite(parsedValue) ? parsedValue : null;
+};
+
+const listReminders = (state: LocalDemoState, filter: LocalReminderFilter) => {
+    const start = toTime(filter.start);
+    const end = toTime(filter.end);
+    const sortBy = filter.sortBy === 'updatedAt' ? 'updatedAt' : 'reminderDate';
+    const direction = filter.sortOrder === 'desc' ? -1 : 1;
+
+    return state.reminders
+        .filter((reminder) => reminder.completed === (filter.status === 'completed'))
+        .filter((reminder) => !filter.priority || reminder.priority === filter.priority)
+        .filter((reminder) => {
+            const reminderTime = toTime(reminder.reminderDate);
+            if (reminderTime == null) return false;
+            if (start != null && reminderTime < start) return false;
+            if (end != null && reminderTime >= end) return false;
+            return true;
+        })
+        .sort((left, right) => {
+            const leftTime = toTime(left[sortBy]) ?? 0;
+            const rightTime = toTime(right[sortBy]) ?? 0;
+            if (leftTime !== rightTime) return (leftTime - rightTime) * direction;
+            return left.id.localeCompare(right.id) * direction;
+        })
+        .map((reminder) => ({ ...reminder, note: findNote(state, reminder.noteId) }));
+};
+
+const reminderCollection = (state: LocalDemoState, variables: LocalGraphVariables, filter: LocalReminderFilter) => {
+    const reminders = listReminders(state, filter);
+    return {
+        totalCount: reminders.length,
+        reminders: paginate(reminders, variables, { limit: 25, offset: 0 }),
+    };
+};
 
 export const remindersLocalPlugin: LocalDemoPlugin = {
     name: 'reminders',
     graphHandlers: {
+        FetchReminders: ({ state, variables }) =>
+            success({
+                reminders: reminderCollection(state, variables, variables.filter as LocalReminderFilter),
+            }),
+        FetchOpenReminderOverview: ({ state, variables }) =>
+            success({
+                overdue: reminderCollection(state, variables, variables.overdueFilter as LocalReminderFilter),
+                today: reminderCollection(state, variables, variables.todayFilter as LocalReminderFilter),
+                upcoming: reminderCollection(state, variables, variables.upcomingFilter as LocalReminderFilter),
+            }),
         FetchUpcomingReminders: ({ state, variables }) => {
             const reminders = state.reminders
                 .filter((reminder) => !reminder.completed)

--- a/packages/client/src/modules/query-key-factory.ts
+++ b/packages/client/src/modules/query-key-factory.ts
@@ -6,7 +6,11 @@ import type {
     FetchTagNotesParams,
 } from '~/apis/note.api';
 import type { FetchPlaceholdersParams } from '~/apis/placeholder.api';
-import type { ReminderPaginationParams } from '~/apis/reminder.api';
+import type {
+    FetchOpenReminderOverviewParams,
+    FetchRemindersParams,
+    ReminderPaginationParams,
+} from '~/apis/reminder.api';
 import type { FetchSearchNotesParams } from '~/apis/search.api';
 import type { FetchTagsParams } from '~/apis/tag.api';
 
@@ -145,6 +149,35 @@ export const queryKeys = {
     },
     reminders: {
         all: () => ['reminders'] as const,
+        listAll: () => ['reminders', 'list'] as const,
+        list: ({ filter, limit = 25, offset = 0 }: FetchRemindersParams) =>
+            [
+                'reminders',
+                'list',
+                {
+                    filter: {
+                        status: filter.status,
+                        priority: filter.priority ?? null,
+                        start: filter.start ?? null,
+                        end: filter.end ?? null,
+                        sortBy: filter.sortBy ?? 'reminderDate',
+                        sortOrder: filter.sortOrder ?? 'asc',
+                    },
+                    limit,
+                    offset,
+                },
+            ] as const,
+        overview: ({ now, tomorrow, priority, limit = 5 }: FetchOpenReminderOverviewParams) =>
+            [
+                'reminders',
+                'overview',
+                {
+                    now,
+                    tomorrow,
+                    priority: priority ?? null,
+                    limit,
+                },
+            ] as const,
         note: (noteId: string, params: ReminderPaginationParams = {}) =>
             [
                 'reminders',

--- a/packages/client/src/modules/route-search.spec.ts
+++ b/packages/client/src/modules/route-search.spec.ts
@@ -6,6 +6,7 @@ import {
     validateGraphSearch,
     validateHomeSearch,
     validatePaginationSearch,
+    validateReminderSearch,
     validateSearchPageSearch,
     validateTagSearch,
     validateViewNotesSearch,
@@ -44,6 +45,29 @@ describe('route-search validators', () => {
 
     it('returns a safe pagination fallback', () => {
         expect(validatePaginationSearch({ page: '-2' })).toEqual({ page: 1 });
+    });
+
+    it('normalizes reminder management state', () => {
+        expect(
+            validateReminderSearch({
+                page: '3',
+                status: 'completed',
+                scope: 'overdue',
+                priority: 'high',
+            }),
+        ).toEqual({
+            page: 3,
+            status: 'completed',
+            scope: 'all',
+            priority: 'high',
+        });
+
+        expect(validateReminderSearch({ status: 'unknown', scope: 'later', priority: 'urgent' })).toEqual({
+            page: 1,
+            status: 'open',
+            scope: 'all',
+            priority: 'all',
+        });
     });
 
     it('reads search page query and page', () => {

--- a/packages/client/src/modules/route-search.ts
+++ b/packages/client/src/modules/route-search.ts
@@ -2,6 +2,7 @@ import dayjs from 'dayjs';
 
 import type { SearchMode } from '~/apis/search.api';
 import type { SortBy, SortOrder } from '~/components/shared/NoteFilters';
+import type { ReminderPriority } from '~/models/reminder.model';
 import { HOME_DEFAULT_LIMIT, HOME_LIMIT_OPTIONS, type HomeLimit } from '~/modules/home-pagination';
 import { TAG_DEFAULT_LIMIT, TAG_LIMIT_OPTIONS, type TagLimit } from '~/modules/tag-pagination';
 import { normalizeViewRouteState, type ViewRouteState } from '~/modules/view-route-state';
@@ -13,6 +14,9 @@ const TAG_SORT_BY = ['referenceCount', 'name'] as const;
 const SORT_ORDER = ['asc', 'desc'] as const satisfies readonly SortOrder[];
 const CALENDAR_TYPES = ['create', 'update'] as const;
 const SEARCH_MODES = ['hybrid', 'lexical', 'semantic'] as const satisfies readonly SearchMode[];
+const REMINDER_STATUSES = ['open', 'completed'] as const;
+const REMINDER_SCOPES = ['all', 'overdue', 'today', 'upcoming'] as const;
+const REMINDER_PRIORITIES = ['all', 'high', 'medium', 'low'] as const satisfies readonly ('all' | ReminderPriority)[];
 
 const getFirstValue = (value: unknown) => (Array.isArray(value) ? value[0] : value);
 
@@ -83,6 +87,12 @@ export interface PaginationRouteSearch {
     page: number;
 }
 
+export interface ReminderRouteSearch extends PaginationRouteSearch {
+    status: (typeof REMINDER_STATUSES)[number];
+    scope: (typeof REMINDER_SCOPES)[number];
+    priority: (typeof REMINDER_PRIORITIES)[number];
+}
+
 export interface SearchRouteSearch extends PaginationRouteSearch {
     query: string;
     mode: SearchMode;
@@ -125,6 +135,18 @@ export const validateHomeSearch = (search: SearchRecord): HomeRouteSearch => ({
 export const validatePaginationSearch = (search: SearchRecord): PaginationRouteSearch => ({
     page: parsePositiveInt(search.page, 1),
 });
+
+export const validateReminderSearch = (search: SearchRecord): ReminderRouteSearch => {
+    const status = parseEnum(search.status, REMINDER_STATUSES, 'open');
+    const scope = parseEnum(search.scope, REMINDER_SCOPES, 'all');
+
+    return {
+        page: parsePositiveInt(search.page, 1),
+        status,
+        scope: status === 'completed' ? 'all' : scope,
+        priority: parseEnum(search.priority, REMINDER_PRIORITIES, 'all'),
+    };
+};
 
 export const validateSearchPageSearch = (search: SearchRecord): SearchRouteSearch => ({
     page: parsePositiveInt(search.page, 1),

--- a/packages/client/src/pages/Reminders.tsx
+++ b/packages/client/src/pages/Reminders.tsx
@@ -1,134 +1,500 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { getRouteApi } from '@tanstack/react-router';
+import dayjs from 'dayjs';
+import { useEffect, useState } from 'react';
+
+import { fetchOpenReminderOverview, fetchReminders, type ReminderListFilter } from '~/apis/reminder.api';
 import { QueryBoundary } from '~/components/app';
-import { Reminders as RemindersEntity } from '~/components/entities';
+import * as Icon from '~/components/icon';
 import ReminderCard from '~/components/reminder/ReminderCard';
+import ReminderModal from '~/components/reminder/ReminderModal';
 import { Empty, PageLayout, Pagination, Skeleton } from '~/components/shared';
-import { Text } from '~/components/ui';
+import { Button, Select, SelectItem, Text, ToggleGroup, ToggleGroupItem, useConfirm } from '~/components/ui';
 import useReminderMutate from '~/hooks/resource/useReminderMutate';
-import { priorityColors } from '~/modules/color';
+import type { Reminder, Reminders as ReminderCollection, ReminderPriority } from '~/models/reminder.model';
+import { queryKeys } from '~/modules/query-key-factory';
+import type { ReminderRouteSearch } from '~/modules/route-search';
 import { REMINDERS_ROUTE } from '~/modules/url';
 
 const Route = getRouteApi(REMINDERS_ROUTE);
-const priorityHints = [
-    {
-        label: 'High',
-        className: priorityColors.high,
+const PAGE_LIMIT = 25;
+const OVERVIEW_LIMIT = 5;
+
+type ReminderScope = Exclude<ReminderRouteSearch['scope'], 'all'>;
+
+interface TimeBoundaries {
+    now: string;
+    tomorrow: string;
+}
+
+interface ReminderActions {
+    onUpdate: (id: string, noteId: string, data: { completed?: boolean }) => void;
+    onDelete: (id: string, noteId: string) => void;
+    onEdit: (reminder: Reminder) => void;
+}
+
+const scopeDetails: Record<ReminderScope, { title: string; description: string; empty: string }> = {
+    overdue: {
+        title: 'Overdue',
+        description: 'Recently missed reminders that still need a decision.',
+        empty: 'Nothing overdue',
     },
-    {
-        label: 'Medium',
-        className: priorityColors.medium,
+    today: {
+        title: 'Today',
+        description: 'Open reminders due before the day ends.',
+        empty: 'Nothing else due today',
     },
-    {
-        label: 'Low',
-        className: priorityColors.low,
+    upcoming: {
+        title: 'Upcoming',
+        description: 'Reminders scheduled after today.',
+        empty: 'Nothing upcoming',
     },
-] as const;
+};
+
+const getPriority = (priority: ReminderRouteSearch['priority']) =>
+    priority === 'all' ? undefined : (priority as ReminderPriority);
+
+const buildOpenFilter = (
+    scope: ReminderScope,
+    priority: ReminderRouteSearch['priority'],
+    boundaries: TimeBoundaries,
+): ReminderListFilter => {
+    const baseFilter = {
+        status: 'open' as const,
+        ...(getPriority(priority) ? { priority: getPriority(priority) } : {}),
+        sortBy: 'reminderDate' as const,
+    };
+
+    if (scope === 'overdue') {
+        return {
+            ...baseFilter,
+            end: boundaries.now,
+            sortOrder: 'desc',
+        };
+    }
+
+    if (scope === 'today') {
+        return {
+            ...baseFilter,
+            start: boundaries.now,
+            end: boundaries.tomorrow,
+            sortOrder: 'asc',
+        };
+    }
+
+    return {
+        ...baseFilter,
+        start: boundaries.tomorrow,
+        sortOrder: 'asc',
+    };
+};
+
+function ReminderListSkeleton() {
+    return (
+        <div role="status" aria-label="Loading reminders" className="flex flex-col gap-2.5">
+            <Skeleton height="72px" />
+            <Skeleton height="72px" />
+            <Skeleton height="72px" />
+        </div>
+    );
+}
+
+function ReminderCards({ reminders, actions }: { reminders: Reminder[]; actions: ReminderActions }) {
+    return (
+        <div className="flex flex-col gap-2.5">
+            {reminders.map((reminder) => (
+                <ReminderCard
+                    key={reminder.id}
+                    reminder={reminder}
+                    onUpdate={actions.onUpdate}
+                    onDelete={actions.onDelete}
+                    onEdit={actions.onEdit}
+                />
+            ))}
+        </div>
+    );
+}
+
+function ReminderOverviewSection({
+    scope,
+    collection,
+    actions,
+    onViewAll,
+}: {
+    scope: ReminderScope;
+    collection: ReminderCollection;
+    actions: ReminderActions;
+    onViewAll: (scope: ReminderScope) => void;
+}) {
+    const detail = scopeDetails[scope];
+    const headingId = `reminder-${scope}-heading`;
+
+    return (
+        <section aria-labelledby={headingId} className="border-b border-border-subtle pb-5 last:border-b-0 last:pb-0">
+            <div className="mb-3 flex flex-wrap items-end justify-between gap-3">
+                <div className="min-w-0">
+                    <div className="flex items-center gap-2">
+                        <Text as="h2" id={headingId} variant="body" weight="bold">
+                            {detail.title}
+                        </Text>
+                        <Text
+                            as="span"
+                            variant="label"
+                            weight="semibold"
+                            tone="tertiary"
+                            className="rounded-full bg-hover-subtle px-2 py-0.5"
+                        >
+                            {collection.totalCount}
+                        </Text>
+                    </div>
+                    <Text as="p" variant="meta" tone="tertiary" className="mt-0.5">
+                        {detail.description}
+                    </Text>
+                </div>
+                {collection.totalCount > OVERVIEW_LIMIT ? (
+                    <Button type="button" variant="ghost" size="sm" onClick={() => onViewAll(scope)}>
+                        View all
+                        <Icon.ArrowRight className="size-3.5" aria-hidden="true" />
+                    </Button>
+                ) : null}
+            </div>
+
+            {collection.reminders.length > 0 ? (
+                <ReminderCards reminders={collection.reminders} actions={actions} />
+            ) : (
+                <div className="rounded-[16px] border border-dashed border-border-subtle px-4 py-4">
+                    <Text as="p" variant="meta" weight="medium" tone="tertiary">
+                        {detail.empty}
+                    </Text>
+                </div>
+            )}
+        </section>
+    );
+}
+
+function OpenReminderOverview({
+    priority,
+    boundaries,
+    actions,
+    onViewAll,
+}: {
+    priority: ReminderRouteSearch['priority'];
+    boundaries: TimeBoundaries;
+    actions: ReminderActions;
+    onViewAll: (scope: ReminderScope) => void;
+}) {
+    const queryParams = {
+        now: boundaries.now,
+        tomorrow: boundaries.tomorrow,
+        priority: getPriority(priority),
+        limit: OVERVIEW_LIMIT,
+    };
+    const { data } = useSuspenseQuery({
+        queryKey: queryKeys.reminders.overview(queryParams),
+        queryFn: async () => {
+            const response = await fetchOpenReminderOverview(queryParams);
+            if (response.type === 'error') throw response;
+
+            return {
+                overdue: response.overdue,
+                today: response.today,
+                upcoming: response.upcoming,
+            };
+        },
+    });
+    const totalCount = data.overdue.totalCount + data.today.totalCount + data.upcoming.totalCount;
+
+    if (totalCount === 0) {
+        return (
+            <Empty
+                title="No open reminders"
+                description={
+                    priority === 'all'
+                        ? 'Add a reminder inside any note to see it here.'
+                        : 'Try another priority or add a matching reminder.'
+                }
+            />
+        );
+    }
+
+    return (
+        <div className="flex flex-col gap-5">
+            <ReminderOverviewSection
+                scope="overdue"
+                collection={data.overdue}
+                actions={actions}
+                onViewAll={onViewAll}
+            />
+            <ReminderOverviewSection scope="today" collection={data.today} actions={actions} onViewAll={onViewAll} />
+            <ReminderOverviewSection
+                scope="upcoming"
+                collection={data.upcoming}
+                actions={actions}
+                onViewAll={onViewAll}
+            />
+        </div>
+    );
+}
+
+function PaginatedReminderList({
+    status,
+    scope,
+    priority,
+    page,
+    boundaries,
+    actions,
+    onPageChange,
+    onBackToOverview,
+}: {
+    status: ReminderRouteSearch['status'];
+    scope: ReminderRouteSearch['scope'];
+    priority: ReminderRouteSearch['priority'];
+    page: number;
+    boundaries: TimeBoundaries;
+    actions: ReminderActions;
+    onPageChange: (page: number) => void;
+    onBackToOverview: () => void;
+}) {
+    const filter: ReminderListFilter =
+        status === 'completed'
+            ? {
+                  status: 'completed',
+                  ...(getPriority(priority) ? { priority: getPriority(priority) } : {}),
+                  sortBy: 'updatedAt',
+                  sortOrder: 'desc',
+              }
+            : buildOpenFilter(scope as ReminderScope, priority, boundaries);
+    const queryParams = {
+        filter,
+        limit: PAGE_LIMIT,
+        offset: (page - 1) * PAGE_LIMIT,
+    };
+    const { data } = useSuspenseQuery({
+        queryKey: queryKeys.reminders.list(queryParams),
+        queryFn: async () => {
+            const response = await fetchReminders(queryParams);
+            if (response.type === 'error') throw response;
+            return response.reminders;
+        },
+    });
+    const lastPage = Math.max(1, Math.ceil(data.totalCount / PAGE_LIMIT));
+
+    useEffect(() => {
+        if (page > lastPage) onPageChange(lastPage);
+    }, [lastPage, onPageChange, page]);
+
+    const detail = status === 'completed' ? null : scopeDetails[scope as ReminderScope];
+    const title = status === 'completed' ? 'Completed' : (detail?.title ?? 'Open reminders');
+
+    return (
+        <section aria-labelledby="reminder-list-heading">
+            <div className="mb-3 flex flex-wrap items-end justify-between gap-3">
+                <div>
+                    {status === 'open' ? (
+                        <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            className="-ml-3 mb-1"
+                            onClick={onBackToOverview}
+                        >
+                            <Icon.ArrowLeft className="size-3.5" aria-hidden="true" />
+                            All open reminders
+                        </Button>
+                    ) : null}
+                    <div className="flex items-center gap-2">
+                        <Text as="h2" id="reminder-list-heading" variant="body" weight="bold">
+                            {title}
+                        </Text>
+                        <Text
+                            as="span"
+                            variant="label"
+                            weight="semibold"
+                            tone="tertiary"
+                            className="rounded-full bg-hover-subtle px-2 py-0.5"
+                        >
+                            {data.totalCount}
+                        </Text>
+                    </div>
+                    <Text as="p" variant="meta" tone="tertiary" className="mt-0.5">
+                        {status === 'completed'
+                            ? 'Completed reminders can be reopened or permanently deleted.'
+                            : detail?.description}
+                    </Text>
+                </div>
+                {data.totalCount > 0 ? (
+                    <Text as="span" variant="label" tone="tertiary">
+                        {Math.min(queryParams.offset + 1, data.totalCount)}–
+                        {Math.min(queryParams.offset + data.reminders.length, data.totalCount)} of {data.totalCount}
+                    </Text>
+                ) : null}
+            </div>
+
+            {data.reminders.length > 0 ? (
+                <>
+                    <ReminderCards reminders={data.reminders} actions={actions} />
+                    {lastPage > 1 ? <Pagination page={page} last={lastPage} onChange={onPageChange} /> : null}
+                </>
+            ) : (
+                <Empty
+                    title={status === 'completed' ? 'No completed reminders' : detail?.empty}
+                    description={
+                        priority === 'all'
+                            ? 'There is nothing to manage in this list yet.'
+                            : 'Try another priority to see more reminders.'
+                    }
+                />
+            )}
+        </section>
+    );
+}
 
 export default function Reminders() {
     const navigate = Route.useNavigate();
-    const { page } = Route.useSearch();
+    const { status, scope, priority, page } = Route.useSearch();
     const { onUpdate, onDelete } = useReminderMutate();
+    const confirm = useConfirm();
+    const [editingReminder, setEditingReminder] = useState<Reminder>();
+    const [boundaries] = useState<TimeBoundaries>(() => {
+        const now = dayjs();
+        return {
+            now: now.toISOString(),
+            tomorrow: now.add(1, 'day').startOf('day').toISOString(),
+        };
+    });
 
-    const limit = 25;
-    const priorityLegend = (
-        <div className="flex flex-wrap items-center gap-3">
-            {priorityHints.map(({ label, className }) => (
-                <div key={label} className="flex items-center gap-1.5">
-                    <span
-                        className={`h-2.5 w-2.5 rounded-full border border-border-subtle ${className}`}
-                        aria-hidden="true"
-                    />
-                    <Text as="span" variant="label" weight="medium" tone="tertiary">
-                        {label}
-                    </Text>
-                </div>
-            ))}
+    const setPage = (nextPage: number) => {
+        navigate({
+            search: (prev) => ({
+                ...prev,
+                page: nextPage,
+            }),
+        });
+    };
+    const handleDelete = async (id: string, noteId: string) => {
+        if (await confirm('Delete this reminder? This cannot be undone.')) {
+            await onDelete(id, noteId);
+        }
+    };
+    const actions: ReminderActions = {
+        onUpdate,
+        onDelete: handleDelete,
+        onEdit: setEditingReminder,
+    };
+    const controls = (
+        <div className="flex flex-wrap items-center gap-2">
+            <ToggleGroup
+                type="single"
+                variant="quiet"
+                size="sm"
+                value={status}
+                onValueChange={(value) => {
+                    if (!value) return;
+                    navigate({
+                        search: (prev) => ({
+                            ...prev,
+                            status: value as ReminderRouteSearch['status'],
+                            scope: 'all',
+                            page: 1,
+                        }),
+                    });
+                }}
+            >
+                <ToggleGroupItem value="open">Open</ToggleGroupItem>
+                <ToggleGroupItem value="completed">Completed</ToggleGroupItem>
+            </ToggleGroup>
+            <Select
+                value={priority}
+                size="sm"
+                ariaLabel="Filter reminders by priority"
+                className="w-[148px]"
+                onValueChange={(value) => {
+                    navigate({
+                        search: (prev) => ({
+                            ...prev,
+                            priority: value as ReminderRouteSearch['priority'],
+                            page: 1,
+                        }),
+                    });
+                }}
+            >
+                <SelectItem value="all">All priorities</SelectItem>
+                <SelectItem value="high">High priority</SelectItem>
+                <SelectItem value="medium">Medium priority</SelectItem>
+                <SelectItem value="low">Low priority</SelectItem>
+            </Select>
         </div>
     );
 
     return (
-        <QueryBoundary
-            fallback={
-                <PageLayout
-                    title="Reminders"
-                    heading={<Skeleton width={164} height={24} className="rounded-full" />}
-                    description={<Skeleton width={224} height={16} className="rounded-full" />}
-                    headerRight={priorityLegend}
+        <>
+            <PageLayout
+                title="Reminders"
+                description={
+                    status === 'completed'
+                        ? 'Review completed reminders and reopen anything that still needs attention.'
+                        : 'Act on what is overdue, due today, and coming next.'
+                }
+                headerRight={controls}
+            >
+                <QueryBoundary
+                    fallback={<ReminderListSkeleton />}
+                    errorTitle="Failed to load reminders"
+                    errorDescription="Retry loading the reminder workspace."
+                    resetKeys={[status, scope, priority, page, boundaries.now]}
                 >
-                    <div className="flex flex-col gap-2.5">
-                        <Skeleton height="60px" />
-                        <Skeleton height="60px" />
-                        <Skeleton height="60px" />
-                        <Skeleton height="60px" />
-                    </div>
-                </PageLayout>
-            }
-            errorTitle="Failed to load reminders"
-            errorDescription="Retry loading the upcoming reminder list"
-            resetKeys={[page, limit]}
-        >
-            <RemindersEntity
-                searchParams={{
-                    offset: (page - 1) * limit,
-                    limit,
-                }}
-                render={({ reminders, totalCount }) => {
-                    const heading = totalCount > 0 ? `Reminders (${totalCount})` : undefined;
-                    const description = 'Review reminders created from notes and mark them complete here';
+                    {status === 'open' && scope === 'all' ? (
+                        <OpenReminderOverview
+                            priority={priority}
+                            boundaries={boundaries}
+                            actions={actions}
+                            onViewAll={(nextScope) => {
+                                navigate({
+                                    search: (prev) => ({
+                                        ...prev,
+                                        scope: nextScope,
+                                        page: 1,
+                                    }),
+                                });
+                            }}
+                        />
+                    ) : (
+                        <PaginatedReminderList
+                            status={status}
+                            scope={scope}
+                            priority={priority}
+                            page={page}
+                            boundaries={boundaries}
+                            actions={actions}
+                            onPageChange={setPage}
+                            onBackToOverview={() => {
+                                navigate({
+                                    search: (prev) => ({
+                                        ...prev,
+                                        scope: 'all',
+                                        page: 1,
+                                    }),
+                                });
+                            }}
+                        />
+                    )}
+                </QueryBoundary>
+            </PageLayout>
 
-                    if (reminders.length === 0) {
-                        return (
-                            <PageLayout
-                                title="Reminders"
-                                heading={heading}
-                                description={description}
-                                headerRight={priorityLegend}
-                            >
-                                <Empty
-                                    title="No upcoming reminders"
-                                    description="Add a reminder inside any note to see it here"
-                                />
-                            </PageLayout>
-                        );
-                    }
-
-                    return (
-                        <PageLayout
-                            title="Reminders"
-                            heading={heading}
-                            description={description}
-                            headerRight={priorityLegend}
-                        >
-                            <div className="flex flex-col gap-4">
-                                <div className="flex flex-col gap-2.5">
-                                    {reminders.map((reminder) => (
-                                        <ReminderCard
-                                            key={reminder.id}
-                                            reminder={reminder}
-                                            onUpdate={onUpdate}
-                                            onDelete={onDelete}
-                                        />
-                                    ))}
-                                </div>
-                                {totalCount && limit < totalCount && (
-                                    <Pagination
-                                        page={page}
-                                        last={Math.ceil(totalCount / limit)}
-                                        onChange={(nextPage) => {
-                                            navigate({
-                                                search: (prev) => ({
-                                                    ...prev,
-                                                    page: nextPage,
-                                                }),
-                                            });
-                                        }}
-                                    />
-                                )}
-                            </div>
-                        </PageLayout>
-                    );
+            <ReminderModal
+                isOpen={Boolean(editingReminder)}
+                mode="edit"
+                reminder={editingReminder}
+                onClose={() => setEditingReminder(undefined)}
+                onSave={(date, nextPriority, content) => {
+                    if (!editingReminder) return;
+                    onUpdate(editingReminder.id, String(editingReminder.noteId), {
+                        reminderDate: date,
+                        priority: nextPriority,
+                        content,
+                    });
                 }}
             />
-        </QueryBoundary>
+        </>
     );
 }

--- a/packages/client/src/router.tsx
+++ b/packages/client/src/router.tsx
@@ -14,6 +14,7 @@ import {
     validateGraphSearch,
     validateHomeSearch,
     validatePaginationSearch,
+    validateReminderSearch,
     validateSearchPageSearch,
     validateTagSearch,
     validateViewNotesSearch,
@@ -82,9 +83,9 @@ const remindersRoute = createRoute({
     path: REMINDERS_ROUTE,
     component: lazyRouteComponent(() => import('~/pages/Reminders')),
     pendingComponent: () => (
-        <RoutePendingView title="Loading reminders" description="Collecting upcoming reminder cards." />
+        <RoutePendingView title="Loading reminders" description="Preparing your reminder workspace." />
     ),
-    validateSearch: validatePaginationSearch,
+    validateSearch: validateReminderSearch,
 });
 
 const graphRoute = createRoute({

--- a/packages/server/src/features/reminder/graphql/reminder.query.resolver.test.ts
+++ b/packages/server/src/features/reminder/graphql/reminder.query.resolver.test.ts
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { createNoteRemindersQueryResolver, createUpcomingRemindersQueryResolver } from './reminder.query.resolver.js';
+import {
+    createNoteRemindersQueryResolver,
+    createRemindersQueryResolver,
+    createUpcomingRemindersQueryResolver,
+} from './reminder.query.resolver.js';
 
 test('noteReminders resolver applies note id and pagination to reminder queries', async () => {
     const seenArgs: Array<unknown> = [];
@@ -61,4 +65,115 @@ test('upcomingReminders resolver defaults pagination and includes notes', async 
         totalCount: 2,
         reminders: [{ id: 7 }],
     });
+});
+
+test('reminders resolver applies status, priority, date bounds, sorting, and pagination', async () => {
+    const start = '2026-08-03T00:00:00.000Z';
+    const end = '2026-08-04T00:00:00.000Z';
+    const expectedWhere = {
+        completed: false,
+        priority: 'high',
+        reminderDate: {
+            gte: new Date(start),
+            lt: new Date(end),
+        },
+    };
+    const resolver = createRemindersQueryResolver({
+        countReminders: async (where) => {
+            assert.deepEqual(where, expectedWhere);
+            return 4;
+        },
+        findReminders: async (args) => {
+            assert.deepEqual(args, {
+                where: expectedWhere,
+                orderBy: [{ reminderDate: 'desc' }, { id: 'desc' }],
+                take: 10,
+                skip: 20,
+                include: { note: true },
+            });
+            return [{ id: 9 }] as never;
+        },
+    });
+
+    const result = await resolver(null, {
+        filter: {
+            status: 'open',
+            priority: 'high',
+            start,
+            end,
+            sortBy: 'reminderDate',
+            sortOrder: 'desc',
+        },
+        pagination: {
+            limit: 10,
+            offset: 20,
+        },
+    });
+
+    assert.deepEqual(result, {
+        totalCount: 4,
+        reminders: [{ id: 9 }],
+    });
+});
+
+test('reminders resolver can list recently updated completed reminders', async () => {
+    const resolver = createRemindersQueryResolver({
+        countReminders: async (where) => {
+            assert.deepEqual(where, { completed: true });
+            return 1;
+        },
+        findReminders: async (args) => {
+            assert.deepEqual(args, {
+                where: { completed: true },
+                orderBy: [{ updatedAt: 'desc' }, { id: 'desc' }],
+                take: 25,
+                skip: 0,
+                include: { note: true },
+            });
+            return [{ id: 11 }] as never;
+        },
+    });
+
+    const result = await resolver(null, {
+        filter: {
+            status: 'completed',
+            sortBy: 'updatedAt',
+            sortOrder: 'desc',
+        },
+    });
+
+    assert.deepEqual(result, {
+        totalCount: 1,
+        reminders: [{ id: 11 }],
+    });
+});
+
+test('reminders resolver bounds pagination before querying', async () => {
+    const resolver = createRemindersQueryResolver({
+        countReminders: async () => 0,
+        findReminders: async (args) => {
+            assert.equal(args.take, 100);
+            assert.equal(args.skip, 0);
+            return [];
+        },
+    });
+
+    await resolver(null, {
+        filter: { status: 'completed' },
+        pagination: { limit: 1_000, offset: -10 },
+    });
+});
+
+test('reminders resolver rejects invalid date filters instead of dropping them', async () => {
+    const resolver = createRemindersQueryResolver({
+        countReminders: async () => 0,
+        findReminders: async () => [],
+    });
+
+    await assert.rejects(
+        resolver(null, {
+            filter: { status: 'open', start: 'not-a-date' },
+        }),
+        /valid date strings/,
+    );
 });

--- a/packages/server/src/features/reminder/graphql/reminder.query.resolver.ts
+++ b/packages/server/src/features/reminder/graphql/reminder.query.resolver.ts
@@ -1,12 +1,13 @@
 import type { IResolvers } from '@graphql-tools/utils';
+import type { Prisma } from '~/models.js';
 import models from '~/models.js';
 import type { Pagination } from '~/types/index.js';
 
 interface ReminderListDeps {
-    countReminders: (where: object) => Promise<number>;
+    countReminders: (where: Prisma.ReminderWhereInput) => Promise<number>;
     findReminders: (args: {
-        where: object;
-        orderBy: { reminderDate: 'asc' };
+        where: Prisma.ReminderWhereInput;
+        orderBy: Prisma.ReminderOrderByWithRelationInput | Prisma.ReminderOrderByWithRelationInput[];
         take?: number;
         skip?: number;
         include?: { note: true };
@@ -15,6 +16,63 @@ interface ReminderListDeps {
 
 type NoteRemindersResolverDeps = ReminderListDeps;
 type UpcomingRemindersResolverDeps = ReminderListDeps;
+type RemindersResolverDeps = ReminderListDeps;
+
+type ReminderFilter = {
+    status?: 'open' | 'completed';
+    priority?: 'low' | 'medium' | 'high';
+    start?: string;
+    end?: string;
+    sortBy?: 'reminderDate' | 'updatedAt';
+    sortOrder?: 'asc' | 'desc';
+};
+
+const DEFAULT_REMINDER_LIMIT = 25;
+const MAX_REMINDER_LIMIT = 100;
+
+const toValidDate = (value?: string) => {
+    if (!value) return undefined;
+
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        throw new Error('Reminder date filters must be valid date strings.');
+    }
+
+    return date;
+};
+
+const normalizeReminderPagination = (pagination?: Pagination | null) => {
+    const numericLimit = Number(pagination?.limit ?? DEFAULT_REMINDER_LIMIT);
+    const limit = Number.isInteger(numericLimit)
+        ? Math.min(MAX_REMINDER_LIMIT, Math.max(1, numericLimit))
+        : DEFAULT_REMINDER_LIMIT;
+    const numericOffset = Number(pagination?.offset ?? 0);
+    const offset = Number.isInteger(numericOffset) ? Math.max(0, numericOffset) : 0;
+
+    return { limit, offset };
+};
+
+const buildReminderWhere = (filter: ReminderFilter): Prisma.ReminderWhereInput => {
+    const start = toValidDate(filter.start);
+    const end = toValidDate(filter.end);
+    const reminderDate: Prisma.DateTimeFilter = {};
+
+    if (start) reminderDate.gte = start;
+    if (end) reminderDate.lt = end;
+
+    return {
+        completed: filter.status === 'completed',
+        ...(filter.priority ? { priority: filter.priority } : {}),
+        ...(start || end ? { reminderDate } : {}),
+    };
+};
+
+const buildReminderOrderBy = (filter: ReminderFilter): Prisma.ReminderOrderByWithRelationInput[] => {
+    const sortBy = filter.sortBy === 'updatedAt' ? 'updatedAt' : 'reminderDate';
+    const sortOrder = filter.sortOrder === 'desc' ? 'desc' : 'asc';
+
+    return [{ [sortBy]: sortOrder }, { id: sortOrder }];
+};
 
 export const createNoteRemindersQueryResolver = (
     deps: NoteRemindersResolverDeps = {
@@ -89,10 +147,47 @@ export const createUpcomingRemindersQueryResolver = (
     };
 };
 
+export const createRemindersQueryResolver = (
+    deps: RemindersResolverDeps = {
+        countReminders: async (where) => models.reminder.count({ where }),
+        findReminders: async (args) => models.reminder.findMany(args),
+    },
+) => {
+    return async (
+        _: unknown,
+        {
+            filter,
+            pagination,
+        }: {
+            filter: ReminderFilter;
+            pagination?: Pagination | null;
+        },
+    ) => {
+        const where = buildReminderWhere(filter);
+        const normalizedPagination = normalizeReminderPagination(pagination);
+        const [totalCount, reminders] = await Promise.all([
+            deps.countReminders(where),
+            deps.findReminders({
+                where,
+                orderBy: buildReminderOrderBy(filter),
+                take: normalizedPagination.limit,
+                skip: normalizedPagination.offset,
+                include: { note: true },
+            }),
+        ]);
+
+        return {
+            totalCount,
+            reminders,
+        };
+    };
+};
+
 type ReminderQueryResolvers = NonNullable<IResolvers['Query']>;
 
 export const reminderQueryResolvers: ReminderQueryResolvers = {
     noteReminders: createNoteRemindersQueryResolver(),
+    reminders: createRemindersQueryResolver(),
     upcomingReminders: createUpcomingRemindersQueryResolver(),
     remindersInDateRange: async (
         _,

--- a/packages/server/src/features/reminder/graphql/reminder.type-defs.ts
+++ b/packages/server/src/features/reminder/graphql/reminder.type-defs.ts
@@ -7,6 +7,30 @@ export const reminderType = gql`
         high
     }
 
+    enum ReminderStatus {
+        open
+        completed
+    }
+
+    enum ReminderSortBy {
+        reminderDate
+        updatedAt
+    }
+
+    enum ReminderSortOrder {
+        asc
+        desc
+    }
+
+    input ReminderFilterInput {
+        status: ReminderStatus!
+        priority: ReminderPriority
+        start: String
+        end: String
+        sortBy: ReminderSortBy
+        sortOrder: ReminderSortOrder
+    }
+
     type Reminder {
         id: ID!
         noteId: Int!
@@ -28,6 +52,7 @@ export const reminderType = gql`
 export const reminderQuery = gql`
     extend type Query {
         noteReminders(noteId: ID!, pagination: PaginationInput): Reminders!
+        reminders(filter: ReminderFilterInput!, pagination: PaginationInput): Reminders!
         upcomingReminders(pagination: PaginationInput): Reminders!
         remindersInDateRange(dateRange: DateRangeInput): [Reminder!]!
     }


### PR DESCRIPTION
## :dart: Goal
- Turn the reminders page from an upcoming-only feed into a workspace for acting on open reminders and reviewing completed history.
- Keep large reminder histories manageable without changing the database schema or breaking existing reminder consumers.

## :hammer_and_wrench: Core Changes
- Split open reminders into independent Overdue, Today, and Upcoming previews, with priority filtering and scoped View all lists.
- Add a completed-reminder view with reopen, note navigation, confirmed deletion, and URL-backed pagination at 25 items per page.
- Add a filtered and sorted GraphQL reminder collection query, local-demo parity, and shared cache invalidation after reminder writes.
- Bound pagination inputs and reject invalid date filters before database access.

## :brain: Key Decisions
- Preserve the existing upcomingReminders query so note panels and existing clients keep their current contract.
- Store status, scope, priority, and page in the URL so back/forward navigation restores the management context.
- Sort completed reminders by reminder updatedAt because the current schema has no completedAt field; this PR intentionally adds no migration.
- Keep tests focused on route normalization, reminder state actions, query filters, ordering, and input boundaries; no visual snapshots were added.

## :test_tube: Verification Guide
### How to verify
1. Run pnpm check:encoding.
2. Run pnpm lint.
3. Run pnpm type-check.
4. Run pnpm test:ci.
5. Run pnpm build.
6. Open /reminders, switch between Open and Completed, change priority, paginate completed reminders, and use browser back/forward.
7. Open reminder actions and verify edit, reopen, and confirmed delete paths.

### Expected result
- Open reminders remain independently discoverable even when one time bucket contains many items.
- Completed reminders show a stable total, item range, and URL-restorable pages.
- Reminder writes refresh page, note-panel, and calendar reminder data.
- Existing reminder data works without a database migration.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (not needed; behavior and verification are documented here)