### PR TITLE
✅ Align graph production smoke with graph state

### DIFF
--- a/tests/e2e/production-routes.spec.ts
+++ b/tests/e2e/production-routes.spec.ts
@@ -145,10 +145,10 @@ test('production graph chunks render after a direct hard refresh', async ({ page
 
     await page.goto('/graph');
     await expect(page.getByRole('heading', { name: 'Knowledge Graph' })).toBeVisible();
-    await expect(page.getByText('No constellations yet')).toBeVisible();
+    await expect(page.getByText(/0 linked notes.*0 connections/)).toBeVisible();
 
     await page.reload();
     await expect(page.getByRole('heading', { name: 'Knowledge Graph' })).toBeVisible();
-    await expect(page.getByText('No constellations yet')).toBeVisible();
+    await expect(page.getByText(/0 linked notes.*0 connections/)).toBeVisible();
     expect(runtimeErrors).toEqual([]);
 });


### PR DESCRIPTION
## :dart: Goal
Keep the production graph hard-refresh smoke aligned with the redesigned graph while preserving its real chunk-readiness signal.

## :hammer_and_wrench: Core Changes
- Replace the removed empty-state copy assertion with the loaded graph count summary.
- Keep the same direct navigation, hard refresh, and runtime-error checks.

## :brain: Key Decisions
- Assert the data-ready state rather than the changeable empty-state headline.
- Keep this as a test-only correction with no released runtime behavior change.

## :test_tube: Verification Guide
- Run pnpm check:encoding; expect the workspace encoding check to pass.
- Run pnpm lint; expect client and server lint to pass.
- Run pnpm build; expect client and server production builds to pass.
- Run pnpm exec playwright test; expect all 6 browser E2E tests to pass.

## :white_check_mark: Checklist
- [x] Release PR failure identified as a stale graph assertion
- [x] Targeted graph E2E passed locally
- [x] Full browser E2E passed locally
- [x] Encoding, lint, and build passed locally
- [x] PR CI passed