### PR TITLE
🐛 Refine calendar browsing experience

### DIFF
--- a/packages/client/src/components/calendar/CalendarDay.spec.tsx
+++ b/packages/client/src/components/calendar/CalendarDay.spec.tsx
@@ -1,20 +1,13 @@
-import { render, screen, within } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-
-vi.mock('./NoteCard', () => ({
-    NoteCard: ({ note }: { note: { title: string } }) => <div data-testid="calendar-note-card">{note.title}</div>,
-}));
-
-vi.mock('./ReminderCard', () => ({
-    ReminderCard: ({ reminder }: { reminder: { content: string } }) => (
-        <div data-testid="calendar-reminder-card">{reminder.content}</div>
-    ),
-}));
 
 import { CalendarDay } from './CalendarDay';
 
 describe('<CalendarDay />', () => {
-    it('prioritizes reminders before notes for upcoming days', () => {
+    it('summarizes the day and selects it from the month overview', async () => {
+        const user = userEvent.setup();
+        const handleSelect = vi.fn();
+
         render(
             <CalendarDay
                 year={2026}
@@ -23,90 +16,56 @@ describe('<CalendarDay />', () => {
                 isCurrentMonth
                 isSunday={false}
                 isToday={false}
+                isSelected={false}
                 isPast={false}
                 notes={
                     [
-                        {
-                            id: 'n1',
-                            title: 'Note one',
-                        },
-                        {
-                            id: 'n2',
-                            title: 'Note two',
-                        },
+                        { id: 'n1', title: 'Note one' },
+                        { id: 'n2', title: 'Note two' },
                     ] as never[]
                 }
-                reminders={
-                    [
-                        {
-                            id: 'r1',
-                            content: 'Reminder one',
-                        },
-                        {
-                            id: 'r2',
-                            content: 'Reminder two',
-                        },
-                    ] as never[]
-                }
-                type="create"
+                reminders={[{ id: 'r1', content: 'Reminder one', completed: true }] as never[]}
+                onSelect={handleSelect}
             />,
         );
 
-        const visibleCards = screen
-            .getAllByTestId(/calendar-(note|reminder)-card/)
-            .map((element) => element.textContent);
+        const dayButton = screen.getByRole('button', {
+            name: 'Thursday, April 2, 2026, 2 notes, 1 reminder',
+        });
 
-        expect(visibleCards).toEqual(['Reminder one', 'Reminder two', 'Note one']);
-        expect(screen.getByRole('button', { name: '+1 more' })).toBeInTheDocument();
+        expect(dayButton).toHaveAttribute('aria-pressed', 'false');
+        expect(screen.getByText('Notes')).toBeInTheDocument();
+        expect(screen.getByText('Reminders')).toBeInTheDocument();
+        expect(screen.getByText('Reminder one')).toHaveClass('line-through');
+        expect(screen.getByText('Note one')).toBeInTheDocument();
+        expect(screen.getByText('+1 more')).toBeInTheDocument();
+
+        await user.click(dayButton);
+
+        expect(handleSelect).toHaveBeenCalledTimes(1);
     });
 
-    it('opens an overflow dialog with the full day contents', async () => {
-        const user = userEvent.setup();
-
+    it('keeps adjacent-month dates unavailable in the current month overview', () => {
         render(
             <CalendarDay
                 year={2026}
-                month={4}
-                day={2}
-                isCurrentMonth
-                isSunday={false}
+                month={3}
+                day={29}
+                isCurrentMonth={false}
+                isSunday
                 isToday={false}
+                isSelected={false}
                 isPast
-                notes={
-                    [
-                        {
-                            id: 'n1',
-                            title: 'Note one',
-                        },
-                        {
-                            id: 'n2',
-                            title: 'Note two',
-                        },
-                    ] as never[]
-                }
-                reminders={
-                    [
-                        {
-                            id: 'r1',
-                            content: 'Reminder one',
-                        },
-                        {
-                            id: 'r2',
-                            content: 'Reminder two',
-                        },
-                    ] as never[]
-                }
-                type="create"
+                notes={[]}
+                reminders={[]}
+                onSelect={vi.fn()}
             />,
         );
 
-        await user.click(screen.getByRole('button', { name: '+1 more' }));
-
-        const dialog = screen.getByRole('dialog');
-
-        expect(within(dialog).getAllByTestId('calendar-note-card')).toHaveLength(2);
-        expect(within(dialog).getAllByTestId('calendar-reminder-card')).toHaveLength(2);
-        expect(within(dialog).getByText('Note one')).toBeInTheDocument();
-        expect(within(dialog).getByText('Reminder one')).toBeInTheDocument();
+        expect(
+            screen.getByRole('button', {
+                name: 'Sunday, March 29, 2026, 0 notes, 0 reminders',
+            }),
+        ).toBeDisabled();
     });
 });

--- a/packages/client/src/components/calendar/CalendarDay.tsx
+++ b/packages/client/src/components/calendar/CalendarDay.tsx
@@ -1,14 +1,11 @@
-import { memo, useCallback, useMemo, useState } from 'react';
+import dayjs from 'dayjs';
 
-import { Modal } from '~/components/ui';
 import type { Note } from '~/models/note.model';
 import type { Reminder } from '~/models/reminder.model';
 import { CalendarDayView } from './CalendarDayView';
-import { NoteCard } from './NoteCard';
-import { ReminderCard } from './ReminderCard';
-import type { CalendarDisplayType, CalendarItem } from './types';
+import type { CalendarDayPreviewItem } from './types';
 
-const MAX_VISIBLE_ITEMS = 3;
+const MAX_PREVIEW_ITEMS = 2;
 
 interface Props {
     year: number;
@@ -17,20 +14,12 @@ interface Props {
     isCurrentMonth: boolean;
     isSunday: boolean;
     isToday: boolean;
+    isSelected: boolean;
     isPast: boolean;
     notes: Note[];
     reminders: Reminder[];
-    type: CalendarDisplayType;
+    onSelect: () => void;
 }
-
-const renderItems = (items: CalendarItem[], type: CalendarDisplayType) =>
-    items.map((calendarItem) =>
-        calendarItem.type === 'note' ? (
-            <NoteCard key={`note-${calendarItem.item.id}`} note={calendarItem.item} type={type} />
-        ) : (
-            <ReminderCard key={`reminder-${calendarItem.item.id}`} reminder={calendarItem.item} />
-        ),
-    );
 
 const CalendarDayComponent = ({
     year,
@@ -39,84 +28,67 @@ const CalendarDayComponent = ({
     isCurrentMonth,
     isSunday,
     isToday,
+    isSelected,
     isPast,
     notes,
     reminders,
-    type,
+    onSelect,
 }: Props) => {
-    const [isModalOpen, setIsModalOpen] = useState(false);
-
-    const sortedItems = useMemo<CalendarItem[]>(() => {
-        const noteItems: CalendarItem[] = notes.map((n) => ({
-            type: 'note',
-            item: n,
-        }));
-        const reminderItems: CalendarItem[] = reminders.map((r) => ({
-            type: 'reminder',
-            item: r,
-        }));
-
-        return isPast ? [...noteItems, ...reminderItems] : [...reminderItems, ...noteItems];
-    }, [isPast, notes, reminders]);
-
-    const hasOverflow = sortedItems.length > MAX_VISIBLE_ITEMS;
-    const visibleItems = useMemo(() => renderItems(sortedItems.slice(0, MAX_VISIBLE_ITEMS), type), [sortedItems, type]);
-    const allItems = useMemo(() => renderItems(sortedItems, type), [sortedItems, type]);
-
-    const handleOpenModal = useCallback(() => setIsModalOpen(true), []);
-    const handleCloseModal = useCallback(() => setIsModalOpen(false), []);
+    const noteItems: CalendarDayPreviewItem[] = notes.slice(0, MAX_PREVIEW_ITEMS).map((note) => ({
+        key: `note-${note.id}`,
+        type: 'note',
+        title: note.title,
+    }));
+    const reminderItems: CalendarDayPreviewItem[] = reminders.slice(0, MAX_PREVIEW_ITEMS).map((reminder) => ({
+        key: `reminder-${reminder.id}`,
+        type: 'reminder',
+        title: reminder.content || reminder.note?.title || 'No title',
+        isCompleted: reminder.completed,
+    }));
+    const previewItems = (isPast ? [...noteItems, ...reminderItems] : [...reminderItems, ...noteItems]).slice(
+        0,
+        MAX_PREVIEW_ITEMS,
+    );
 
     const getCellStyle = () => {
         if (!isCurrentMonth) {
-            return 'bg-muted/18 border-border-subtle/70';
+            return 'cursor-default bg-[var(--page-bg)] text-fg-disabled';
         }
-        if (isToday) {
-            return 'border-border-secondary/70 bg-[color:color-mix(in_srgb,var(--surface)_88%,var(--accent-soft-primary)_12%)]';
+        if (isSelected) {
+            return 'bg-elevated shadow-[inset_0_0_0_1px_var(--border-secondary)] hover:bg-surface';
         }
-        return 'bg-surface border-border-subtle';
+        return 'bg-surface hover:bg-muted';
     };
 
     const getDayNumberStyle = () => {
         if (isToday) {
-            return 'bg-cta text-fg-on-filled font-semibold';
+            return 'bg-cta font-semibold text-fg-on-filled';
         }
         if (!isCurrentMonth) {
-            return 'text-fg-disabled opacity-55';
+            return 'font-medium text-fg-tertiary';
         }
         if (isSunday) {
-            return 'text-fg-weekend font-bold';
+            return 'font-semibold text-fg-weekend';
         }
-        return 'text-fg-secondary font-bold';
+        return 'font-semibold text-fg-secondary';
     };
 
     return (
-        <>
-            <CalendarDayView
-                day={day}
-                cellClassName={getCellStyle()}
-                dayNumberClassName={getDayNumberStyle()}
-                isCurrentMonth={isCurrentMonth}
-                items={visibleItems}
-                overflowCount={hasOverflow ? sortedItems.length - MAX_VISIBLE_ITEMS : 0}
-                onOpenOverflow={handleOpenModal}
-            />
-
-            {hasOverflow && (
-                <Modal isOpen={isModalOpen} onClose={handleCloseModal} variant="inspect">
-                    <Modal.Header
-                        title={`${year}/${String(month).padStart(2, '0')}/${String(day).padStart(2, '0')}`}
-                        onClose={handleCloseModal}
-                    />
-                    <Modal.Body>
-                        <Modal.Description className="sr-only">
-                            View all notes and reminders scheduled for day {day}.
-                        </Modal.Description>
-                        <div className="flex max-h-[60vh] flex-col gap-2 overflow-y-auto">{allItems}</div>
-                    </Modal.Body>
-                </Modal>
-            )}
-        </>
+        <CalendarDayView
+            day={day}
+            dateLabel={dayjs(new Date(year, month - 1, day)).format('dddd, MMMM D, YYYY')}
+            cellClassName={getCellStyle()}
+            dayNumberClassName={getDayNumberStyle()}
+            isCurrentMonth={isCurrentMonth}
+            isToday={isToday}
+            isSelected={isSelected}
+            noteCount={notes.length}
+            reminderCount={reminders.length}
+            previewItems={previewItems}
+            overflowCount={Math.max(0, notes.length + reminders.length - MAX_PREVIEW_ITEMS)}
+            onSelect={onSelect}
+        />
     );
 };
 
-export const CalendarDay = memo(CalendarDayComponent);
+export const CalendarDay = CalendarDayComponent;

--- a/packages/client/src/components/calendar/CalendarDayDetail.spec.tsx
+++ b/packages/client/src/components/calendar/CalendarDayDetail.spec.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from '@testing-library/react';
+
+vi.mock('./NoteCard', () => ({
+    NoteCard: ({ note }: { note: { title: string } }) => <div data-testid="calendar-note-card">{note.title}</div>,
+}));
+
+vi.mock('./ReminderCard', () => ({
+    ReminderCard: ({ reminder }: { reminder: { content: string } }) => (
+        <div data-testid="calendar-reminder-card">{reminder.content}</div>
+    ),
+}));
+
+import { CalendarDayDetail } from './CalendarDayDetail';
+import type { CalendarDayData } from './types';
+
+describe('<CalendarDayDetail />', () => {
+    it('keeps the selected date visible without skeleton cards while activity is loading', () => {
+        const day = {
+            key: '2026-4-2',
+            year: 2026,
+            month: 4,
+            day: 2,
+            isCurrentMonth: true,
+            isSunday: false,
+            isToday: false,
+            isPast: false,
+            notes: [],
+            reminders: [],
+        } as CalendarDayData;
+
+        render(<CalendarDayDetail day={day} type="create" isLoading />);
+
+        expect(screen.getByRole('heading', { name: 'Thursday, April 2' })).toBeInTheDocument();
+        expect(screen.getByText('Loading activity...')).toBeInTheDocument();
+        expect(screen.queryByTestId(/calendar-(note|reminder)-card/)).not.toBeInTheDocument();
+    });
+
+    it('shows every item with reminders first for an upcoming day', () => {
+        const day = {
+            key: '2026-4-2',
+            year: 2026,
+            month: 4,
+            day: 2,
+            isCurrentMonth: true,
+            isSunday: false,
+            isToday: false,
+            isPast: false,
+            notes: [
+                { id: 'n1', title: 'Note one' },
+                { id: 'n2', title: 'Note two' },
+            ],
+            reminders: [
+                { id: 'r1', content: 'Reminder one' },
+                { id: 'r2', content: 'Reminder two' },
+            ],
+        } as CalendarDayData;
+
+        render(<CalendarDayDetail day={day} type="create" isLoading={false} />);
+
+        const items = screen.getAllByTestId(/calendar-(note|reminder)-card/).map((element) => element.textContent);
+
+        expect(items).toEqual(['Reminder one', 'Reminder two', 'Note one', 'Note two']);
+        expect(screen.getByRole('heading', { name: 'Thursday, April 2' })).toBeInTheDocument();
+    });
+
+    it('asks for a date before showing day details', () => {
+        render(<CalendarDayDetail type="update" isLoading={false} />);
+
+        expect(screen.getByText('Select a day to see its activity.')).toBeInTheDocument();
+    });
+});

--- a/packages/client/src/components/calendar/CalendarDayDetail.tsx
+++ b/packages/client/src/components/calendar/CalendarDayDetail.tsx
@@ -1,0 +1,96 @@
+import dayjs from 'dayjs';
+import { useMemo } from 'react';
+
+import * as Icon from '~/components/icon';
+import { Text } from '~/components/ui';
+import { NoteCard } from './NoteCard';
+import { ReminderCard } from './ReminderCard';
+import type { CalendarDayData, CalendarDisplayType, CalendarItem } from './types';
+
+interface CalendarDayDetailProps {
+    day?: CalendarDayData;
+    type: CalendarDisplayType;
+    isLoading: boolean;
+    presentation?: 'rail' | 'modal';
+}
+
+const renderItems = (items: CalendarItem[], type: CalendarDisplayType) =>
+    items.map((calendarItem) =>
+        calendarItem.type === 'note' ? (
+            <NoteCard key={`note-${calendarItem.item.id}`} note={calendarItem.item} type={type} />
+        ) : (
+            <ReminderCard key={`reminder-${calendarItem.item.id}`} reminder={calendarItem.item} />
+        ),
+    );
+
+const formatCount = (count: number, singular: string) => `${count} ${count === 1 ? singular : `${singular}s`}`;
+const RAIL_ACTIVITY_CLASS_NAME =
+    'mt-3 flex min-h-0 flex-1 flex-col gap-1 overflow-y-auto overscroll-y-contain pr-2 [scrollbar-color:var(--border-secondary)_transparent] [scrollbar-width:thin] [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-border-secondary [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar]:w-1.5';
+
+export const getCalendarDayHeading = (day: CalendarDayData) =>
+    dayjs(new Date(day.year, day.month - 1, day.day)).format('dddd, MMMM D');
+
+export const CalendarDayDetail = ({ day, type, isLoading, presentation = 'rail' }: CalendarDayDetailProps) => {
+    const sortedItems = useMemo<CalendarItem[]>(() => {
+        if (!day) return [];
+
+        const noteItems: CalendarItem[] = day.notes.map((note) => ({ type: 'note', item: note }));
+        const reminderItems: CalendarItem[] = day.reminders.map((reminder) => ({ type: 'reminder', item: reminder }));
+
+        return day.isPast ? [...noteItems, ...reminderItems] : [...reminderItems, ...noteItems];
+    }, [day]);
+
+    if (!day) {
+        return (
+            <section aria-label="Day details" className="flex h-full min-h-40 items-center justify-center text-center">
+                <Text as="p" variant="meta" weight="medium" tone="secondary">
+                    Select a day to see its activity.
+                </Text>
+            </section>
+        );
+    }
+
+    const heading = getCalendarDayHeading(day);
+    const summary = isLoading
+        ? 'Loading activity...'
+        : [formatCount(day.notes.length, 'note'), formatCount(day.reminders.length, 'reminder')].join(' · ');
+    const activity = isLoading ? null : (
+        <div className={presentation === 'rail' ? RAIL_ACTIVITY_CLASS_NAME : 'flex flex-col gap-1'}>
+            {sortedItems.length > 0 ? (
+                renderItems(sortedItems, type)
+            ) : (
+                <Text as="p" variant="meta" weight="medium" tone="secondary" className="py-8 text-center">
+                    No activity on this day.
+                </Text>
+            )}
+        </div>
+    );
+
+    if (presentation === 'modal') {
+        return (
+            <div aria-label={`${heading} activity`}>
+                <Text as="p" variant="label" weight="medium" tone="secondary" className="mb-3">
+                    {summary}
+                </Text>
+                {activity}
+            </div>
+        );
+    }
+
+    return (
+        <section aria-label={`${heading} details`} className="flex h-full min-h-0 flex-col">
+            <div className="flex shrink-0 items-start gap-2 border-b border-border-subtle/80 pb-3">
+                <Icon.Calendar aria-hidden="true" className="mt-0.5 shrink-0 text-fg-tertiary" size={15} />
+                <div className="min-w-0">
+                    <Text as="h2" variant="subheading" weight="semibold" tracking="tight">
+                        {heading}
+                    </Text>
+                    <Text as="p" variant="label" weight="medium" tone="secondary" className="mt-0.5">
+                        {summary}
+                    </Text>
+                </div>
+            </div>
+            {activity}
+        </section>
+    );
+};

--- a/packages/client/src/components/calendar/CalendarDayView.tsx
+++ b/packages/client/src/components/calendar/CalendarDayView.tsx
@@ -1,50 +1,187 @@
+import classNames from 'classnames';
+
+import * as Icon from '~/components/icon';
 import { Text } from '~/components/ui';
+import type { CalendarDayPreviewItem } from './types';
 
 interface CalendarDayViewProps {
     day: number;
+    dateLabel: string;
     cellClassName: string;
     dayNumberClassName: string;
     isCurrentMonth: boolean;
-    items: React.ReactNode[];
+    isToday: boolean;
+    isSelected: boolean;
+    noteCount: number;
+    reminderCount: number;
+    previewItems: CalendarDayPreviewItem[];
     overflowCount: number;
-    onOpenOverflow: () => void;
+    onSelect: () => void;
 }
+
+const NOTE_PREVIEW_TONE = 'bg-surface shadow-[inset_0_0_0_1px_var(--border-subtle)]';
+const REMINDER_PREVIEW_TONE = 'bg-emphasis';
+
+const itemLabel = (count: number, singular: string) => `${count} ${count === 1 ? singular : `${singular}s`}`;
 
 export const CalendarDayView = ({
     day,
+    dateLabel,
     cellClassName,
     dayNumberClassName,
     isCurrentMonth,
-    items,
+    isToday,
+    isSelected,
+    noteCount,
+    reminderCount,
+    previewItems,
     overflowCount,
-    onOpenOverflow,
+    onSelect,
 }: CalendarDayViewProps) => {
-    return (
-        <div className={`min-h-[196px] rounded-[16px] border p-2.5 ${cellClassName}`.trim()}>
-            <div className="mb-2.5 flex justify-end">
-                <Text
-                    as="span"
-                    variant="label"
-                    className={`flex h-7 w-7 items-center justify-center rounded-[10px] ${dayNumberClassName}`.trim()}
-                >
-                    {day}
-                </Text>
-            </div>
+    const totalCount = noteCount + reminderCount;
+    const accessibleLabel = `${dateLabel}, ${itemLabel(noteCount, 'note')}, ${itemLabel(reminderCount, 'reminder')}`;
 
-            {isCurrentMonth && items.length > 0 ? (
-                <div className="flex flex-col gap-1.5">
-                    {items}
-                    {overflowCount > 0 ? (
-                        <button
-                            type="button"
-                            onClick={onOpenOverflow}
-                            className="focus-ring-soft w-full rounded-[10px] border border-dashed border-border-subtle/70 bg-subtle/70 py-1 text-center text-micro font-semibold text-fg-tertiary outline-none transition-colors hover:border-border-secondary/70 hover:bg-hover-subtle hover:text-fg-secondary"
-                        >
-                            +{overflowCount} more
-                        </button>
-                    ) : null}
+    return (
+        <button
+            type="button"
+            disabled={!isCurrentMonth}
+            aria-label={accessibleLabel}
+            aria-pressed={isCurrentMonth ? isSelected : undefined}
+            aria-current={isCurrentMonth && isToday ? 'date' : undefined}
+            onClick={onSelect}
+            className={classNames(
+                'focus-ring-soft relative flex min-h-16 min-w-0 flex-col p-1.5 text-left outline-none transition-colors focus-visible:z-10 sm:min-h-24 sm:p-2 lg:min-h-36 lg:p-2.5',
+                cellClassName,
+            )}
+        >
+            <Text
+                as="span"
+                variant="label"
+                className={classNames(
+                    'flex h-6 min-w-6 items-center justify-center self-end whitespace-nowrap rounded-[9px] px-1.5 sm:h-7 sm:min-w-7 lg:!text-sm',
+                    dayNumberClassName,
+                )}
+            >
+                {day}
+            </Text>
+
+            {isCurrentMonth && totalCount > 0 ? (
+                <div aria-hidden="true" className="mt-1.5 w-full sm:mt-2">
+                    <div className="flex flex-col gap-0.5 text-fg-tertiary sm:hidden">
+                        {noteCount > 0 ? (
+                            <span className="flex items-center justify-between leading-none">
+                                <Icon.FileNote className="shrink-0" size={10} />
+                                <span className="whitespace-nowrap text-[10px] font-semibold text-fg-secondary tabular-nums">
+                                    {noteCount}
+                                </span>
+                            </span>
+                        ) : null}
+                        {reminderCount > 0 ? (
+                            <span className="flex items-center justify-between leading-none">
+                                <Icon.Bell className="shrink-0" size={10} />
+                                <span className="whitespace-nowrap text-[10px] font-semibold text-fg-secondary tabular-nums">
+                                    {reminderCount}
+                                </span>
+                            </span>
+                        ) : null}
+                    </div>
+
+                    <div className="hidden flex-col gap-1 sm:flex 2xl:hidden">
+                        {noteCount > 0 ? (
+                            <span
+                                className={classNames(
+                                    'flex min-h-7 min-w-0 items-center justify-between gap-1 rounded-[8px] px-2 py-1.5 text-fg-tertiary',
+                                    NOTE_PREVIEW_TONE,
+                                )}
+                            >
+                                <Text
+                                    as="span"
+                                    variant="micro"
+                                    weight="medium"
+                                    tone="secondary"
+                                    className="truncate !text-[11px] !leading-4"
+                                >
+                                    Notes
+                                </Text>
+                                <Text
+                                    as="span"
+                                    variant="micro"
+                                    weight="semibold"
+                                    tone="secondary"
+                                    className="!text-[11px] !leading-4 tabular-nums"
+                                >
+                                    {noteCount}
+                                </Text>
+                            </span>
+                        ) : null}
+                        {reminderCount > 0 ? (
+                            <span
+                                className={classNames(
+                                    'flex min-h-7 min-w-0 items-center justify-between gap-1 rounded-[8px] px-2 py-1.5 text-fg-tertiary',
+                                    REMINDER_PREVIEW_TONE,
+                                )}
+                            >
+                                <Text
+                                    as="span"
+                                    variant="micro"
+                                    weight="medium"
+                                    tone="secondary"
+                                    className="truncate !text-[11px] !leading-4"
+                                >
+                                    Reminders
+                                </Text>
+                                <Text
+                                    as="span"
+                                    variant="micro"
+                                    weight="semibold"
+                                    tone="secondary"
+                                    className="!text-[11px] !leading-4 tabular-nums"
+                                >
+                                    {reminderCount}
+                                </Text>
+                            </span>
+                        ) : null}
+                    </div>
+
+                    <div className="hidden flex-col gap-1 2xl:flex">
+                        {previewItems.map((item) => (
+                            <span
+                                key={item.key}
+                                className={classNames(
+                                    'flex min-h-8 min-w-0 items-center gap-1.5 rounded-[8px] px-2 py-1.5',
+                                    item.type === 'reminder' ? REMINDER_PREVIEW_TONE : NOTE_PREVIEW_TONE,
+                                )}
+                            >
+                                {item.type === 'reminder' ? (
+                                    <Icon.Bell className="shrink-0 text-fg-tertiary" size={12} />
+                                ) : (
+                                    <Icon.FileNote className="shrink-0 text-fg-tertiary" size={12} />
+                                )}
+                                <Text
+                                    as="span"
+                                    variant="label"
+                                    weight="medium"
+                                    tone="secondary"
+                                    className={classNames('truncate', item.isCompleted && 'line-through')}
+                                >
+                                    {item.title}
+                                </Text>
+                            </span>
+                        ))}
+                        {overflowCount > 0 ? (
+                            <Text
+                                as="span"
+                                variant="micro"
+                                weight="medium"
+                                tone="secondary"
+                                className="flex min-h-4 items-center px-2 !text-[11px] !leading-4"
+                            >
+                                +{overflowCount} more
+                            </Text>
+                        ) : null}
+                    </div>
                 </div>
             ) : null}
-        </div>
+        </button>
     );
 };

--- a/packages/client/src/components/calendar/CalendarEntryCard.tsx
+++ b/packages/client/src/components/calendar/CalendarEntryCard.tsx
@@ -25,7 +25,7 @@ export const CalendarEntryCard = ({
         <Link to={NOTE_ROUTE} params={params} className="focus-ring-soft group block rounded-[8px] outline-none">
             <div
                 className={classNames(
-                    'flex items-start gap-1.5 rounded-[8px] px-1.5 py-1 transition-colors group-hover:bg-hover-subtle',
+                    'flex items-start gap-1.5 rounded-[8px] px-1.5 py-1 transition-colors group-hover:bg-muted',
                     toneClassName,
                 )}
             >
@@ -48,7 +48,13 @@ export const CalendarEntryCard = ({
                         {title}
                     </Text>
                     {meta ? (
-                        <Text as="div" variant="micro" weight="medium" tone="tertiary" className="mt-0.5">
+                        <Text
+                            as="div"
+                            variant="micro"
+                            weight="medium"
+                            tone="secondary"
+                            className="mt-0.5 !text-[11px] !leading-4"
+                        >
                             {meta}
                         </Text>
                     ) : null}

--- a/packages/client/src/components/calendar/CalendarHeader.tsx
+++ b/packages/client/src/components/calendar/CalendarHeader.tsx
@@ -54,16 +54,16 @@ export const CalendarHeader = ({ month, year, type, onPrevMonth, onNextMonth, on
                         {year}
                     </Text>
                 </div>
-                <Text as="p" variant="meta" weight="medium" tone="secondary">
+                <Text as="p" variant="meta" weight="medium" tone="secondary" className="hidden sm:block">
                     {headerDescription}
                 </Text>
             </div>
 
             <div className="flex lg:justify-end">
-                <div className="surface-base inline-flex flex-wrap items-center gap-3 rounded-[16px] px-3.5 py-2.5">
+                <div className="flex w-full flex-col gap-2 sm:inline-flex sm:w-auto sm:flex-row sm:items-center sm:gap-3">
                     <div className="flex items-center gap-2">
                         <Icon.Calendar className="h-4 w-4 shrink-0 text-fg-tertiary" />
-                        <Text id="calendar-note-date-label" as="span" variant="label" weight="medium" tone="tertiary">
+                        <Text id="calendar-note-date-label" as="span" variant="label" weight="medium" tone="secondary">
                             Note date
                         </Text>
                         <Select
@@ -78,18 +78,20 @@ export const CalendarHeader = ({ month, year, type, onPrevMonth, onNextMonth, on
                         </Select>
                     </div>
 
-                    <div className="h-5 w-px bg-divider" />
+                    <div className="hidden h-5 w-px bg-divider sm:block" />
 
-                    <div className="flex items-center gap-1.5">
+                    <div className="flex items-center justify-between sm:justify-start sm:gap-1.5">
                         <Button variant="ghost" size="sm" onClick={onToday}>
                             Today
                         </Button>
-                        <Button variant="ghost" size="icon-sm" aria-label="Previous month" onClick={onPrevMonth}>
-                            <Icon.ChevronLeft width={18} height={18} />
-                        </Button>
-                        <Button variant="ghost" size="icon-sm" aria-label="Next month" onClick={onNextMonth}>
-                            <Icon.ChevronRight width={18} height={18} />
-                        </Button>
+                        <div className="flex items-center gap-1" role="group" aria-label="Month navigation">
+                            <Button variant="ghost" size="icon-sm" aria-label="Previous month" onClick={onPrevMonth}>
+                                <Icon.ChevronLeft width={18} height={18} />
+                            </Button>
+                            <Button variant="ghost" size="icon-sm" aria-label="Next month" onClick={onNextMonth}>
+                                <Icon.ChevronRight width={18} height={18} />
+                            </Button>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/packages/client/src/components/calendar/CalendarMonth.spec.tsx
+++ b/packages/client/src/components/calendar/CalendarMonth.spec.tsx
@@ -1,0 +1,84 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+
+import { CalendarMonth } from './CalendarMonth';
+import type { CalendarDayData } from './types';
+
+const days = [
+    {
+        key: '2026-4-1',
+        year: 2026,
+        month: 4,
+        day: 1,
+        isCurrentMonth: true,
+        isSunday: false,
+        isToday: false,
+        isPast: false,
+        notes: [],
+        reminders: [],
+    },
+    {
+        key: '2026-4-2',
+        year: 2026,
+        month: 4,
+        day: 2,
+        isCurrentMonth: true,
+        isSunday: false,
+        isToday: false,
+        isPast: false,
+        notes: [],
+        reminders: [],
+    },
+] as CalendarDayData[];
+
+const CalendarMonthHarness = () => {
+    const [selectedDayKey, setSelectedDayKey] = useState<string | undefined>('2026-4-1');
+
+    return (
+        <CalendarMonth
+            days={days}
+            type="create"
+            isLoading={false}
+            selectedDayKey={selectedDayKey}
+            onSelectedDayChange={setSelectedDayKey}
+        />
+    );
+};
+
+describe('<CalendarMonth />', () => {
+    it('renders the month dates immediately while activity is loading', () => {
+        render(
+            <CalendarMonth
+                days={days}
+                type="create"
+                isLoading
+                selectedDayKey="2026-4-1"
+                onSelectedDayChange={vi.fn()}
+            />,
+        );
+
+        expect(
+            screen.getByRole('button', {
+                name: 'Wednesday, April 1, 2026, 0 notes, 0 reminders',
+            }),
+        ).toBeInTheDocument();
+        expect(screen.getByRole('region', { name: 'Month overview' })).toHaveAttribute('aria-busy', 'true');
+    });
+
+    it('updates the focused detail when a date is selected', async () => {
+        const user = userEvent.setup();
+
+        render(<CalendarMonthHarness />);
+
+        await user.click(
+            screen.getByRole('button', {
+                name: 'Thursday, April 2, 2026, 0 notes, 0 reminders',
+            }),
+        );
+
+        const dialog = screen.getByRole('dialog');
+
+        expect(within(dialog).getByRole('heading', { name: 'Thursday, April 2' })).toBeInTheDocument();
+    });
+});

--- a/packages/client/src/components/calendar/CalendarMonth.tsx
+++ b/packages/client/src/components/calendar/CalendarMonth.tsx
@@ -1,0 +1,115 @@
+import { useEffect, useMemo, useState } from 'react';
+
+import { Modal, Text } from '~/components/ui';
+import { CalendarDay } from './CalendarDay';
+import { CalendarDayDetail, getCalendarDayHeading } from './CalendarDayDetail';
+import type { CalendarDayData, CalendarDisplayType } from './types';
+
+const DAYS_OF_WEEK = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'];
+const DESKTOP_CALENDAR_QUERY = '(min-width: 1280px)';
+
+interface CalendarMonthProps {
+    days: CalendarDayData[];
+    type: CalendarDisplayType;
+    isLoading: boolean;
+    selectedDayKey?: string;
+    onSelectedDayChange: (dayKey: string) => void;
+}
+
+export const CalendarMonth = ({ days, type, isLoading, selectedDayKey, onSelectedDayChange }: CalendarMonthProps) => {
+    const [isMobileDetailOpen, setIsMobileDetailOpen] = useState(false);
+    const selectedDay = useMemo(() => days.find((day) => day.key === selectedDayKey), [days, selectedDayKey]);
+
+    useEffect(() => {
+        const mediaQuery = window.matchMedia(DESKTOP_CALENDAR_QUERY);
+        const handleBreakpointChange = (event: MediaQueryListEvent) => {
+            if (event.matches) setIsMobileDetailOpen(false);
+        };
+
+        mediaQuery.addEventListener('change', handleBreakpointChange);
+        return () => mediaQuery.removeEventListener('change', handleBreakpointChange);
+    }, []);
+
+    const handleDaySelect = (dayKey: string) => {
+        onSelectedDayChange(dayKey);
+        if (!window.matchMedia(DESKTOP_CALENDAR_QUERY).matches) {
+            setIsMobileDetailOpen(true);
+        }
+    };
+
+    const modalTitle = selectedDay ? getCalendarDayHeading(selectedDay) : 'Day details';
+
+    return (
+        <>
+            <div className="min-w-0 xl:grid xl:grid-cols-[minmax(0,1fr)_20rem] 2xl:grid-cols-[minmax(0,1fr)_22rem]">
+                <section aria-label="Month overview" aria-busy={isLoading} className="min-w-0 xl:pr-5">
+                    <div className="overflow-x-auto overscroll-x-contain [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+                        <div className="min-w-[19rem]">
+                            <div className="mb-2 grid grid-cols-7 gap-px">
+                                {DAYS_OF_WEEK.map((day, index) => (
+                                    <Text
+                                        key={day}
+                                        as="div"
+                                        variant="label"
+                                        weight="semibold"
+                                        tracking="wider"
+                                        transform="uppercase"
+                                        className={`py-1.5 text-center ${index === 0 ? 'text-fg-weekend' : 'text-fg-secondary'}`}
+                                    >
+                                        <span aria-hidden="true" className="sm:hidden">
+                                            {day.slice(0, 1)}
+                                        </span>
+                                        <span className="hidden sm:inline">{day}</span>
+                                    </Text>
+                                ))}
+                            </div>
+
+                            <div className="grid grid-cols-7 gap-px overflow-hidden rounded-[12px] border border-border-subtle/80 bg-border-subtle/70">
+                                {days.map((day) => (
+                                    <CalendarDay
+                                        key={day.key}
+                                        year={day.year}
+                                        month={day.month}
+                                        day={day.day}
+                                        isCurrentMonth={day.isCurrentMonth}
+                                        isSunday={day.isSunday}
+                                        isToday={day.isToday}
+                                        isSelected={day.key === selectedDayKey}
+                                        isPast={day.isPast}
+                                        notes={day.notes}
+                                        reminders={day.reminders}
+                                        onSelect={() => handleDaySelect(day.key)}
+                                    />
+                                ))}
+                            </div>
+                        </div>
+                    </div>
+                </section>
+
+                <aside
+                    className="relative hidden min-h-0 border-l border-border-subtle xl:block"
+                    aria-label="Selected day"
+                >
+                    <div className="absolute inset-y-0 right-0 left-5">
+                        <CalendarDayDetail day={selectedDay} type={type} isLoading={isLoading} />
+                    </div>
+                </aside>
+            </div>
+
+            <Modal
+                isOpen={isMobileDetailOpen && Boolean(selectedDay)}
+                onClose={() => setIsMobileDetailOpen(false)}
+                variant="inspect"
+                className="xl:hidden"
+            >
+                <Modal.Header title={modalTitle} onClose={() => setIsMobileDetailOpen(false)} />
+                <Modal.Body>
+                    <Modal.Description className="sr-only">
+                        View notes and reminders for {modalTitle}.
+                    </Modal.Description>
+                    <CalendarDayDetail day={selectedDay} type={type} isLoading={isLoading} presentation="modal" />
+                </Modal.Body>
+            </Modal>
+        </>
+    );
+};

--- a/packages/client/src/components/calendar/index.ts
+++ b/packages/client/src/components/calendar/index.ts
@@ -1,8 +1,10 @@
 export { CalendarDay } from './CalendarDay';
+export { CalendarDayDetail } from './CalendarDayDetail';
 export { CalendarEntryCard } from './CalendarEntryCard';
 export { CalendarHeader } from './CalendarHeader';
+export { CalendarMonth } from './CalendarMonth';
 export { NoteCard } from './NoteCard';
 export { PriorityLegend } from './PriorityLegend';
 export { ReminderCard } from './ReminderCard';
-export type { CalendarDisplayType } from './types';
+export type { CalendarDayData, CalendarDisplayType } from './types';
 export { useCalendarData } from './useCalendarData';

--- a/packages/client/src/components/calendar/types.ts
+++ b/packages/client/src/components/calendar/types.ts
@@ -4,3 +4,23 @@ import type { Reminder } from '~/models/reminder.model';
 export type CalendarDisplayType = 'create' | 'update';
 
 export type CalendarItem = { type: 'note'; item: Note } | { type: 'reminder'; item: Reminder };
+
+export interface CalendarDayPreviewItem {
+    key: string;
+    type: CalendarItem['type'];
+    title: string;
+    isCompleted?: boolean;
+}
+
+export interface CalendarDayData {
+    key: string;
+    year: number;
+    month: number;
+    day: number;
+    isCurrentMonth: boolean;
+    isSunday: boolean;
+    isToday: boolean;
+    isPast: boolean;
+    notes: Note[];
+    reminders: Reminder[];
+}

--- a/packages/client/src/pages/Calendar.tsx
+++ b/packages/client/src/pages/Calendar.tsx
@@ -1,68 +1,25 @@
 import { getRouteApi } from '@tanstack/react-router';
 import dayjs from 'dayjs';
-import { useCallback, useMemo, useRef } from 'react';
-import type { CalendarDisplayType } from '~/components/calendar';
-import { CalendarDay, CalendarHeader, useCalendarData } from '~/components/calendar';
+import { useMemo, useState } from 'react';
+import type { CalendarDayData, CalendarDisplayType } from '~/components/calendar';
+import { CalendarHeader, CalendarMonth, useCalendarData } from '~/components/calendar';
 import { Callout, PageLayout } from '~/components/shared';
-import { Skeleton, Text } from '~/components/ui';
 import type { Note } from '~/models/note.model';
 import type { Reminder } from '~/models/reminder.model';
 import { CALENDAR_ROUTE } from '~/modules/url';
 
-const DAYS_OF_WEEK = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'];
-
 const EMPTY_NOTES: Note[] = [];
 const EMPTY_REMINDERS: Reminder[] = [];
-
-interface CalendarDayView {
-    key: string;
-    year: number;
-    month: number;
-    day: number;
-    isCurrentMonth: boolean;
-    isSunday: boolean;
-    isToday: boolean;
-    isPast: boolean;
-    notes: Note[];
-    reminders: Reminder[];
-}
 
 const Route = getRouteApi(CALENDAR_ROUTE);
 
 export default function Calendar() {
     const navigate = Route.useNavigate();
     const { year, month, type } = Route.useSearch();
-
-    const gridScrollRef = useRef<HTMLDivElement>(null);
-    const isDragging = useRef(false);
-    const dragStartX = useRef(0);
-    const dragScrollLeft = useRef(0);
-
-    const handleMouseDown = useCallback((e: React.MouseEvent) => {
-        isDragging.current = true;
-        dragStartX.current = e.pageX - (gridScrollRef.current?.offsetLeft ?? 0);
-        dragScrollLeft.current = gridScrollRef.current?.scrollLeft ?? 0;
-        if (gridScrollRef.current) {
-            gridScrollRef.current.style.cursor = 'grabbing';
-            gridScrollRef.current.style.userSelect = 'none';
-        }
-    }, []);
-
-    const handleMouseMove = useCallback((e: React.MouseEvent) => {
-        if (!isDragging.current || !gridScrollRef.current) return;
-        e.preventDefault();
-        const x = e.pageX - gridScrollRef.current.offsetLeft;
-        const walk = (x - dragStartX.current) * 1.2;
-        gridScrollRef.current.scrollLeft = dragScrollLeft.current - walk;
-    }, []);
-
-    const handleMouseUp = useCallback(() => {
-        isDragging.current = false;
-        if (gridScrollRef.current) {
-            gridScrollRef.current.style.cursor = 'grab';
-            gridScrollRef.current.style.userSelect = '';
-        }
-    }, []);
+    const currentMonthKey = `${year}-${month}`;
+    const [calendarSelection, setCalendarSelection] = useState<{ monthKey: string; dayKey?: string }>(() => ({
+        monthKey: currentMonthKey,
+    }));
 
     const { notes, reminders, isLoading, isError } = useCalendarData({
         year,
@@ -141,7 +98,7 @@ export default function Calendar() {
         }
 
         // Merge into stable view objects
-        return days.map((d, index): CalendarDayView => {
+        return days.map((d, index): CalendarDayData => {
             const key = `${d.year}-${d.month}-${d.day}`;
             const dayDate = dayjs(`${d.year}-${String(d.month).padStart(2, '0')}-${String(d.day).padStart(2, '0')}`);
             return {
@@ -158,6 +115,12 @@ export default function Calendar() {
             };
         });
     }, [year, month, notes, reminders, type]);
+
+    const defaultSelectedDayKey = calendarDayViews.find((day) => day.isCurrentMonth && day.isToday)?.key;
+    const selectedDayKey =
+        calendarSelection.monthKey === currentMonthKey
+            ? (calendarSelection.dayKey ?? defaultSelectedDayKey)
+            : defaultSelectedDayKey;
 
     const handlePrevMonth = () => {
         const newMonth = month === 1 ? 12 : month - 1;
@@ -184,11 +147,18 @@ export default function Calendar() {
     };
 
     const handleToday = () => {
+        const today = dayjs();
+        const todayMonth = today.month() + 1;
+        const todayYear = today.year();
+        setCalendarSelection({
+            monthKey: `${todayYear}-${todayMonth}`,
+            dayKey: `${todayYear}-${todayMonth}-${today.date()}`,
+        });
         navigate({
             search: (prev) => ({
                 ...prev,
-                month: dayjs().month() + 1,
-                year: dayjs().year(),
+                month: todayMonth,
+                year: todayYear,
             }),
         });
     };
@@ -203,14 +173,17 @@ export default function Calendar() {
         });
     };
 
+    const handleSelectedDayChange = (dayKey: string) => {
+        setCalendarSelection({ monthKey: currentMonthKey, dayKey });
+    };
+
     return (
         <PageLayout title="Calendar" variant="none">
             {isError ? (
                 <Callout>Failed to load calendar data. Please try again later.</Callout>
             ) : (
-                <div className="surface-base">
-                    {/* Header - not scrollable */}
-                    <div className="border-b border-border-subtle/80 px-4 py-4 sm:px-5">
+                <div className="-mr-4">
+                    <div className="border-b border-border-subtle/80 pb-4">
                         <CalendarHeader
                             month={month}
                             year={year}
@@ -222,58 +195,14 @@ export default function Calendar() {
                         />
                     </div>
 
-                    {/* Scrollable grid */}
-                    <div
-                        ref={gridScrollRef}
-                        className="cursor-grab overflow-x-auto px-4 pb-4 pt-3 sm:px-5"
-                        onMouseDown={handleMouseDown}
-                        onMouseMove={handleMouseMove}
-                        onMouseUp={handleMouseUp}
-                        onMouseLeave={handleMouseUp}
-                    >
-                        <div className="min-w-[1260px]">
-                            <div className="mb-2.5 grid grid-cols-7 gap-1.5">
-                                {DAYS_OF_WEEK.map((day, index) => (
-                                    <Text
-                                        key={day}
-                                        as="div"
-                                        variant="label"
-                                        weight="semibold"
-                                        tracking="wider"
-                                        transform="uppercase"
-                                        className={`py-2 text-center ${index === 0 ? 'text-fg-weekend' : 'text-fg-tertiary'}`}
-                                    >
-                                        {day}
-                                    </Text>
-                                ))}
-                            </div>
-
-                            {isLoading ? (
-                                <div className="grid grid-cols-7 gap-1.5">
-                                    {Array.from({ length: 35 }).map((_, i) => (
-                                        <Skeleton key={i} height={180} />
-                                    ))}
-                                </div>
-                            ) : (
-                                <div className="grid grid-cols-7 gap-1.5">
-                                    {calendarDayViews.map((view) => (
-                                        <CalendarDay
-                                            key={view.key}
-                                            year={view.year}
-                                            month={view.month}
-                                            day={view.day}
-                                            isCurrentMonth={view.isCurrentMonth}
-                                            isSunday={view.isSunday}
-                                            isToday={view.isToday}
-                                            isPast={view.isPast}
-                                            notes={view.notes}
-                                            reminders={view.reminders}
-                                            type={type}
-                                        />
-                                    ))}
-                                </div>
-                            )}
-                        </div>
+                    <div className="pt-4">
+                        <CalendarMonth
+                            days={calendarDayViews}
+                            type={type}
+                            isLoading={isLoading}
+                            selectedDayKey={selectedDayKey}
+                            onSelectedDayChange={handleSelectedDayChange}
+                        />
                     </div>
                 </div>
             )}


### PR DESCRIPTION
## :dart: Goal

- Make the calendar easier to scan and navigate across desktop, mobile, and fold-sized screens.
- Bring the calendar into the shared workspace visual system while preserving the intuitive monthly spatial layout.

## :hammer_and_wrench: Core Changes

- Reworked the month overview with responsive day sizing, top-aligned activity, and compact fold-only horizontal scrolling.
- Added a desktop selected-day rail and a mobile inspect modal with consistent internal scrolling.
- Aligned adjacent-month, selected-day, hover, note, and reminder states with shared surface tokens.
- Removed calendar skeletons, improved readable type sizing, and kept the date grid available while activity loads.
- Added focused tests for month loading, selection, overflow previews, completed reminders, and day details.

## :brain: Key Decisions

- Kept a full seven-column month instead of replacing it with a mobile list so spatial navigation remains predictable.
- Separated today, selection, and adjacent-month styling so each state communicates one meaning.
- Limited overview previews to two items per type while exposing the complete activity list in the selected-day detail.
- Classified this as a patch: it is a backward-compatible UX and correctness improvement with no API, data, CLI, or MCP contract changes. Version changes remain part of the release PR workflow.

## :test_tube: Verification Guide

### How to verify
1. Run `pnpm check:encoding`, `pnpm lint`, `pnpm test:ci`, and `pnpm type-check`.
2. Run `pnpm build` and confirm the client bundle budget passes.
3. Open Calendar at desktop, mobile, and sub-320 px widths; select populated and empty dates and navigate between months.

### Expected result

- All checks pass; client tests report 90 files and 392 tests, server tests report 421 tests, and CLI tests report 32 tests.
- The initial client bundle remains within the 300 KiB gzip budget.
- The seven-column month stays readable, fold-sized screens scroll only the grid, and selected-day details use the desktop rail or mobile modal without page-level overflow.

## :white_check_mark: Checklist

- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (not needed for this UI-only patch)