### PR TITLE
🛠 Unify development server port

### DIFF
--- a/docs/process/DEV_CONVENTION.md
+++ b/docs/process/DEV_CONVENTION.md
@@ -19,6 +19,8 @@ Updated: 2026-08-04
 Both browser test commands build the production app before starting Playwright.
 Install the local browser once with `pnpm exec playwright install chromium` after Playwright is installed or updated.
 
+Full dev mode exposes Express APIs, the Vite client, and HMR through the server port (`6683` by default). Client-only mode keeps the standalone Vite server and development proxy for isolated frontend work. Server-only mode runs Express with the existing built client fallback and does not start Vite.
+
 ## 3. Standard Quality Checks
 - `pnpm check:encoding`
 - `pnpm lint`

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "license": "MIT",
   "scripts": {
     "check:encoding": "node scripts/ci/check-encoding.mjs",
-    "dev": "pnpm --parallel --filter @ocean-brain/client --filter @ocean-brain/server dev",
+    "dev": "pnpm --filter @ocean-brain/server dev",
     "dev:client": "pnpm --filter @ocean-brain/client dev",
-    "dev:server": "pnpm --filter @ocean-brain/server dev",
+    "dev:server": "pnpm --filter @ocean-brain/server dev:server",
     "build": "pnpm --filter @ocean-brain/client build && pnpm --filter @ocean-brain/server build",
     "build:client": "pnpm --filter @ocean-brain/client build",
     "build:server": "pnpm --filter @ocean-brain/server build",

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -7,6 +7,7 @@ import { createClientRollupOptions, createRoutePreloadPlugin } from './build/cli
 import { createDevAuthGateMiddleware } from './src/dev-auth-gate';
 
 const backendOrigin = process.env.OCEAN_BRAIN_DEV_SERVER_URL || 'http://localhost:6683';
+const isEmbeddedMiddlewareMode = process.env.OCEAN_BRAIN_VITE_MIDDLEWARE_MODE === 'true';
 const isLocalOnlyDemoBuild = process.env.VITE_DEMO_MODE === 'local-only';
 const demoSidebarPromoSlotPath = isLocalOnlyDemoBuild
     ? './src/components/demo/DemoSidebarPromoSlot.tsx'
@@ -27,12 +28,16 @@ export default defineConfig({
         createRoutePreloadPlugin(),
         react(),
         tailwindcss(),
-        {
-            name: 'ocean-brain-dev-auth-gate',
-            configureServer(server) {
-                server.middlewares.use(createDevAuthGateMiddleware({ backendOrigin }));
-            },
-        },
+        ...(!isEmbeddedMiddlewareMode
+            ? [
+                  {
+                      name: 'ocean-brain-dev-auth-gate',
+                      configureServer(server) {
+                          server.middlewares.use(createDevAuthGateMiddleware({ backendOrigin }));
+                      },
+                  },
+              ]
+            : []),
     ],
     resolve: {
         alias: [
@@ -61,13 +66,17 @@ export default defineConfig({
     },
     server: {
         host: '0.0.0.0',
-        proxy: {
-            '/api': { target: backendOrigin },
-            '/login': { target: backendOrigin },
-            '/logout': { target: backendOrigin },
-            '/graphql': { target: backendOrigin },
-            '/assets/images': { target: backendOrigin },
-        },
+        ...(!isEmbeddedMiddlewareMode
+            ? {
+                  proxy: {
+                      '/api': { target: backendOrigin },
+                      '/login': { target: backendOrigin },
+                      '/logout': { target: backendOrigin },
+                      '/graphql': { target: backendOrigin },
+                      '/assets/images': { target: backendOrigin },
+                  },
+              }
+            : {}),
     },
     test: {
         globals: true,

--- a/packages/server/dev/main.ts
+++ b/packages/server/dev/main.ts
@@ -1,0 +1,48 @@
+import { createServer as createNodeHttpServer } from 'node:http';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import express, { type RequestHandler } from 'express';
+import { createServer as createViteServer, type ViteDevServer } from 'vite';
+
+import { createApp } from '../src/app.js';
+import { startServer } from '../src/server.js';
+
+const devDirectory = path.dirname(fileURLToPath(import.meta.url));
+const clientRoot = path.resolve(devDirectory, '../../client');
+
+process.env.OCEAN_BRAIN_VITE_MIDDLEWARE_MODE = 'true';
+
+let viteServer: ViteDevServer | undefined;
+
+try {
+    await startServer({
+        serverFactory: async (authConfig) => {
+            const application = express();
+            const httpServer = createNodeHttpServer(application);
+
+            viteServer = await createViteServer({
+                root: clientRoot,
+                configFile: path.join(clientRoot, 'vite.config.ts'),
+                appType: 'spa',
+                server: {
+                    middlewareMode: { server: httpServer },
+                    hmr: { server: httpServer },
+                },
+            });
+
+            createApp(authConfig, {
+                application,
+                clientContentMiddleware: viteServer.middlewares as unknown as RequestHandler,
+            });
+
+            return httpServer;
+        },
+    });
+} catch (error) {
+    await viteServer?.close();
+
+    const message = error instanceof Error ? error.message : 'Unknown development server error';
+    process.stderr.write(`[dev] Startup failed: ${message}\n`);
+    process.exit(1);
+}

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -5,7 +5,8 @@
     "type": "module",
     "main": "dist/main.js",
     "scripts": {
-        "dev": "prisma migrate deploy && prisma generate && node --watch --import tsx src/main.ts",
+        "dev": "prisma migrate deploy && prisma generate && tsx watch --clear-screen=false --exclude \"../client/node_modules/**\" dev/main.ts",
+        "dev:server": "prisma migrate deploy && prisma generate && node --watch --import tsx src/main.ts",
         "build": "prisma generate && tsup && tsc-alias",
         "start": "node dist/start.js",
         "lint": "biome check .",
@@ -40,6 +41,7 @@
         "tsc-alias": "^1.9.1",
         "tsup": "^8.5.1",
         "tsx": "^4.23.1",
-        "typescript": "^5.9.3"
+        "typescript": "^5.9.3",
+        "vite": "^7.3.5"
     }
 }

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -1,4 +1,4 @@
-import express from 'express';
+import express, { type Express, type RequestHandler } from 'express';
 import { createMcpAdminService, type McpAdminService } from './features/mcp-admin/service.js';
 import { purgeExpiredNoteSnapshots } from './features/note/services/snapshot.js';
 import { purgeExpiredTrashedNotes } from './features/note/services/trash.js';
@@ -8,13 +8,22 @@ import { createErrorHandler } from './modules/error-handler.js';
 import logger from './modules/logger.js';
 import { createApiRouter, createAuthPagesRouter, createClientRouter, createGraphqlRouter } from './routes/index.js';
 
-export const createApp = (authConfig: AuthConfig) => {
-    const mcpAdminService = createMcpAdminService();
-    return createAppWithMcpAuth(authConfig, mcpAdminService);
+export type CreateAppOptions = {
+    application?: Express;
+    clientContentMiddleware?: RequestHandler;
 };
 
-export const createAppWithMcpAuth = (authConfig: AuthConfig, mcpAdminService: McpAdminService) => {
-    const app = express();
+export const createApp = (authConfig: AuthConfig, options: CreateAppOptions = {}) => {
+    const mcpAdminService = createMcpAdminService();
+    return createAppWithMcpAuth(authConfig, mcpAdminService, options);
+};
+
+export const createAppWithMcpAuth = (
+    authConfig: AuthConfig,
+    mcpAdminService: McpAdminService,
+    options: CreateAppOptions = {},
+) => {
+    const app = options.application ?? express();
     app.locals.authConfig = authConfig;
 
     void Promise.all([purgeExpiredNoteSnapshots(), purgeExpiredTrashedNotes()]).catch((error) => {
@@ -29,7 +38,7 @@ export const createAppWithMcpAuth = (authConfig: AuthConfig, mcpAdminService: Mc
         .use('/api', createApiRouter(authConfig, mcpAdminService))
         .use(createAuthPagesRouter(authConfig))
         .use('/graphql', createGraphqlRouter(authConfig, mcpAdminService))
-        .use(createClientRouter(authConfig))
+        .use(createClientRouter(authConfig, options.clientContentMiddleware))
         .use(createErrorHandler());
 
     return app;

--- a/packages/server/src/main.ts
+++ b/packages/server/src/main.ts
@@ -1,42 +1,4 @@
-import { createApp } from './app.js';
-import { ensureNoteReferenceIndex } from './features/note/services/note-reference-index.js';
-import { getDefaultSemanticSearchManager } from './features/search/search-manager.js';
-import { logAuthConfig, resolveAuthConfig } from './modules/auth-mode.js';
-import { startDataMaintenanceScheduler } from './modules/data-maintenance.js';
-
-const PORT = Number(process.env.PORT || 6683);
-const HOST = process.env.HOST || '0.0.0.0';
-
-const startServer = async () => {
-    const authConfig = resolveAuthConfig(process.env);
-
-    logAuthConfig(authConfig);
-
-    const app = createApp(authConfig);
-    getDefaultSemanticSearchManager();
-
-    const rebuiltReferenceCount = await ensureNoteReferenceIndex();
-
-    if (rebuiltReferenceCount > 0) {
-        process.stdout.write(`[maintenance] Rebuilt ${rebuiltReferenceCount} note reference rows\n`);
-    }
-
-    app.listen(PORT, HOST, () => {
-        process.stdout.write(`http server listen on ${HOST}:${PORT} (auth: ${authConfig.mode})\n`);
-
-        startDataMaintenanceScheduler({
-            onResults: (results) => {
-                for (const result of results) {
-                    process.stdout.write(`[maintenance] Reconciled ${result.processedCount} rows for ${result.key}\n`);
-                }
-            },
-            onError: (error) => {
-                const message = error instanceof Error ? error.message : 'Unknown data maintenance error';
-                process.stderr.write(`[maintenance] Background run failed: ${message}\n`);
-            },
-        });
-    });
-};
+import { startServer } from './server.js';
 
 startServer().catch((error) => {
     const message = error instanceof Error ? error.message : 'Unknown auth configuration error';

--- a/packages/server/src/routes/client.ts
+++ b/packages/server/src/routes/client.ts
@@ -76,7 +76,26 @@ const createClientRouteCsrfTokenMiddleware = (authConfig: AuthConfig) => {
     };
 };
 
-export const createClientRouter = (authConfig: AuthConfig) =>
+const createProductionClientContentRouter = () =>
+    Router()
+        .use(express.static(paths.clientDist, { extensions: ['html'] }))
+        .get(/.*/, (req, res, next) => {
+            if (!isClientDocumentRequest(req)) {
+                next();
+                return;
+            }
+
+            res.sendFile('index.html', { root: paths.clientDist });
+        })
+        .use((_req, res) => {
+            res.setHeader('X-Content-Type-Options', 'nosniff');
+            res.status(404).end();
+        });
+
+export const createClientRouter = (
+    authConfig: AuthConfig,
+    clientContentMiddleware: RequestHandler = createProductionClientContentRouter(),
+) =>
     Router()
         .use(
             '/assets/images',
@@ -111,16 +130,4 @@ export const createClientRouter = (authConfig: AuthConfig) =>
             next();
         })
         .use(createClientRouteCsrfTokenMiddleware(authConfig))
-        .use(express.static(paths.clientDist, { extensions: ['html'] }))
-        .get(/.*/, (req, res, next) => {
-            if (!isClientDocumentRequest(req)) {
-                next();
-                return;
-            }
-
-            res.sendFile('index.html', { root: paths.clientDist });
-        })
-        .use((_req, res) => {
-            res.setHeader('X-Content-Type-Options', 'nosniff');
-            res.status(404).end();
-        });
+        .use(clientContentMiddleware);

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1,0 +1,51 @@
+import { createServer as createNodeHttpServer, type Server as HttpServer } from 'node:http';
+
+import { createApp } from './app.js';
+import { ensureNoteReferenceIndex } from './features/note/services/note-reference-index.js';
+import { getDefaultSemanticSearchManager } from './features/search/search-manager.js';
+import { type AuthConfig, logAuthConfig, resolveAuthConfig } from './modules/auth-mode.js';
+import { startDataMaintenanceScheduler } from './modules/data-maintenance.js';
+
+type ServerFactory = (authConfig: AuthConfig) => HttpServer | Promise<HttpServer>;
+
+export type StartServerOptions = {
+    serverFactory?: ServerFactory;
+};
+
+export const startServer = async (options: StartServerOptions = {}) => {
+    const port = Number(process.env.PORT || 6683);
+    const host = process.env.HOST || '0.0.0.0';
+    const authConfig = resolveAuthConfig(process.env);
+
+    logAuthConfig(authConfig);
+
+    const httpServer = options.serverFactory
+        ? await options.serverFactory(authConfig)
+        : createNodeHttpServer(createApp(authConfig));
+
+    getDefaultSemanticSearchManager();
+
+    const rebuiltReferenceCount = await ensureNoteReferenceIndex();
+
+    if (rebuiltReferenceCount > 0) {
+        process.stdout.write(`[maintenance] Rebuilt ${rebuiltReferenceCount} note reference rows\n`);
+    }
+
+    httpServer.listen(port, host, () => {
+        process.stdout.write(`http server listen on ${host}:${port} (auth: ${authConfig.mode})\n`);
+
+        startDataMaintenanceScheduler({
+            onResults: (results) => {
+                for (const result of results) {
+                    process.stdout.write(`[maintenance] Reconciled ${result.processedCount} rows for ${result.key}\n`);
+                }
+            },
+            onError: (error) => {
+                const message = error instanceof Error ? error.message : 'Unknown data maintenance error';
+                process.stderr.write(`[maintenance] Background run failed: ${message}\n`);
+            },
+        });
+    });
+
+    return httpServer;
+};

--- a/packages/server/test/client-route.test.ts
+++ b/packages/server/test/client-route.test.ts
@@ -81,3 +81,26 @@ test('does not serve the SPA document for missing assets or non-document request
     assert.equal(nonDocumentRoute.status, 404);
     assert.equal(await nonDocumentRoute.text(), '');
 });
+
+test('serves client routes through an injected content middleware', async (t: TestContext) => {
+    const server = express()
+        .use(
+            createClientRouter({ mode: 'open' }, (_req, res) => {
+                res.status(200).send('Development client');
+            }),
+        )
+        .listen(0);
+
+    await new Promise<void>((resolve, reject) => {
+        server.once('listening', resolve);
+        server.once('error', reject);
+    });
+
+    t.after(() => server.close());
+
+    const { port } = server.address() as AddressInfo;
+    const response = await fetch(`http://127.0.0.1:${port}/notes`);
+
+    assert.equal(response.status, 200);
+    assert.equal(await response.text(), 'Development client');
+});

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -17,7 +17,7 @@
             "~/*": ["./*"]
         }
     },
-    "include": ["src/**/*"],
+    "include": ["src/**/*", "dev/**/*"],
     "tsx": {
         "tsconfig": "./tsconfig.json"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -354,6 +354,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      vite:
+        specifier: ^7.3.5
+        version: 7.3.5(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.31.1)(sass@1.101.7)(tsx@4.23.1)
 
 packages:
 


### PR DESCRIPTION
## :dart: Goal

Expose the Express API, Vite client, and HMR through one port during full-stack development without changing production or CLI behavior.

## :hammer_and_wrench: Core Changes

- Add a development-only launcher that mounts Vite middleware on the Express HTTP server and shares that server with HMR.
- Keep `pnpm dev:client` as the standalone Vite/proxy workflow and `pnpm dev:server` as the existing server-only workflow.
- Allow the client content middleware and HTTP server factory to be injected while preserving the production defaults.
- Document the three development modes and cover injected client routing with a server test.

## :brain: Key Decisions

- Vite remains a server `devDependency` and is imported only from `packages/server/dev`, outside the production `src` build boundary.
- Embedded mode disables the standalone Vite auth gate and proxy because Express continues to own auth, sessions, CSRF, APIs, and image routes.
- The cross-platform `tsx watch` runner excludes Vite temporary config files to prevent restart loops while Vite independently watches client files for HMR.
- Production builds and CLI packaging continue to copy only compiled server/client artifacts; neither contains Vite or the development launcher.

## :test_tube: Verification Guide

- `pnpm check:encoding`
- `pnpm lint`
- `pnpm test:ci` — client 387, server 422, CLI 32 tests passed
- `pnpm type-check`
- `pnpm build`
- `pnpm prepublish` and packaged CLI smoke test for the document and auth session API
- Open and password development modes validated on a single Express port, including login/CSRF flow and a live `vite-hmr` WebSocket
- Production initial bundle remains 246.71 KiB gzip, identical to `main`
- CLI tarball comparison: 4,832,165 bytes on `main` and 4,832,359 bytes here (+194 bytes, about 0.004%); Vite is absent from the package

## :white_check_mark: Checklist

- [x] Production and CLI runtime paths remain Vite-free
- [x] Standalone client/server development commands remain available
- [x] Automated checks and real runtime smoke tests pass
- [x] Development documentation is updated
- [x] Exactly one release-impact label is applied: `release: no-impact`