### PR TITLE
🧪 Align CLI smoke request with browser navigation

### DIFF
--- a/scripts/ci/smoke-cli-npx.mjs
+++ b/scripts/ci/smoke-cli-npx.mjs
@@ -180,6 +180,7 @@ async function assertGraphql() {
 
 async function assertClientShellLoads(pathname) {
     const response = await fetch(`${rootUrl}${pathname}`, {
+        headers: { Accept: 'text/html' },
         redirect: 'manual',
         signal: AbortSignal.timeout(5000)
     });


### PR DESCRIPTION
## :dart: Goal
Keep the packaged CLI smoke test aligned with the hardened SPA fallback behavior.

## :hammer_and_wrench: Core Changes
- Send an HTML Accept header when probing the root and direct client routes.
- Leave production routing behavior unchanged.

## :brain: Key Decisions
- Model a real browser document navigation in the smoke test instead of weakening the production fallback.
- Mark this as release no-impact because only CI verification changes.

## :test_tube: Verification Guide
- node --check scripts/ci/smoke-cli-npx.mjs
- pnpm check:encoding
- Packaged CLI smoke: insecure open mode, missing-auth rejection, and password mode all passed.

## :white_check_mark: Checklist
- [x] Verified the direct /12 client route returns the SPA shell.
- [x] Verified packaged CLI startup and auth scenarios.
- [x] Confirmed no production source or dependency changes.