### PR TITLE
🐛 Harden note export boundaries

### DIFF
--- a/packages/client/src/modules/blocknote-markdown.spec.ts
+++ b/packages/client/src/modules/blocknote-markdown.spec.ts
@@ -43,6 +43,30 @@ describe('blocknote markdown helpers', () => {
         expect(prepared.blocks[0].content).toEqual([{ type: 'text', text: '[[Title Only Note]]', styles: {} }]);
     });
 
+    it('preserves literal text that matches an internal tag placeholder', () => {
+        const prepared = prepareBlocksForMarkdown([
+            {
+                type: 'paragraph',
+                content: [
+                    { type: 'text', text: 'Literal OCEAN_BRAIN_TAG_0_TOKEN ', styles: {} },
+                    { type: 'tag', props: { tag: '@project' } },
+                ],
+                children: [],
+            },
+        ]);
+
+        expect(prepared.blocks[0].content).toEqual([
+            { type: 'text', text: 'Literal OCEAN_BRAIN_TAG_0_TOKEN ', styles: {} },
+            { type: 'text', text: 'OCEAN_BRAIN_TAG_1_TOKEN', styles: {} },
+        ]);
+        expect(
+            restoreTagPlaceholdersInMarkdown(
+                'Literal OCEAN_BRAIN_TAG_0_TOKEN OCEAN_BRAIN_TAG_1_TOKEN',
+                prepared.placeholderToTag,
+            ),
+        ).toBe('Literal OCEAN_BRAIN_TAG_0_TOKEN [@project]');
+    });
+
     it('strips unsupported table of contents blocks', () => {
         const prepared = prepareBlocksForMarkdown([
             { type: 'tableOfContents', content: [], children: [] },

--- a/packages/client/src/modules/blocknote-markdown.ts
+++ b/packages/client/src/modules/blocknote-markdown.ts
@@ -35,6 +35,23 @@ const TAG_PLACEHOLDER_SUFFIX = '_TOKEN';
 
 const createTagPlaceholder = (index: number) => `${TAG_PLACEHOLDER_PREFIX}${index}${TAG_PLACEHOLDER_SUFFIX}`;
 
+const createTagPlaceholderFactory = (blocks: MarkdownBlock[]) => {
+    const serializedBlocks = JSON.stringify(blocks);
+    let nextPlaceholderIndex = 0;
+
+    return () => {
+        let placeholder = createTagPlaceholder(nextPlaceholderIndex);
+
+        while (serializedBlocks.includes(placeholder)) {
+            nextPlaceholderIndex += 1;
+            placeholder = createTagPlaceholder(nextPlaceholderIndex);
+        }
+
+        nextPlaceholderIndex += 1;
+        return placeholder;
+    };
+};
+
 const isTableContent = (content: MarkdownBlock['content']): content is MarkdownTableContent => {
     return !Array.isArray(content) && content?.type === 'tableContent';
 };
@@ -78,7 +95,7 @@ const mapBlocks = (
 
 export function prepareBlocksForMarkdown(blocks: MarkdownBlock[]) {
     const placeholderToTag = new Map<string, string>();
-    let nextPlaceholderIndex = 0;
+    const createPlaceholder = createTagPlaceholderFactory(blocks);
 
     const markdownBlocks = mapBlocks(blocks, (content) =>
         mapBlockContent(content, (inline) => {
@@ -96,8 +113,7 @@ export function prepareBlocksForMarkdown(blocks: MarkdownBlock[]) {
 
             if (inline.type === 'tag') {
                 const tag = (inline.props?.tag as string) || '';
-                const placeholder = createTagPlaceholder(nextPlaceholderIndex);
-                nextPlaceholderIndex += 1;
+                const placeholder = createPlaceholder();
                 placeholderToTag.set(placeholder, tag);
 
                 return {

--- a/packages/client/src/modules/image-upload-policy.spec.ts
+++ b/packages/client/src/modules/image-upload-policy.spec.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { isSupportedImageUploadType, SUPPORTED_IMAGE_UPLOAD_TYPES } from './image-upload-policy';
+import {
+    getSupportedImageFileExtension,
+    isSupportedImageUploadType,
+    SUPPORTED_IMAGE_UPLOAD_TYPES,
+} from './image-upload-policy';
 
 describe('image upload policy', () => {
     it('allows the supported raster image types', () => {
@@ -13,5 +17,21 @@ describe('image upload policy', () => {
         expect(isSupportedImageUploadType('image/svg+xml')).toBe(false);
         expect(isSupportedImageUploadType('image/heic')).toBe(false);
         expect(isSupportedImageUploadType('')).toBe(false);
+    });
+
+    it('provides canonical file extensions for supported image types', () => {
+        expect(
+            Object.fromEntries(
+                SUPPORTED_IMAGE_UPLOAD_TYPES.map((type) => [type, getSupportedImageFileExtension(type)]),
+            ),
+        ).toEqual({
+            'image/png': 'png',
+            'image/jpeg': 'jpg',
+            'image/gif': 'gif',
+            'image/webp': 'webp',
+            'image/bmp': 'bmp',
+            'image/avif': 'avif',
+        });
+        expect(getSupportedImageFileExtension('image/svg+xml')).toBeUndefined();
     });
 });

--- a/packages/client/src/modules/image-upload-policy.ts
+++ b/packages/client/src/modules/image-upload-policy.ts
@@ -8,8 +8,18 @@ export const SUPPORTED_IMAGE_UPLOAD_TYPES = [
 ] as const;
 
 const SUPPORTED_IMAGE_UPLOAD_TYPE_SET = new Set<string>(SUPPORTED_IMAGE_UPLOAD_TYPES);
+const IMAGE_FILE_EXTENSION_BY_TYPE = new Map<string, string>([
+    ['image/png', 'png'],
+    ['image/jpeg', 'jpg'],
+    ['image/gif', 'gif'],
+    ['image/webp', 'webp'],
+    ['image/bmp', 'bmp'],
+    ['image/avif', 'avif'],
+]);
 
 export const UNSUPPORTED_IMAGE_UPLOAD_MESSAGE = 'Unsupported image type. Use PNG, JPEG, GIF, WebP, BMP, or AVIF.';
 export const FAILED_IMAGE_UPLOAD_MESSAGE = 'Failed to upload image.';
 
 export const isSupportedImageUploadType = (type: string) => SUPPORTED_IMAGE_UPLOAD_TYPE_SET.has(type);
+
+export const getSupportedImageFileExtension = (type: string) => IMAGE_FILE_EXTENSION_BY_TYPE.get(type);

--- a/packages/client/src/modules/note-export.spec.ts
+++ b/packages/client/src/modules/note-export.spec.ts
@@ -67,19 +67,20 @@ describe('note-export', () => {
         const html = createHtmlDocumentExport(
             '<p>Body</p>',
             {
-                id: '123-->\n<img src=x onerror=alert(1)><!--',
+                id: '123-->\n<img src=x onerror=alert(1)><!-- --!>',
                 title: 'Line 1\r\nLine 2 -- tail',
                 createdAt: '8640000000000001',
             },
             { includeMetadata: true },
         );
 
-        expect(html.match(/-->/g)).toHaveLength(1);
+        expect(html.split('-->')).toHaveLength(2);
+        expect(html).not.toContain('--!>');
         expect(html).toContain('&lt;img src=x onerror=alert(1)&gt;');
         expect(html).not.toContain('<img src=x onerror=alert(1)>');
         expect(html).not.toContain('Line 1\r\nLine 2');
         expect(html).toContain('created_at: 8640000000000001');
-        expect(html).toMatch(/-->\n<p>Body<\/p>$/);
+        expect(html.endsWith('-->\n<p>Body</p>')).toBe(true);
 
         const container = document.createElement('div');
 

--- a/packages/client/src/modules/note-export.spec.ts
+++ b/packages/client/src/modules/note-export.spec.ts
@@ -1,18 +1,30 @@
 import JSZip from 'jszip';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
     createHtmlAssetsZipExport,
     createHtmlDocumentExport,
     createMarkdownAssetsZipExport,
     createMarkdownDocumentExport,
     createMarkdownExport,
+    downloadBlobFile,
     getNoteExportFilename,
 } from './note-export';
 
 describe('note-export', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
     it('creates a safe markdown filename from a note title', () => {
         expect(getNoteExportFilename('VSCode에서 탈출하기?', 'md')).toBe('vscode에서-탈출하기.md');
         expect(getNoteExportFilename('HTML Export', 'zip')).toBe('html-export.zip');
+        expect(getNoteExportFilename('CON', 'md')).toBe('note-con.md');
+        expect(getNoteExportFilename('...', 'html')).toBe('untitled-note.html');
+        expect(getNoteExportFilename('Report\u0000Draft. ', 'html')).toBe('report-draft.html');
+
+        const longFilename = getNoteExportFilename('\uac00'.repeat(100), 'zip');
+
+        expect(new TextEncoder().encode(longFilename).byteLength).toBeLessThanOrEqual(124);
     });
 
     it('adds frontmatter when markdown metadata is requested', () => {
@@ -28,8 +40,52 @@ describe('note-export', () => {
         );
 
         expect(markdown).toContain('---\ntitle: "Hello: World"');
-        expect(markdown).toContain('note_id: 123');
+        expect(markdown).toContain('note_id: "123"');
         expect(markdown).toContain('source: ocean-brain\n---\n\nBody');
+    });
+
+    it('keeps frontmatter values as valid YAML strings', () => {
+        const markdown = createMarkdownExport(
+            'Body',
+            {
+                id: 'true',
+                title: 'Line one\n---\nadmin: true',
+                createdAt: '8640000000000001',
+                updatedAt: 'null',
+            },
+            true,
+        );
+
+        expect(markdown).toContain('title: "Line one\\n---\\nadmin: true"');
+        expect(markdown).toContain('note_id: "true"');
+        expect(markdown).toContain('created_at: "8640000000000001"');
+        expect(markdown).toContain('updated_at: "null"');
+        expect(markdown).not.toContain('title: Line one\n---\nadmin: true');
+    });
+
+    it('keeps exported html metadata inside a single comment', () => {
+        const html = createHtmlDocumentExport(
+            '<p>Body</p>',
+            {
+                id: '123-->\n<img src=x onerror=alert(1)><!--',
+                title: 'Line 1\r\nLine 2 -- tail',
+                createdAt: '8640000000000001',
+            },
+            { includeMetadata: true },
+        );
+
+        expect(html.match(/-->/g)).toHaveLength(1);
+        expect(html).toContain('&lt;img src=x onerror=alert(1)&gt;');
+        expect(html).not.toContain('<img src=x onerror=alert(1)>');
+        expect(html).not.toContain('Line 1\r\nLine 2');
+        expect(html).toContain('created_at: 8640000000000001');
+        expect(html).toMatch(/-->\n<p>Body<\/p>$/);
+
+        const container = document.createElement('div');
+
+        container.innerHTML = html;
+        expect(container.querySelector('img')).toBeNull();
+        expect(container.querySelector('p')?.textContent).toBe('Body');
     });
 
     it('omits local image assets from document-only markdown exports', () => {
@@ -89,6 +145,29 @@ describe('note-export', () => {
         expect(markdown).toContain('![Local](./assets/photo.png)');
         expect(markdown).toContain('![External](https://example.com/external.png)');
         expect(imageBytes).toBe('image-bytes');
+    });
+
+    it('resolves escaped markdown punctuation before fetching local image assets', async () => {
+        const sourceMarkdown = '![Local](/assets/images/path/image\\(foo\\).png)';
+        const zipBlob = await createMarkdownAssetsZipExport(
+            sourceMarkdown,
+            { id: '123', title: 'Hello' },
+            {
+                fetchImpl: async (input) => {
+                    expect(input).toBe('/assets/images/path/image(foo).png');
+
+                    return new Response('escaped-image', {
+                        headers: { 'Content-Type': 'image/png' },
+                    });
+                },
+            },
+        );
+        const zip = await JSZip.loadAsync(zipBlob);
+        const markdown = await zip.file('note.md')?.async('string');
+
+        expect(markdown).toBe('![Local](./assets/image-foo.png)');
+        expect(await zip.file('assets/image-foo.png')?.async('string')).toBe('escaped-image');
+        expect(createMarkdownDocumentExport(sourceMarkdown, { id: '123', title: 'Hello' })).toBe('');
     });
 
     it('omits local image assets from document-only html exports', () => {
@@ -162,6 +241,50 @@ describe('note-export', () => {
         expect(html?.match(/\.\/assets\/same\.png/g)).toHaveLength(2);
     });
 
+    it('avoids case-insensitive asset name collisions in zip exports', async () => {
+        const zipBlob = await createHtmlAssetsZipExport(
+            '<img src="/assets/images/a/Photo.png"><img src="/assets/images/b/photo.PNG">',
+            { id: '123', title: 'Hello' },
+            {
+                fetchImpl: async (input) =>
+                    new Response(String(input), {
+                        headers: { 'Content-Type': 'image/png' },
+                    }),
+            },
+        );
+        const zip = await JSZip.loadAsync(zipBlob);
+        const html = await zip.file('note.html')?.async('string');
+
+        expect(html).toContain('src="./assets/Photo.png"');
+        expect(html).toContain('src="./assets/photo-2.png"');
+        expect(zip.file('assets/Photo.png')).toBeTruthy();
+        expect(zip.file('assets/photo-2.png')).toBeTruthy();
+    });
+
+    it('derives portable asset names from verified response types', async () => {
+        const zipBlob = await createHtmlAssetsZipExport(
+            '<img src="/assets/images/a/%ZZ.html"><img src="/assets/images/b/%2E%2E%2Fevil.svg">',
+            { id: '123', title: 'Hello' },
+            {
+                fetchImpl: async (input) =>
+                    new Response(String(input), {
+                        headers: {
+                            'Content-Type': String(input).includes('%ZZ') ? 'image/png' : 'image/jpeg',
+                        },
+                    }),
+            },
+        );
+        const zip = await JSZip.loadAsync(zipBlob);
+        const html = await zip.file('note.html')?.async('string');
+
+        expect(html).toContain('src="./assets/ZZ.png"');
+        expect(html).toContain('src="./assets/evil.jpg"');
+        expect(zip.file('assets/ZZ.png')).toBeTruthy();
+        expect(zip.file('assets/evil.jpg')).toBeTruthy();
+        expect(zip.file('assets/ZZ.html')).toBeNull();
+        expect(zip.file('assets/evil.svg')).toBeNull();
+    });
+
     it('rewrites local image assets without reparsing the exported html document', async () => {
         const zipBlob = await createHtmlAssetsZipExport(
             '<IMG alt="Before > after" src=/assets/images/a/unquoted.png><p data-copy="<img src=\'/assets/images/not-real.png\'>">Text</p>',
@@ -198,5 +321,33 @@ describe('note-export', () => {
                 },
             ),
         ).rejects.toThrow('Image asset did not return image content: /assets/images/missing.png');
+    });
+
+    it('rejects unsupported image types from local asset responses', async () => {
+        await expect(
+            createHtmlAssetsZipExport(
+                '<img src="/assets/images/vector.svg">',
+                { id: '123', title: 'Hello' },
+                {
+                    fetchImpl: async () =>
+                        new Response('<svg></svg>', {
+                            headers: { 'Content-Type': 'image/svg+xml' },
+                        }),
+                },
+            ),
+        ).rejects.toThrow('Image asset did not return image content: /assets/images/vector.svg');
+    });
+
+    it('cleans up the temporary download URL when the browser click fails', () => {
+        const createObjectUrl = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:note-export');
+        const revokeObjectUrl = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined);
+        vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {
+            throw new Error('download blocked');
+        });
+
+        expect(() => downloadBlobFile(new Blob(['Body']), 'note.md')).toThrow('download blocked');
+        expect(createObjectUrl).toHaveBeenCalledOnce();
+        expect(revokeObjectUrl).toHaveBeenCalledWith('blob:note-export');
+        expect(document.querySelector('a[download="note.md"]')).toBeNull();
     });
 });

--- a/packages/client/src/modules/note-export.ts
+++ b/packages/client/src/modules/note-export.ts
@@ -1,4 +1,5 @@
 import JSZip from 'jszip';
+import { getSupportedImageFileExtension } from './image-upload-policy';
 
 export interface NoteExportMetadata {
     id: string;
@@ -22,31 +23,68 @@ interface MarkdownDocumentExportOptions {
     includeMetadata?: boolean;
 }
 
-const YAML_SPECIAL_CHAR_PATTERN = /[:{}[\],&*#?|<>=!%@`-]/;
 const LOCAL_IMAGE_ASSET_PREFIX = '/assets/images/';
+const MAX_FILENAME_STEM_BYTES = 120;
+const MAX_ASSET_FILENAME_STEM_BYTES = 100;
+const WINDOWS_RESERVED_FILENAME_PATTERN =
+    /^(?:con|prn|aux|nul|com[1-9\u00b9\u00b2\u00b3]|lpt[1-9\u00b9\u00b2\u00b3])(?:\.|$)/i;
+
+const isControlCharacter = (character: string) => {
+    const codePoint = character.codePointAt(0) ?? 0;
+
+    return codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f);
+};
+
+const truncateUtf8 = (value: string, maxBytes: number) => {
+    const encoder = new TextEncoder();
+    let byteLength = 0;
+    let truncated = '';
+
+    for (const character of value) {
+        const characterBytes = encoder.encode(character).byteLength;
+
+        if (byteLength + characterBytes > maxBytes) {
+            break;
+        }
+
+        truncated += character;
+        byteLength += characterBytes;
+    }
+
+    return truncated;
+};
+
+const trimPortableFilenameEdges = (value: string) => value.replace(/^[.\s-]+|[.\s-]+$/g, '');
 
 const normalizeTitleForFilename = (title: string) => {
-    const normalized = title
-        .trim()
-        .toLowerCase()
-        .replace(/\s+/g, '-')
-        .replace(/[\\/:*?"<>|]/g, '-')
+    let normalized = Array.from(title.normalize('NFC').trim().toLowerCase(), (character) =>
+        isControlCharacter(character) || /[\\/:*?"<>|\s]/.test(character) ? '-' : character,
+    )
+        .join('')
         .replace(/-+/g, '-')
-        .replace(/^-|-$/g, '');
+        .replace(/^[.-]+|[.-]+$/g, '');
+
+    if (WINDOWS_RESERVED_FILENAME_PATTERN.test(normalized)) {
+        normalized = `note-${normalized}`;
+    }
+
+    normalized = trimPortableFilenameEdges(truncateUtf8(normalized, MAX_FILENAME_STEM_BYTES));
 
     return normalized || 'untitled-note';
 };
 
-const formatYamlString = (value: string) => {
-    if (!value) {
-        return '""';
-    }
+const formatYamlString = (value: string) => JSON.stringify(value);
 
-    if (YAML_SPECIAL_CHAR_PATTERN.test(value) || /^\s|\s$/.test(value)) {
-        return JSON.stringify(value);
-    }
+const formatHtmlCommentValue = (value: string) => {
+    const escapedValue = value
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/--/g, '&#45;&#45;');
 
-    return value;
+    return Array.from(escapedValue, (character) =>
+        isControlCharacter(character) ? `&#${character.codePointAt(0)};` : character,
+    ).join('');
 };
 
 const formatTimestamp = (timestamp?: string) => {
@@ -60,7 +98,9 @@ const formatTimestamp = (timestamp?: string) => {
         return timestamp;
     }
 
-    return new Date(numericTimestamp).toISOString();
+    const date = new Date(numericTimestamp);
+
+    return Number.isNaN(date.getTime()) ? timestamp : date.toISOString();
 };
 
 const getDocumentOrigin = () => {
@@ -91,16 +131,20 @@ const getResponseContentType = (response: Response) => {
     return response.headers.get('content-type')?.split(';')[0]?.trim().toLowerCase() ?? '';
 };
 
-const sanitizeZipAssetName = (value: string) => {
-    const withoutUnsafeChars = value
+const sanitizeZipAssetStem = (value: string, fallback: string) => {
+    let sanitized = value
+        .normalize('NFC')
         .trim()
-        .replace(/[\\/:*?"<>|]/g, '-')
-        .split('')
-        .map((character) => (character.charCodeAt(0) < 32 ? '-' : character))
-        .join('');
-    const sanitized = withoutUnsafeChars.replace(/\s+/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '');
+        .replace(/[^\p{L}\p{M}\p{N}._-]+/gu, '-')
+        .replace(/-+/g, '-');
 
-    return sanitized || 'image';
+    sanitized = trimPortableFilenameEdges(sanitized);
+
+    if (WINDOWS_RESERVED_FILENAME_PATTERN.test(sanitized)) {
+        sanitized = `image-${sanitized}`;
+    }
+
+    return trimPortableFilenameEdges(truncateUtf8(sanitized, MAX_ASSET_FILENAME_STEM_BYTES)) || fallback;
 };
 
 const splitFileName = (fileName: string) => {
@@ -119,23 +163,68 @@ const splitFileName = (fileName: string) => {
     };
 };
 
-const createZipAssetName = (src: string, index: number, usedNames: Set<string>) => {
+const safeDecodeURIComponent = (value: string) => {
+    try {
+        return decodeURIComponent(value);
+    } catch {
+        return value;
+    }
+};
+
+const createZipAssetName = (src: string, index: number, extension: string, usedNames: Set<string>) => {
     const url = new URL(src, getDocumentOrigin());
     const pathSegments = url.pathname.split('/').filter(Boolean);
-    const rawName = decodeURIComponent(pathSegments[pathSegments.length - 1] ?? '');
+    const rawName = safeDecodeURIComponent(pathSegments[pathSegments.length - 1] ?? '');
     const fallbackName = `image-${index + 1}`;
-    const { baseName, extension } = splitFileName(sanitizeZipAssetName(rawName || fallbackName));
-    let candidate = `${baseName}${extension}`;
+    const { baseName } = splitFileName(rawName || fallbackName);
+    const sanitizedBaseName = sanitizeZipAssetStem(baseName, fallbackName);
+    let candidate = `${sanitizedBaseName}.${extension}`;
     let suffix = 2;
 
-    while (usedNames.has(candidate)) {
-        candidate = `${baseName}-${suffix}${extension}`;
+    while (usedNames.has(candidate.normalize('NFC').toLowerCase())) {
+        candidate = `${sanitizedBaseName}-${suffix}.${extension}`;
         suffix += 1;
     }
 
-    usedNames.add(candidate);
+    usedNames.add(candidate.normalize('NFC').toLowerCase());
 
     return `assets/${candidate}`;
+};
+
+const unescapeMarkdownDestination = (value: string) => {
+    return value.replace(/\\([!"#$%&'()*+,\-./:;<=>?@[\]\\^_`{|}~])/g, '$1');
+};
+
+const addLocalImageAssetToZip = async (
+    zip: JSZip,
+    requestPath: string,
+    fetchImpl: FetchAsset,
+    assetNameByRequestPath: Map<string, string>,
+    usedNames: Set<string>,
+) => {
+    const existingAssetName = assetNameByRequestPath.get(requestPath);
+
+    if (existingAssetName) {
+        return existingAssetName;
+    }
+
+    const response = await fetchImpl(requestPath, { credentials: 'same-origin' });
+
+    if (!response.ok) {
+        throw new Error(`Failed to fetch image asset: ${requestPath}`);
+    }
+
+    const extension = getSupportedImageFileExtension(getResponseContentType(response));
+
+    if (!extension) {
+        throw new Error(`Image asset did not return image content: ${requestPath}`);
+    }
+
+    const zipAssetName = createZipAssetName(requestPath, assetNameByRequestPath.size, extension, usedNames);
+    zip.file(zipAssetName, new Uint8Array(await response.arrayBuffer()));
+    assetNameByRequestPath.set(requestPath, zipAssetName);
+
+    return zipAssetName;
 };
 
 const findTagEnd = (html: string, startIndex: number) => {
@@ -530,7 +619,7 @@ export const createMarkdownDocumentExport = (
 ) => {
     const markdownExport = createMarkdownExport(markdown, metadata, includeMetadata);
     const replacements = findMarkdownImageTags(markdownExport)
-        .filter((imageTag) => isLocalImageAssetUrl(imageTag.source.value))
+        .filter((imageTag) => isLocalImageAssetUrl(unescapeMarkdownDestination(imageTag.source.value)))
         .map((imageTag) => ({
             end: imageTag.end,
             start: imageTag.start,
@@ -546,7 +635,16 @@ export const createHtmlExport = (
     { includeMetadata = false }: HtmlDocumentExportOptions = {},
 ) => {
     const metadataComment = includeMetadata
-        ? `<!--\nsource: ocean-brain\nnote_id: ${metadata.id}\ntitle: ${metadata.title}\ncreated_at: ${formatTimestamp(metadata.createdAt) ?? ''}\nupdated_at: ${formatTimestamp(metadata.updatedAt) ?? ''}\n-->\n`
+        ? [
+              '<!--',
+              'source: ocean-brain',
+              `note_id: ${formatHtmlCommentValue(metadata.id)}`,
+              `title: ${formatHtmlCommentValue(metadata.title)}`,
+              `created_at: ${formatHtmlCommentValue(formatTimestamp(metadata.createdAt) ?? '')}`,
+              `updated_at: ${formatHtmlCommentValue(formatTimestamp(metadata.updatedAt) ?? '')}`,
+              '-->',
+              '',
+          ].join('\n')
         : '';
 
     return `${metadataComment}${html}`;
@@ -587,24 +685,13 @@ export const createHtmlAssetsZipExport = async (
         }
 
         const requestPath = getImageAssetRequestPath(imageSourceRange.value);
-        let zipAssetName = assetNameByRequestPath.get(requestPath);
-
-        if (!zipAssetName) {
-            zipAssetName = createZipAssetName(requestPath, assetNameByRequestPath.size, usedNames);
-            assetNameByRequestPath.set(requestPath, zipAssetName);
-
-            const response = await fetchImpl(requestPath, { credentials: 'same-origin' });
-
-            if (!response.ok) {
-                throw new Error(`Failed to fetch image asset: ${requestPath}`);
-            }
-
-            if (!getResponseContentType(response).startsWith('image/')) {
-                throw new Error(`Image asset did not return image content: ${requestPath}`);
-            }
-
-            zip.file(zipAssetName, new Uint8Array(await response.arrayBuffer()));
-        }
+        const zipAssetName = await addLocalImageAssetToZip(
+            zip,
+            requestPath,
+            fetchImpl,
+            assetNameByRequestPath,
+            usedNames,
+        );
 
         replacements.push({
             end: imageSourceRange.end,
@@ -631,29 +718,20 @@ export const createMarkdownAssetsZipExport = async (
     const assetNameByRequestPath = new Map<string, string>();
 
     for (const { source: imageSourceRange } of imageTags) {
-        if (!isLocalImageAssetUrl(imageSourceRange.value)) {
+        const imageSource = unescapeMarkdownDestination(imageSourceRange.value);
+
+        if (!isLocalImageAssetUrl(imageSource)) {
             continue;
         }
 
-        const requestPath = getImageAssetRequestPath(imageSourceRange.value);
-        let zipAssetName = assetNameByRequestPath.get(requestPath);
-
-        if (!zipAssetName) {
-            zipAssetName = createZipAssetName(requestPath, assetNameByRequestPath.size, usedNames);
-            assetNameByRequestPath.set(requestPath, zipAssetName);
-
-            const response = await fetchImpl(requestPath, { credentials: 'same-origin' });
-
-            if (!response.ok) {
-                throw new Error(`Failed to fetch image asset: ${requestPath}`);
-            }
-
-            if (!getResponseContentType(response).startsWith('image/')) {
-                throw new Error(`Image asset did not return image content: ${requestPath}`);
-            }
-
-            zip.file(zipAssetName, new Uint8Array(await response.arrayBuffer()));
-        }
+        const requestPath = getImageAssetRequestPath(imageSource);
+        const zipAssetName = await addLocalImageAssetToZip(
+            zip,
+            requestPath,
+            fetchImpl,
+            assetNameByRequestPath,
+            usedNames,
+        );
 
         replacements.push({
             end: imageSourceRange.end,
@@ -668,15 +746,18 @@ export const createMarkdownAssetsZipExport = async (
 };
 
 export const downloadBlobFile = (blob: Blob, filename: string) => {
-    const url = URL.createObjectURL(blob);
     const anchor = document.createElement('a');
+    const url = URL.createObjectURL(blob);
 
-    anchor.href = url;
-    anchor.download = filename;
-    document.body.appendChild(anchor);
-    anchor.click();
-    anchor.remove();
-    URL.revokeObjectURL(url);
+    try {
+        anchor.href = url;
+        anchor.download = filename;
+        document.body.appendChild(anchor);
+        anchor.click();
+    } finally {
+        anchor.remove();
+        URL.revokeObjectURL(url);
+    }
 };
 
 export const downloadTextFile = (content: string, filename: string, type: string) => {

--- a/packages/server/src/modules/blocknote.ts
+++ b/packages/server/src/modules/blocknote.ts
@@ -140,14 +140,6 @@ function visitBlocks(blocks: BlockNote[], visit: (block: BlockNote) => void) {
     }
 }
 
-function createTagPlaceholder(index: number) {
-    return `${TAG_PLACEHOLDER_PREFIX}${index}${TAG_PLACEHOLDER_SUFFIX}`;
-}
-
-function createReferencePlaceholder(index: number) {
-    return `${REFERENCE_PLACEHOLDER_PREFIX}${index}${REFERENCE_PLACEHOLDER_SUFFIX}`;
-}
-
 function isValidNoteIdString(id: string) {
     if (!/^[1-9]\d*$/.test(id)) {
         return false;
@@ -249,7 +241,7 @@ function mapBlocks(
 function preprocessCustomInlineContent(
     blocks: BlockNote[],
     placeholderToTag: Map<string, string>,
-    nextPlaceholderIndex: { value: number },
+    createTagPlaceholder: () => string,
 ): BlockNote[] {
     return mapBlocks(blocks, (content) =>
         mapBlockContent(content, (inline) => {
@@ -265,7 +257,7 @@ function preprocessCustomInlineContent(
             }
             if (inline.type === 'tag') {
                 const tag = (inline.props?.tag as string) || '';
-                const placeholder = createTagPlaceholder(nextPlaceholderIndex.value++);
+                const placeholder = createTagPlaceholder();
                 placeholderToTag.set(placeholder, tag);
                 return {
                     type: 'text',
@@ -290,9 +282,13 @@ function restoreTagPlaceholdersInMarkdown(markdown: string, placeholderToTag: Ma
 
 function preprocessMarkdownExplicitTags(markdown: string) {
     const placeholderToTag = new Map<string, string>();
-    let nextPlaceholderIndex = 0;
+    const createPlaceholder = createProtectedTextPlaceholderFactory(
+        markdown,
+        TAG_PLACEHOLDER_PREFIX,
+        TAG_PLACEHOLDER_SUFFIX,
+    );
     const preprocessedMarkdown = markdown.replace(/\[(@[^\s[\]]+)\]/g, (_match, tagToken: string) => {
-        const placeholder = createTagPlaceholder(nextPlaceholderIndex++);
+        const placeholder = createPlaceholder();
         placeholderToTag.set(placeholder, tagToken);
         return placeholder;
     });
@@ -305,6 +301,11 @@ function preprocessMarkdownExplicitTags(markdown: string) {
 
 function preprocessMarkdownExplicitReferences(markdown: string) {
     const placeholderToReference = new Map<string, { id: string; title: string; token: string }>();
+    const createPlaceholder = createProtectedTextPlaceholderFactory(
+        markdown,
+        REFERENCE_PLACEHOLDER_PREFIX,
+        REFERENCE_PLACEHOLDER_SUFFIX,
+    );
     let activeFence: { marker: '`' | '~'; length: number } | null = null;
 
     const preprocessedLines = markdown.split(/(?<=\n)/).map((line) => {
@@ -331,7 +332,11 @@ function preprocessMarkdownExplicitReferences(markdown: string) {
             return line;
         }
 
-        return `${replaceMarkdownLineExplicitReferences(lineBody, placeholderToReference)}${lineEnding}`;
+        return `${replaceMarkdownLineExplicitReferences(
+            lineBody,
+            placeholderToReference,
+            createPlaceholder,
+        )}${lineEnding}`;
     });
 
     return {
@@ -343,6 +348,7 @@ function preprocessMarkdownExplicitReferences(markdown: string) {
 function replaceMarkdownLineExplicitReferences(
     line: string,
     placeholderToReference: Map<string, { id: string; title: string; token: string }>,
+    createPlaceholder: () => string,
 ) {
     let result = '';
     let cursor = 0;
@@ -351,11 +357,15 @@ function replaceMarkdownLineExplicitReferences(
         const codeSpan = findNextInlineCodeSpan(line, cursor);
 
         if (!codeSpan) {
-            result += replaceExplicitReferenceTokens(line.slice(cursor), placeholderToReference);
+            result += replaceExplicitReferenceTokens(line.slice(cursor), placeholderToReference, createPlaceholder);
             break;
         }
 
-        result += replaceExplicitReferenceTokens(line.slice(cursor, codeSpan.start), placeholderToReference);
+        result += replaceExplicitReferenceTokens(
+            line.slice(cursor, codeSpan.start),
+            placeholderToReference,
+            createPlaceholder,
+        );
         result += line.slice(codeSpan.start, codeSpan.end);
         cursor = codeSpan.end;
     }
@@ -366,9 +376,10 @@ function replaceMarkdownLineExplicitReferences(
 function replaceExplicitReferenceTokens(
     text: string,
     placeholderToReference: Map<string, { id: string; title: string; token: string }>,
+    createPlaceholder: () => string,
 ) {
     return text.replace(/\[\[([^\n]+?)\]\]\(note:([^)\s]+)\)/g, (token, title: string, id: string) => {
-        const placeholder = createReferencePlaceholder(placeholderToReference.size);
+        const placeholder = createPlaceholder();
         placeholderToReference.set(placeholder, { id, title, token });
         return placeholder;
     });
@@ -1434,7 +1445,12 @@ export async function blocksToMarkdown(contentJson: string): Promise<string> {
         const blocks = parseBlockNoteContent(contentJson);
         const supportedBlocks = stripUnsupportedMarkdownBlocks(blocks);
         const placeholderToTag = new Map<string, string>();
-        const processed = preprocessCustomInlineContent(supportedBlocks, placeholderToTag, { value: 0 });
+        const createTagPlaceholder = createProtectedTextPlaceholderFactory(
+            contentJson,
+            TAG_PLACEHOLDER_PREFIX,
+            TAG_PLACEHOLDER_SUFFIX,
+        );
+        const processed = preprocessCustomInlineContent(supportedBlocks, placeholderToTag, createTagPlaceholder);
         const editor = getEditor();
         const markdown = await editor.blocksToMarkdownLossy(
             processed as Parameters<typeof editor.blocksToMarkdownLossy>[0],

--- a/packages/server/test/blocknote.test.ts
+++ b/packages/server/test/blocknote.test.ts
@@ -222,6 +222,34 @@ test('blocksToMarkdown serializes tags using explicit bracket syntax', async () 
     assert.match(markdown, /\[\[Reference Note\]\]\(note:44\)/);
 });
 
+test('blocksToMarkdown preserves literal text that matches its tag placeholder', async () => {
+    const content = JSON.stringify([
+        {
+            type: 'paragraph',
+            props: {},
+            content: [
+                {
+                    type: 'text',
+                    text: 'Literal OCEAN_BRAIN_TAG_0_TOKEN ',
+                    styles: {},
+                },
+                {
+                    type: 'tag',
+                    props: {
+                        id: '12',
+                        tag: '@project',
+                    },
+                },
+            ],
+            children: [],
+        },
+    ]);
+
+    const markdown = await blocksToMarkdown(content);
+
+    assert.match(markdown, /Literal OCEAN_BRAIN_TAG_0_TOKEN \[@project\]/);
+});
+
 test('blocksToMarkdown serializes custom inline content inside table cells', async () => {
     const content = JSON.stringify([
         {
@@ -580,6 +608,29 @@ test('markdownToBlocksJson restores custom tag and reference inline content from
             },
         },
     ]);
+});
+
+test('markdownToBlocksJson preserves literal text matching tag and reference placeholders', async () => {
+    const contentJson = await markdownToBlocksJson(
+        'Literal OCEAN_BRAIN_TAG_0_TOKEN OCEAN_BRAIN_REFERENCE_0_TOKEN [@project] [[Old Title]](note:44)',
+        {
+            ensureTag: async () => ({
+                id: '12',
+                name: '@project',
+            }),
+            findNotesByTitle: async () => [],
+            findNoteById: async (id) => (id === '44' ? { id, title: 'Current Title' } : null),
+        },
+    );
+    const blocks = JSON.parse(contentJson);
+
+    assert.match(blocks[0].content[0].text, /OCEAN_BRAIN_TAG_0_TOKEN/);
+    assert.match(blocks[0].content[0].text, /OCEAN_BRAIN_REFERENCE_0_TOKEN/);
+    assert.equal(blocks[0].content[1].type, 'tag');
+    assert.equal(blocks[0].content[1].props.tag, '@project');
+    assert.equal(blocks[0].content[3].type, 'reference');
+    assert.equal(blocks[0].content[3].props.id, '44');
+    assert.equal(blocks[0].content[3].props.title, 'Current Title');
 });
 
 test('markdownToBlocksJson leaves explicit # tag syntax as text', async () => {


### PR DESCRIPTION
## :dart: Goal
- Prevent malformed or hostile note metadata from escaping HTML comments or changing YAML scalar types during export.
- Make Markdown, HTML, and asset ZIP downloads preserve supported content reliably across browsers, Markdown round trips, and case-insensitive filesystems.

## :hammer_and_wrench: Core Changes
- Serialize frontmatter strings safely, contain HTML metadata in a single valid comment, and tolerate invalid timestamp values.
- Generate bounded cross-platform note filenames and sanitized ZIP asset names with case-insensitive collision handling.
- Validate exported image responses against the supported raster MIME policy and derive canonical asset extensions from verified response types.
- Resolve escaped Markdown image destinations, tolerate malformed URL encoding, and always clean up temporary download resources.
- Generate collision-free tag and reference placeholders in client and server Markdown conversion paths so placeholder-shaped user text remains unchanged.
- Add regression coverage for metadata injection, scalar coercion, filenames, MIME handling, ZIP collisions, escaped paths, cleanup, and Markdown round trips.

## :brain: Key Decisions
- Preserve the existing export product contract: HTML remains a fragment, document-only exports omit local images, and asset-preserving exports remain ZIP files.
- Treat the authenticated asset response MIME as authoritative for both allowlisting and the archived extension instead of trusting the source URL suffix.
- Reuse the existing upload image policy and existing placeholder factory semantics rather than introducing a second content policy or export format.

## :test_tube: Verification Guide
### How to verify
1. Export Markdown and HTML with metadata from a note whose title contains newlines, YAML-like values, or HTML comment delimiters.
2. Export a note with local raster images both as a document and with assets included, then inspect the ZIP paths and rendered document links.
3. Round-trip notes containing tags, references, and literal `OCEAN_BRAIN_*_TOKEN` text through Markdown conversion.

### Expected result
- Metadata remains inert and parseable, document-only exports contain no local image references, ZIP exports contain only supported raster assets with portable unique names, and literal placeholder-shaped text is preserved.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (not needed; existing export contract is unchanged)
