### PR TITLE
🐛 Fix calendar date boundaries and ordering

### DIFF
--- a/packages/client/src/components/calendar/calendar-data.spec.ts
+++ b/packages/client/src/components/calendar/calendar-data.spec.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Note } from '~/models/note.model';
+import { getCalendarMonthRange, sortCalendarNotes } from './calendar-data';
+
+const createNote = (id: string, createdAt: string, updatedAt: string) => ({ id, createdAt, updatedAt }) as Note;
+
+describe('calendar data', () => {
+    it('builds month boundaries from local midnight as absolute timestamps', () => {
+        expect(getCalendarMonthRange(2026, 8)).toEqual({
+            start: new Date(2026, 7, 1).toISOString(),
+            end: new Date(2026, 8, 1).toISOString(),
+        });
+    });
+
+    it('sorts notes by the date field shown in the calendar', () => {
+        const notes = [createNote('older-update', '1000', '3000'), createNote('newer-update', '2000', '1000')];
+
+        expect(sortCalendarNotes(notes, 'create').map((note) => note.id)).toEqual(['older-update', 'newer-update']);
+        expect(sortCalendarNotes(notes, 'update').map((note) => note.id)).toEqual(['newer-update', 'older-update']);
+        expect(notes.map((note) => note.id)).toEqual(['older-update', 'newer-update']);
+    });
+});

--- a/packages/client/src/components/calendar/calendar-data.ts
+++ b/packages/client/src/components/calendar/calendar-data.ts
@@ -1,0 +1,17 @@
+import type { Note } from '~/models/note.model';
+import type { CalendarDisplayType } from './types';
+
+export const getCalendarMonthRange = (year: number, month: number) => ({
+    start: new Date(year, month - 1, 1).toISOString(),
+    end: new Date(year, month, 1).toISOString(),
+});
+
+const toTimestamp = (value: string) => {
+    const numericValue = Number(value);
+    return Number.isFinite(numericValue) ? numericValue : Date.parse(value);
+};
+
+export const sortCalendarNotes = (notes: Note[], type: CalendarDisplayType) => {
+    const dateField = type === 'create' ? 'createdAt' : 'updatedAt';
+    return [...notes].sort((left, right) => toTimestamp(left[dateField]) - toTimestamp(right[dateField]));
+};

--- a/packages/client/src/components/calendar/useCalendarData.ts
+++ b/packages/client/src/components/calendar/useCalendarData.ts
@@ -4,6 +4,7 @@ import type { Note } from '~/models/note.model';
 import type { Reminder } from '~/models/reminder.model';
 import { graphQuery } from '~/modules/graph-query';
 import { queryKeys } from '~/modules/query-key-factory';
+import { getCalendarMonthRange } from './calendar-data';
 
 const NOTES_QUERY = `
     query NotesInDateRange($dateRange: DateRangeInput) {
@@ -60,15 +61,7 @@ interface UseCalendarDataParams {
 }
 
 export const useCalendarData = ({ year, month }: UseCalendarDataParams) => {
-    const startDate = `${year}-${String(month).padStart(2, '0')}-01`;
-    const nextMonth = month === 12 ? 1 : month + 1;
-    const nextYear = month === 12 ? year + 1 : year;
-    const endDate = `${nextYear}-${String(nextMonth).padStart(2, '0')}-01`;
-
-    const dateRange = {
-        start: startDate,
-        end: endDate,
-    };
+    const dateRange = getCalendarMonthRange(year, month);
 
     const notesQuery = useQuery({
         queryKey: queryKeys.calendar.notesInDateRange(year, month),

--- a/packages/client/src/modules/local-demo/plugins/notes.spec.ts
+++ b/packages/client/src/modules/local-demo/plugins/notes.spec.ts
@@ -62,6 +62,38 @@ const createState = (): LocalDemoState => {
 };
 
 describe('notesLocalPlugin', () => {
+    it('returns notes created or updated inside a calendar range', () => {
+        const state = createState();
+        state.notes = [
+            createNote({ id: 'created-in-range', title: 'Created in range', tags: [] }),
+            createNote({ id: 'updated-in-range', title: 'Updated in range', tags: [] }),
+            createNote({ id: 'outside-range', title: 'Outside range', tags: [] }),
+        ];
+        state.notes[0].createdAt = '2026-08-05T00:00:00.000Z';
+        state.notes[0].updatedAt = '2026-09-05T00:00:00.000Z';
+        state.notes[1].createdAt = '2026-07-05T00:00:00.000Z';
+        state.notes[1].updatedAt = '2026-08-06T00:00:00.000Z';
+        state.notes[2].createdAt = '2026-07-05T00:00:00.000Z';
+        state.notes[2].updatedAt = '2026-09-05T00:00:00.000Z';
+
+        const handler = notesLocalPlugin.graphHandlers?.NotesInDateRange;
+        expect(handler).toBeDefined();
+
+        const response = handler?.({
+            state,
+            variables: {
+                dateRange: {
+                    start: '2026-08-01T00:00:00.000Z',
+                    end: '2026-09-01T00:00:00.000Z',
+                },
+            },
+            save: () => undefined,
+        });
+        const notes = response && 'notesInDateRange' in response ? (response.notesInDateRange as Note[]) : [];
+
+        expect(notes.map((note) => note.id)).toEqual(['created-in-range', 'updated-in-range']);
+    });
+
     it('rejects hash-prefixed tags instead of normalizing them', () => {
         expect(() => normalizeTagName('#guide')).toThrow('use @, not #');
     });

--- a/packages/client/src/modules/local-demo/plugins/notes.ts
+++ b/packages/client/src/modules/local-demo/plugins/notes.ts
@@ -341,7 +341,9 @@ export const notesLocalPlugin: LocalDemoPlugin = {
         },
         NotesInDateRange: ({ state, variables }) => {
             const dateRange = variables.dateRange as { start?: string; end?: string } | undefined;
-            const notes = state.notes.filter((note) => isInDateRange(note.createdAt, dateRange));
+            const notes = state.notes.filter(
+                (note) => isInDateRange(note.createdAt, dateRange) || isInDateRange(note.updatedAt, dateRange),
+            );
             return success({ notesInDateRange: notes });
         },
     },

--- a/packages/client/src/pages/Calendar.tsx
+++ b/packages/client/src/pages/Calendar.tsx
@@ -3,6 +3,7 @@ import dayjs from 'dayjs';
 import { useMemo, useState } from 'react';
 import type { CalendarDayData, CalendarDisplayType } from '~/components/calendar';
 import { CalendarHeader, CalendarMonth, useCalendarData } from '~/components/calendar';
+import { sortCalendarNotes } from '~/components/calendar/calendar-data';
 import { Callout, PageLayout } from '~/components/shared';
 import type { Note } from '~/models/note.model';
 import type { Reminder } from '~/models/reminder.model';
@@ -38,6 +39,9 @@ export default function Calendar() {
             const existing = notesMap.get(key) || [];
             existing.push(note);
             notesMap.set(key, existing);
+        }
+        for (const [key, dayNotes] of notesMap) {
+            notesMap.set(key, sortCalendarNotes(dayNotes, type));
         }
 
         // Build reminders map

--- a/packages/server/src/features/note/graphql/note.query.resolver.test.ts
+++ b/packages/server/src/features/note/graphql/note.query.resolver.test.ts
@@ -2,11 +2,24 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import {
+    buildNotesInDateRangeWhere,
     createAllNotesQueryResolver,
     createBackReferencesQueryResolver,
     createNoteGraphQueryResolver,
     createNoteQueryResolver,
 } from './note.query.resolver.js';
+
+test('notes in date range uses an exclusive end boundary for both note dates', () => {
+    const start = '2026-08-01T00:00:00.000Z';
+    const end = '2026-09-01T00:00:00.000Z';
+
+    assert.deepEqual(buildNotesInDateRangeWhere({ start, end }), {
+        OR: [
+            { updatedAt: { gte: new Date(start), lt: new Date(end) } },
+            { createdAt: { gte: new Date(start), lt: new Date(end) } },
+        ],
+    });
+});
 
 const createNoteRecord = (input: { id: number; title: string; content: string; updatedAt?: Date }) =>
     ({

--- a/packages/server/src/features/note/graphql/note.query.resolver.ts
+++ b/packages/server/src/features/note/graphql/note.query.resolver.ts
@@ -442,6 +442,23 @@ export const createNoteQueryResolver = (
     };
 };
 
+export const buildNotesInDateRangeWhere = (dateRange: { start: string; end: string }): Prisma.NoteWhereInput => ({
+    OR: [
+        {
+            updatedAt: {
+                gte: new Date(dateRange.start),
+                lt: new Date(dateRange.end),
+            },
+        },
+        {
+            createdAt: {
+                gte: new Date(dateRange.start),
+                lt: new Date(dateRange.end),
+            },
+        },
+    ],
+});
+
 export const noteQueryResolvers: NoteQueryResolvers = {
     allNotes: createAllNotesQueryResolver(),
     notesInDateRange: async (
@@ -455,22 +472,7 @@ export const noteQueryResolvers: NoteQueryResolvers = {
             };
         },
     ) => {
-        const where: Prisma.NoteWhereInput = {
-            OR: [
-                {
-                    updatedAt: {
-                        gte: new Date(dateRange.start),
-                        lte: new Date(dateRange.end),
-                    },
-                },
-                {
-                    createdAt: {
-                        gte: new Date(dateRange.start),
-                        lte: new Date(dateRange.end),
-                    },
-                },
-            ],
-        };
+        const where = buildNotesInDateRangeWhere(dateRange);
 
         return models.note.findMany({
             orderBy: { createdAt: 'asc' },


### PR DESCRIPTION
## :dart: Goal
- Fix calendar entries that can be omitted or assigned to the wrong month when browser-local dates are interpreted as UTC on the server.
- Align the Updated calendar view and local demo date-range behavior with the server contract.

## :hammer_and_wrench: Core Changes
- Send the current month and next month boundaries as ISO timestamps derived from browser-local midnight.
- Query notes whose createdAt or updatedAt falls within the half-open range [start, end), with matching local demo behavior.
- Sort notes within each day by the date field selected by the Create or Updated view.
- Add regression coverage for month boundaries, display-specific ordering, and created or updated range matching.

## :brain: Key Decisions
- Use absolute timestamps instead of timezone-free date strings so the client calendar and server query share the same month boundaries.
- Keep the end boundary exclusive to match reminder queries and prevent entries at the next month midnight from being included twice.
- Keep saved Views Calendar support outside this bug-fix PR as a separate minor update.

## :test_tube: Verification Guide
### How to verify
1. `corepack pnpm@10.25.0 check:encoding`
2. `corepack pnpm@10.25.0 check:deps`
3. `corepack pnpm@10.25.0 --filter @ocean-brain/client lint`
4. `corepack pnpm@10.25.0 --filter @ocean-brain/server lint`
5. `corepack pnpm@10.25.0 --filter @ocean-brain/client type-check`
6. `corepack pnpm@10.25.0 --filter @ocean-brain/server type-check`
7. `corepack pnpm@10.25.0 --parallel -r run --if-present test:ci`
8. `corepack pnpm@10.25.0 --filter @ocean-brain/client build`
9. `corepack pnpm@10.25.0 --filter @ocean-brain/server build`

### Expected result
- Every command exits successfully.
- Notes and reminders appear from browser-local month start through the instant before the next browser-local month.
- Switching between Create and Updated orders notes by the corresponding date field.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Build completed
- [x] Documentation updated (not needed; no docs, scripts, or environment changes)