### PR TITLE
✅ Align calendar range regression test

### DIFF
--- a/packages/client/src/components/calendar/useCalendarData.spec.tsx
+++ b/packages/client/src/components/calendar/useCalendarData.spec.tsx
@@ -27,6 +27,10 @@ describe('useCalendarData', () => {
             } as never;
         });
         const { Wrapper } = createQueryClientWrapper();
+        const expectedDateRange = {
+            start: new Date(2026, 11, 1).toISOString(),
+            end: new Date(2027, 0, 1).toISOString(),
+        };
 
         const { result } = renderHook(() => useCalendarData({ year: 2026, month: 12 }), { wrapper: Wrapper });
 
@@ -35,10 +39,10 @@ describe('useCalendarData', () => {
         });
         expect(graphQuery).toHaveBeenCalledTimes(2);
         expect(graphQuery).toHaveBeenCalledWith(expect.stringContaining('query NotesInDateRange'), {
-            dateRange: { start: '2026-12-01', end: '2027-01-01' },
+            dateRange: expectedDateRange,
         });
         expect(graphQuery).toHaveBeenCalledWith(expect.stringContaining('query RemindersInDateRange'), {
-            dateRange: { start: '2026-12-01', end: '2027-01-01' },
+            dateRange: expectedDateRange,
         });
         expect(result.current.notes).toEqual([{ id: 'note-1', title: 'Year-end note' }]);
         expect(result.current.reminders).toEqual([{ id: 'reminder-1', content: 'Year-end reminder' }]);


### PR DESCRIPTION
## :dart: Goal
- Restore aggregate CI after the calendar boundary fix changed range variables from date-only strings to browser-local ISO timestamps.
- Keep the hook regression test aligned with the production calendar contract across time zones.

## :hammer_and_wrench: Core Changes
- Derive the expected December 2026 and January 2027 boundaries from local midnight.
- Reuse the expected absolute range for both note and reminder GraphQL assertions.

## :brain: Key Decisions
- Calculate expectations with the same browser-local Date semantics required by the calendar contract instead of hard-coding UTC or date-only strings.
- Keep this PR test-only because the production behavior in #319 is correct.

## :test_tube: Verification Guide
### How to verify
1. `corepack pnpm@10.25.0 --filter @ocean-brain/client test --run src/components/calendar/useCalendarData.spec.tsx src/components/calendar/calendar-data.spec.ts`
2. `corepack pnpm@10.25.0 --filter @ocean-brain/client lint`
3. `corepack pnpm@10.25.0 --filter @ocean-brain/client type-check`

### Expected result
- Both calendar test files pass.
- Lint and type-check exit successfully.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (not needed; test-only contract alignment)