### PR TITLE
🛠 Update workflow actions for Node.js 24

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,10 +9,10 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
 

--- a/.github/workflows/CLI_SMOKE.yml
+++ b/.github/workflows/CLI_SMOKE.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
 
@@ -34,7 +34,7 @@ jobs:
         run: node scripts/ci/pack-cli-tarball.mjs
 
       - name: Upload CLI tarball
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cli-tarball
           path: ${{ steps.pack.outputs.path }}
@@ -56,15 +56,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
 
       - name: Download CLI tarball
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: cli-tarball
           path: .tmp

--- a/.github/workflows/CODEQL.yml
+++ b/.github/workflows/CODEQL.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/E2E.yml
+++ b/.github/workflows/E2E.yml
@@ -11,10 +11,10 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'chore/release-v')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
 

--- a/.github/workflows/RELEASE.yml
+++ b/.github/workflows/RELEASE.yml
@@ -17,10 +17,10 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
@@ -49,14 +49,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Extract version from tag
         id: version
         run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
@@ -94,24 +94,24 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Extract version from tag
         id: version
         run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
@@ -128,7 +128,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: digest-${{ strategy.job-index }}
           path: /tmp/digests/*
@@ -144,17 +144,17 @@ jobs:
         run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: digest-*
           path: /tmp/digests
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -174,14 +174,14 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Extract version from tag
         id: version
         run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
 

--- a/.github/workflows/RELEASE_PR.yml
+++ b/.github/workflows/RELEASE_PR.yml
@@ -25,13 +25,13 @@ jobs:
 
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: main
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
 


### PR DESCRIPTION
## :dart: Goal
- Remove GitHub Actions Node.js 20 deprecation warnings before the runner fallback is retired.
- Keep this repository-only workflow maintenance out of product release notes.

## :hammer_and_wrench: Core Changes
- Upgrade checkout and setup-node to v7 across CI, E2E, CLI smoke, CodeQL, release PR, and release workflows.
- Upgrade artifact upload to v7 and artifact download to v8.
- Upgrade Docker setup-buildx and login to v4, and build-push to v7.

## :brain: Key Decisions
- Use the current official major tags, all of which declare the Node.js 24 action runtime.
- Preserve every existing workflow input and command because the updated majors remain compatible with the configurations used here.
- Release impact is none: no npm/Docker artifact, application runtime, public API, CLI, or MCP behavior changes.
- Expected release version: none. Tag plan: none.

## :test_tube: Verification Guide
### How to verify
1. `docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint:latest -shellcheck= -pyflakes=`
2. `corepack pnpm@10.25.0 check:encoding`
3. Confirm required PR CI and CodeQL pass.
4. Dispatch `CLI_SMOKE.yml` on `chore/update-actions-node24` and confirm packaging plus macOS, Ubuntu, and Windows npx smoke jobs pass.

### Expected result
- Workflow syntax and expressions validate without errors.
- Repository encoding validation passes.
- Required PR checks pass.
- Manual CLI smoke validates the upgraded checkout, setup-node, upload, and download actions.

## :white_check_mark: Checklist
- [x] Actionlint completed
- [x] Encoding check completed
- [x] Required PR CI completed
- [x] Manual CLI_SMOKE completed
- [x] Documentation updated (not needed; workflow references only)
