### PR TITLE
🐛 Patch vulnerable deepmerge-ts dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "pnpm": {
     "overrides": {
       "@hono/node-server": "2.0.11",
+      "deepmerge-ts": "8.0.0",
       "esbuild": "0.28.1",
       "seroval": "1.5.6"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,7 @@ catalogs:
 
 overrides:
   '@hono/node-server': 2.0.11
+  deepmerge-ts: 8.0.0
   esbuild: 0.28.1
   seroval: 1.5.6
 
@@ -3351,8 +3352,8 @@ packages:
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
-  deepmerge-ts@7.1.5:
-    resolution: {integrity: sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==}
+  deepmerge-ts@8.0.0:
+    resolution: {integrity: sha512-ICNjaP0ML+eSdEpJYQC46XiAn/UjAdwbEl0dE8p85ZTeNDinN4Kd4+9jS4OSAuH7st6eC7rQhsqTF5zIDaUm2g==}
     engines: {node: '>=16.0.0'}
 
   defu@6.1.7:
@@ -6993,7 +6994,7 @@ snapshots:
   '@prisma/config@6.19.3':
     dependencies:
       c12: 3.1.0
-      deepmerge-ts: 7.1.5
+      deepmerge-ts: 8.0.0
       effect: 3.21.0
       empathic: 2.0.0
     transitivePeerDependencies:
@@ -8716,7 +8717,7 @@ snapshots:
     dependencies:
       character-entities: 2.0.2
 
-  deepmerge-ts@7.1.5: {}
+  deepmerge-ts@8.0.0: {}
 
   defu@6.1.7: {}
 


### PR DESCRIPTION
## :dart: Goal
- Patch the high-severity `deepmerge-ts` vulnerability GHSA-ggr8-5vv4-36mx / CVE-2026-40345.
- The vulnerable `7.1.5` release can exhaust the stack while merging recursive object graphs.

## :hammer_and_wrench: Core Changes
- Add a root pnpm override for `deepmerge-ts@8.0.0`.
- Refresh `pnpm-lock.yaml` so Prisma's transitive dependency resolves to the patched release.

## :brain: Key Decisions
- `@prisma/config@6.19.3` pins `deepmerge-ts@7.1.5` exactly, so an override is required until the upstream dependency range changes.
- Keep this as an isolated dependency-security patch; the application has no direct `deepmerge-ts` imports or API changes.
- Use the first patched upstream release, `8.0.0`, and validate Prisma generation, migrations, and the full quality suite before merging.

## :test_tube: Verification Guide
### How to verify
1. Run `pnpm install --frozen-lockfile --ignore-scripts`.
2. Run `pnpm lint`, `pnpm type-check`, `pnpm test:ci`, and `pnpm build`.
3. Run `pnpm audit --prod --json` and confirm the dependency tree resolves `deepmerge-ts@8.0.0`.

### Expected result
- Install, lint, type-check, tests, and build pass.
- All 914 CI tests pass.
- Prisma generation and all 20 migrations pass against a temporary database.
- Production audit reports 0 high and 0 critical vulnerabilities.
- Prisma's dependency path resolves to `deepmerge-ts@8.0.0`.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed) - no documentation changes needed