### PR TITLE
✅ Refresh graph E2E assertion

### DIFF
--- a/tests/e2e/production-routes.spec.ts
+++ b/tests/e2e/production-routes.spec.ts
@@ -145,10 +145,10 @@ test('production graph chunks render after a direct hard refresh', async ({ page
 
     await page.goto('/graph');
     await expect(page.getByRole('heading', { name: 'Knowledge Graph' })).toBeVisible();
-    await expect(page.getByText(/0 linked notes.*0 connections/)).toBeVisible();
+    await expect(page.getByText('0 notes · 0 areas · 0 connections')).toBeVisible();
 
     await page.reload();
     await expect(page.getByRole('heading', { name: 'Knowledge Graph' })).toBeVisible();
-    await expect(page.getByText(/0 linked notes.*0 connections/)).toBeVisible();
+    await expect(page.getByText('0 notes · 0 areas · 0 connections')).toBeVisible();
     expect(runtimeErrors).toEqual([]);
 });


### PR DESCRIPTION
## :dart: Goal
Keep the production graph smoke test aligned with the current graph page summary.

## :hammer_and_wrench: Core Changes
- Update the stale graph summary expectation used by the direct-refresh E2E test.
- No runtime or release artifact changes.

## :brain: Key Decisions
- Assert the user-visible empty graph summary rendered by the current page instead of the removed legacy wording.
- Keep this maintenance-only change separate from the version bump PR.

## :test_tube: Verification Guide
### How to verify
1. Run `pnpm exec playwright test tests/e2e/production-routes.spec.ts --grep "production graph chunks render"`.
2. Open the production graph route and reload it directly.

### Expected result
- The graph page loads after a direct refresh and displays `0 notes · 0 areas · 0 connections` in the empty state.

## :white_check_mark: Checklist
- [ ] Lint completed
- [ ] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)