### PR TITLE
✅ Make graph E2E summary assertion data-aware

### DIFF
--- a/tests/e2e/production-routes.spec.ts
+++ b/tests/e2e/production-routes.spec.ts
@@ -145,10 +145,10 @@ test('production graph chunks render after a direct hard refresh', async ({ page
 
     await page.goto('/graph');
     await expect(page.getByRole('heading', { name: 'Knowledge Graph' })).toBeVisible();
-    await expect(page.getByText('0 notes · 0 areas · 0 connections')).toBeVisible();
+    await expect(page.getByText(/^\d+ notes · \d+ connections(?: · \d+ areas)?$/)).toBeVisible();
 
     await page.reload();
     await expect(page.getByRole('heading', { name: 'Knowledge Graph' })).toBeVisible();
-    await expect(page.getByText('0 notes · 0 areas · 0 connections')).toBeVisible();
+    await expect(page.getByText(/^\d+ notes · \d+ connections(?: · \d+ areas)?$/)).toBeVisible();
     expect(runtimeErrors).toEqual([]);
 });


### PR DESCRIPTION
## :dart: Goal
Make the production graph smoke test stable when earlier scenarios have created notes.

## :hammer_and_wrench: Core Changes
- Match the graph summary format without assuming a fixed note, connection, or area count.
- Keep the change limited to the production E2E assertion.

## :brain: Key Decisions
- The production route suite shares its test database across scenarios, so the graph test must validate the rendered summary shape rather than a zero-data fixture.
- Keep this test-only maintenance separate from the release version bump.

## :test_tube: Verification Guide
### How to verify
1. Run `pnpm exec playwright test tests/e2e/production-routes.spec.ts`.
2. Confirm the graph route loads and reloads after the preceding note, diagram, and math scenarios.

### Expected result
- All production route tests pass and the graph summary matches the current `notes · connections · areas` format for any seeded counts.

## :white_check_mark: Checklist
- [ ] Lint completed
- [ ] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)