### PR TITLE
🐛 Preserve legacy table cell content

### DIFF
--- a/packages/server/src/modules/blocknote.ts
+++ b/packages/server/src/modules/blocknote.ts
@@ -19,11 +19,13 @@ interface BlockNoteInline {
     styles?: Record<string, unknown>;
 }
 
-interface BlockNoteTableCell {
+interface ModernBlockNoteTableCell {
     type: 'tableCell';
     props?: Record<string, unknown>;
     content?: BlockNoteInline[];
 }
+
+type BlockNoteTableCell = BlockNoteInline[] | ModernBlockNoteTableCell;
 
 interface BlockNoteTableRow {
     cells?: BlockNoteTableCell[];
@@ -170,10 +172,14 @@ function mapBlockContent(
         ...content,
         rows: content.rows?.map((row) => ({
             ...row,
-            cells: row.cells?.map((cell) => ({
-                ...cell,
-                content: cell.content?.map(mapInline),
-            })),
+            cells: row.cells?.map((cell) =>
+                Array.isArray(cell)
+                    ? cell.map(mapInline)
+                    : {
+                          ...cell,
+                          content: cell.content?.map(mapInline),
+                      },
+            ),
         })),
     };
 }
@@ -196,10 +202,18 @@ async function mapBlockContentAsync(
             (content.rows ?? []).map(async (row) => ({
                 ...row,
                 cells: await Promise.all(
-                    (row.cells ?? []).map(async (cell) => ({
-                        ...cell,
-                        content: cell.content ? (await Promise.all(cell.content.map(mapInline))).flat() : cell.content,
-                    })),
+                    (row.cells ?? []).map(async (cell) => {
+                        if (Array.isArray(cell)) {
+                            return (await Promise.all(cell.map(mapInline))).flat();
+                        }
+
+                        return {
+                            ...cell,
+                            content: cell.content
+                                ? (await Promise.all(cell.content.map(mapInline))).flat()
+                                : cell.content,
+                        };
+                    }),
                 ),
             })),
         ),
@@ -220,7 +234,7 @@ function visitBlockContent(content: BlockNoteContent | undefined, visitInline: (
 
     for (const row of content.rows ?? []) {
         for (const cell of row.cells ?? []) {
-            for (const inline of cell.content ?? []) {
+            for (const inline of Array.isArray(cell) ? cell : (cell.content ?? [])) {
                 visitInline(inline);
             }
         }

--- a/packages/server/test/blocknote.test.ts
+++ b/packages/server/test/blocknote.test.ts
@@ -181,6 +181,61 @@ test('blocksToMarkdown does not drop the whole note when table blocks are presen
     assert.match(markdown, /Summary/);
 });
 
+test('blocksToMarkdown preserves legacy array table cells', async () => {
+    const content = JSON.stringify([
+        {
+            id: 'heading-1',
+            type: 'heading',
+            props: {
+                backgroundColor: 'default',
+                textColor: 'default',
+                textAlignment: 'left',
+                level: 2,
+            },
+            content: [{ type: 'text', text: 'Legacy table', styles: {} }],
+            children: [],
+        },
+        {
+            id: 'table-1',
+            type: 'table',
+            props: {
+                textColor: 'default',
+                backgroundColor: 'default',
+            },
+            content: {
+                type: 'tableContent',
+                rows: [
+                    {
+                        cells: [
+                            [{ type: 'text', text: 'Name', styles: {} }],
+                            [{ type: 'text', text: 'Value', styles: {} }],
+                        ],
+                    },
+                    {
+                        cells: [
+                            [{ type: 'text', text: 'Project', styles: {} }],
+                            [
+                                { type: 'tag', props: { id: '12', tag: '@project' } },
+                                { type: 'text', text: ' ', styles: {} },
+                                { type: 'reference', props: { id: '44', title: 'Reference Note' } },
+                            ],
+                        ],
+                    },
+                ],
+            },
+            children: [],
+        },
+    ]);
+
+    const markdown = await blocksToMarkdown(content);
+
+    assert.match(markdown, /Legacy table/);
+    assert.match(markdown, /Name/);
+    assert.match(markdown, /Value/);
+    assert.match(markdown, /\[@project\]/);
+    assert.match(markdown, /\[\[Reference Note\]\]\(note:44\)/);
+});
+
 test('blocksToMarkdown serializes tags using explicit bracket syntax', async () => {
     const content = JSON.stringify([
         {
@@ -1218,6 +1273,44 @@ test('extractTagIdsFromContentJson collects tags from table cells', () => {
     );
 
     assert.deepEqual(tagIds.sort(), ['12', '34']);
+});
+
+test('legacy array table cells remain visible to metadata extraction', () => {
+    const content = JSON.stringify([
+        {
+            id: 'table-1',
+            type: 'table',
+            content: {
+                type: 'tableContent',
+                rows: [
+                    {
+                        cells: [
+                            [
+                                {
+                                    type: 'tag',
+                                    props: {
+                                        id: '12',
+                                        tag: '@project',
+                                    },
+                                },
+                                {
+                                    type: 'reference',
+                                    props: {
+                                        id: '44',
+                                        title: 'Reference Note',
+                                    },
+                                },
+                            ],
+                        ],
+                    },
+                ],
+            },
+            children: [],
+        },
+    ]);
+
+    assert.deepEqual(extractTagIdsFromContentJson(content), ['12']);
+    assert.equal(countReferenceInlinesFromContentJson(content), 1);
 });
 
 test('countReferenceInlinesFromContentJson counts structured note references', () => {


### PR DESCRIPTION
## :dart: Goal
Preserve legacy BlockNote table cells represented as inline arrays during Markdown export and metadata extraction so table content, tags, and references are not lost.

## :hammer_and_wrench: Core Changes
- Accept both modern `tableCell` objects and legacy inline-array cells.
- Apply custom inline mapping in synchronous and asynchronous table-cell conversion paths.
- Traverse both cell shapes for tag and reference metadata extraction.
- Add regression coverage for Markdown export and metadata extraction.

## :brain: Key Decisions
- Keep modern `tableCell` handling unchanged and branch only when a cell is an array.
- Handle the compatibility shape at the shared BlockNote conversion boundary without migrating stored content.

## :test_tube: Verification Guide
### How to verify
1. `pnpm --filter @ocean-brain/server exec tsx --tsconfig tsconfig.json --test test/blocknote.test.ts`
2. `pnpm check:encoding`
3. `pnpm lint`
4. `pnpm type-check`
5. `pnpm test:ci`
6. `pnpm build`

### Expected result
- All commands pass.
- Targeted BlockNote tests: 71 passed.
- Full CI suites: CLI 32 passed, client 459 passed, server 442 passed.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (not needed for this code/test change)
- [x] Documentation change follows `docs/process/DOCUMENTATION_CONVENTION.md` (not applicable)