### PR TITLE
🐛 Improve portable MCP setup

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2,7 +2,7 @@
 npm package README for the public ocean-brain CLI.
 
 Keep the product overview in the repository README. This file owns the public
-`serve` and `mcp` command interface, including npx auth and storage behavior.
+`serve` and `mcp` command interfaces, including npx auth and storage behavior.
 -->
 
 # ocean-brain CLI
@@ -69,7 +69,7 @@ For a long-lived installation, replace `ocean-brain` in the commands with an exa
 
 ## `mcp`
 
-The `mcp` command starts a stdio MCP server that forwards tool calls to an existing Ocean Brain instance. It does not start the web app.
+The `mcp` command starts the built-in stdio MCP adapter that forwards tool calls to an existing Ocean Brain instance. It does not start the web app.
 
 The MCP tools can search and read notes, query tags and properties, create notes, make targeted Markdown or metadata edits, and move notes to Trash.
 
@@ -87,7 +87,7 @@ First enable MCP access under `Settings > MCP`, issue a token, and save it to a 
         "--server",
         "http://localhost:6683",
         "--token-file",
-        "/absolute/path/to/ocean-brain-mcp-token.txt"
+        "/absolute/path/to/ocean-brain/mcp-token"
       ]
     }
   }
@@ -103,6 +103,8 @@ Set `--server` to the Ocean Brain URL reachable from the machine running the MCP
 | `-s, --server <url>` | Ocean Brain server URL; defaults to `http://localhost:6683` |
 | `--token-file <path>` | Read the bearer token from a file; takes precedence over `--token` |
 | `--token <token>` | Direct bearer-token fallback |
+
+The built-in adapter expands token-file paths that begin with `~`, `$HOME`, `${HOME}`, `%USERPROFILE%`, or `%HOME%`. This keeps copied JSON configurations portable even when the MCP client does not run arguments through a shell. `Settings > MCP` can generate either macOS/Linux shell commands or Windows PowerShell commands.
 
 Prefer `--token-file` so the token is not stored directly in client configuration. Ocean Brain keeps one active MCP token; rotating or revoking it immediately invalidates the previous token. For a long-lived MCP setup, pin an npm package version compatible with the requirement shown in `Settings > MCP`.
 

--- a/packages/cli/src/mcp-auth.ts
+++ b/packages/cli/src/mcp-auth.ts
@@ -1,15 +1,28 @@
 import fs from 'fs';
+import os from 'os';
 
 export interface McpAuthOptionsInput {
     token?: string;
     tokenFile?: string;
 }
 
+export const expandMcpTokenFilePath = (
+    tokenFilePath: string,
+    homeDirectory = os.homedir()
+) => {
+    return tokenFilePath.replace(
+        /^(?:~|\$HOME|\$\{HOME\}|%USERPROFILE%|%HOME%)(?=$|[\\/])/i,
+        homeDirectory
+    );
+};
+
 export const resolveMcpBearerToken = (
-    options: McpAuthOptionsInput
+    options: McpAuthOptionsInput,
+    homeDirectory = os.homedir()
 ) => {
     if (options.tokenFile) {
-        const token = fs.readFileSync(options.tokenFile, 'utf-8').trim();
+        const tokenFilePath = expandMcpTokenFilePath(options.tokenFile, homeDirectory);
+        const token = fs.readFileSync(tokenFilePath, 'utf-8').trim();
         return token || undefined;
     }
 

--- a/packages/cli/test/mcp-auth.test.ts
+++ b/packages/cli/test/mcp-auth.test.ts
@@ -7,7 +7,7 @@ import assert from 'node:assert/strict';
 import { resolveMcpBearerToken } from '../src/mcp-auth.js';
 
 const writeTempToken = (value: string) => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ocean-brain-mcp-token-'));
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ocean-brain-token-'));
     const tokenFile = path.join(dir, 'token.txt');
     fs.writeFileSync(tokenFile, `${value}\n`, 'utf-8');
     return tokenFile;
@@ -25,4 +25,18 @@ test('resolveMcpBearerToken prefers token-file over direct token', () => {
 test('resolveMcpBearerToken falls back to direct token', () => {
     const token = resolveMcpBearerToken({ token: 'from-option' });
     assert.equal(token, 'from-option');
+});
+
+test('resolveMcpBearerToken expands portable home-directory token paths', () => {
+    const tokenFile = writeTempToken('from-home-path');
+    const homeDirectory = path.dirname(tokenFile);
+    const tokenFileName = path.basename(tokenFile);
+
+    for (const homePrefix of ['~', '$HOME', '${HOME}', '%USERPROFILE%', '%HOME%']) {
+        const token = resolveMcpBearerToken(
+            { tokenFile: `${homePrefix}/${tokenFileName}` },
+            homeDirectory
+        );
+        assert.equal(token, 'from-home-path');
+    }
 });

--- a/packages/client/src/pages/setting/mcp.spec.tsx
+++ b/packages/client/src/pages/setting/mcp.spec.tsx
@@ -81,6 +81,48 @@ describe('<McpSetting />', () => {
         expect(await screen.findByText('MCP compatibility 0.9.x')).toBeInTheDocument();
     });
 
+    it('uses the built-in ocean-brain MCP command for every client guide', async () => {
+        vi.mocked(mcpAdminApi.fetchMcpAdminStatus).mockResolvedValue(createMcpStatus());
+
+        renderPage();
+
+        expect(((await screen.findByLabelText('Codex setup')) as HTMLTextAreaElement).value).toContain(
+            'npx -y ocean-brain mcp',
+        );
+
+        await userEvent.click(screen.getByRole('radio', { name: 'Claude' }));
+        expect((screen.getByLabelText('Claude setup') as HTMLTextAreaElement).value).toContain(
+            'npx -y ocean-brain mcp',
+        );
+
+        await userEvent.click(screen.getByRole('radio', { name: 'JSON' }));
+        const jsonSetup = screen.getByLabelText('Token file and MCP JSON') as HTMLTextAreaElement;
+
+        expect(jsonSetup.value).toContain('"command": "npx"');
+        expect(jsonSetup.value).toContain('"ocean-brain",');
+        expect(jsonSetup.value).toContain('"mcp",');
+    });
+
+    it('generates a PowerShell setup for Windows clients', async () => {
+        vi.mocked(mcpAdminApi.fetchMcpAdminStatus).mockResolvedValue(createMcpStatus());
+
+        renderPage();
+
+        await userEvent.click(await screen.findByText('Connection options'));
+        await userEvent.click(screen.getByRole('radio', { name: 'Windows PowerShell' }));
+
+        const setup = screen.getByLabelText('Codex setup') as HTMLTextAreaElement;
+        expect(setup.value).toContain('New-Item -ItemType Directory -Force');
+        expect(setup.value).toContain("--token-file '$HOME\\.config\\ocean-brain\\mcp-token'");
+        expect(setup.value).toContain('codex mcp add ocean-brain -- cmd.exe /d /c npx -y ocean-brain mcp');
+
+        await userEvent.click(screen.getByRole('radio', { name: 'JSON' }));
+        const jsonSetup = screen.getByLabelText('Token file and MCP JSON') as HTMLTextAreaElement;
+        expect(jsonSetup.value).toContain('"command": "cmd.exe"');
+        expect(jsonSetup.value).toContain('"/c",');
+        expect(jsonSetup.value).toContain('"npx",');
+    });
+
     it('submits enabled toggle and refreshes status', async () => {
         vi.mocked(mcpAdminApi.fetchMcpAdminStatus).mockResolvedValue(createMcpStatus());
         vi.mocked(mcpAdminApi.setMcpEnabled).mockResolvedValue(createMcpStatus({ enabled: true }));

--- a/packages/client/src/pages/setting/mcp.tsx
+++ b/packages/client/src/pages/setting/mcp.tsx
@@ -18,8 +18,9 @@ import {
 const mcpAdminStatusQueryKey = ['mcp-admin', 'status'] as const;
 
 type ClientGuide = 'codex' | 'claude' | 'json';
+type SetupShell = 'posix' | 'powershell';
 
-const shellQuote = (value: string) => {
+const posixShellQuote = (value: string) => {
     if (/^[A-Za-z0-9_./:@$-]+$/.test(value)) {
         return value;
     }
@@ -27,37 +28,77 @@ const shellQuote = (value: string) => {
     return `'${value.replace(/'/g, "'\\''")}'`;
 };
 
-const defaultTokenFilePath = '$HOME/.config/ocean-brain/mcp-token';
+const powershellQuote = (value: string) => `'${value.replace(/'/g, "''")}'`;
 
-const createTokenFileCommand = (tokenFilePath: string, token: string) => {
-    const quotedPath = shellQuote(tokenFilePath);
+const defaultTokenFilePaths: Record<SetupShell, string> = {
+    posix: '$HOME/.config/ocean-brain/mcp-token',
+    powershell: '$HOME\\.config\\ocean-brain\\mcp-token',
+};
+
+const getDefaultSetupShell = (): SetupShell => {
+    return typeof navigator !== 'undefined' && /Windows/i.test(navigator.userAgent) ? 'powershell' : 'posix';
+};
+
+const createPowershellPathExpression = (tokenFilePath: string) => {
+    const homeRelativePath = tokenFilePath.match(/^\$HOME[\\/](.+)$/i)?.[1];
+    if (homeRelativePath) {
+        return `Join-Path $HOME ${powershellQuote(homeRelativePath)}`;
+    }
+
+    return powershellQuote(tokenFilePath);
+};
+
+const createTokenFileCommand = (setupShell: SetupShell, tokenFilePath: string, token: string) => {
+    if (setupShell === 'powershell') {
+        return [
+            `$tokenPath = ${createPowershellPathExpression(tokenFilePath)}`,
+            'New-Item -ItemType Directory -Force -Path (Split-Path -Parent $tokenPath) | Out-Null',
+            `Set-Content -Path $tokenPath -Value ${powershellQuote(token)} -NoNewline -Encoding utf8`,
+        ].join('\n');
+    }
+
+    const quotedPath = posixShellQuote(tokenFilePath);
 
     return [
         `mkdir -p "$(dirname ${quotedPath})"`,
-        `printf '%s' ${shellQuote(token)} > ${quotedPath}`,
+        `printf '%s' ${posixShellQuote(token)} > ${quotedPath}`,
         `chmod 600 ${quotedPath}`,
     ].join('\n');
 };
 
-const buildOceanBrainMcpArgs = (serverUrl: string, tokenFilePath: string) => {
-    return `npx -y ocean-brain mcp --server ${shellQuote(serverUrl)} --token-file ${shellQuote(tokenFilePath)}`;
+const buildOceanBrainMcpArgs = (setupShell: SetupShell, serverUrl: string, tokenFilePath: string) => {
+    const quote = setupShell === 'powershell' ? powershellQuote : posixShellQuote;
+    const commandPrefix = setupShell === 'powershell' ? 'cmd.exe /d /c ' : '';
+    return `${commandPrefix}npx -y ocean-brain mcp --server ${quote(serverUrl)} --token-file ${quote(tokenFilePath)}`;
 };
 
-const createCodexCommand = (serverUrl: string, tokenFilePath: string) => {
-    return `codex mcp add ocean-brain -- ${buildOceanBrainMcpArgs(serverUrl, tokenFilePath)}`;
+const createCodexCommand = (setupShell: SetupShell, serverUrl: string, tokenFilePath: string) => {
+    return `codex mcp add ocean-brain -- ${buildOceanBrainMcpArgs(setupShell, serverUrl, tokenFilePath)}`;
 };
 
-const createClaudeCommand = (serverUrl: string, tokenFilePath: string) => {
-    return `claude mcp add --transport stdio ocean-brain -- ${buildOceanBrainMcpArgs(serverUrl, tokenFilePath)}`;
+const createClaudeCommand = (setupShell: SetupShell, serverUrl: string, tokenFilePath: string) => {
+    return `claude mcp add --transport stdio ocean-brain -- ${buildOceanBrainMcpArgs(setupShell, serverUrl, tokenFilePath)}`;
 };
 
-const createMcpJsonSnippet = (serverUrl: string, tokenFilePath: string) => {
+const createMcpJsonSnippet = (setupShell: SetupShell, serverUrl: string, tokenFilePath: string) => {
+    const command = setupShell === 'powershell' ? 'cmd.exe' : 'npx';
+    const args = [
+        ...(setupShell === 'powershell' ? ['/d', '/c', 'npx'] : []),
+        '-y',
+        'ocean-brain',
+        'mcp',
+        '--server',
+        serverUrl,
+        '--token-file',
+        tokenFilePath,
+    ];
+
     return JSON.stringify(
         {
             mcpServers: {
                 'ocean-brain': {
-                    command: 'npx',
-                    args: ['-y', 'ocean-brain', 'mcp', '--server', serverUrl, '--token-file', tokenFilePath],
+                    command,
+                    args,
                 },
             },
         },
@@ -66,18 +107,24 @@ const createMcpJsonSnippet = (serverUrl: string, tokenFilePath: string) => {
     );
 };
 
-const createConnectionOutput = (clientGuide: ClientGuide, serverUrl: string, tokenFilePath: string, token: string) => {
+const createConnectionOutput = (
+    clientGuide: ClientGuide,
+    setupShell: SetupShell,
+    serverUrl: string,
+    tokenFilePath: string,
+    token: string,
+) => {
     const connectCommand =
         clientGuide === 'codex'
-            ? createCodexCommand(serverUrl, tokenFilePath)
+            ? createCodexCommand(setupShell, serverUrl, tokenFilePath)
             : clientGuide === 'claude'
-              ? createClaudeCommand(serverUrl, tokenFilePath)
-              : createMcpJsonSnippet(serverUrl, tokenFilePath);
+              ? createClaudeCommand(setupShell, serverUrl, tokenFilePath)
+              : createMcpJsonSnippet(setupShell, serverUrl, tokenFilePath);
 
     if (clientGuide === 'json') {
         return [
             `# 1. Create the token file`,
-            createTokenFileCommand(tokenFilePath, token),
+            createTokenFileCommand(setupShell, tokenFilePath, token),
             '',
             '# 2. Add this MCP JSON',
             connectCommand,
@@ -86,7 +133,7 @@ const createConnectionOutput = (clientGuide: ClientGuide, serverUrl: string, tok
 
     return [
         `# 1. Create the token file`,
-        createTokenFileCommand(tokenFilePath, token),
+        createTokenFileCommand(setupShell, tokenFilePath, token),
         '',
         `# 2. Add Ocean Brain to ${clientGuide}`,
         connectCommand,
@@ -114,7 +161,8 @@ const McpSetting = () => {
 
     const [serverUrl, setServerUrl] = useState(() => window.location.origin);
     const [issuedToken, setIssuedToken] = useState('');
-    const [tokenFilePath, setTokenFilePath] = useState(defaultTokenFilePath);
+    const [setupShell, setSetupShell] = useState<SetupShell>(getDefaultSetupShell);
+    const [tokenFilePath, setTokenFilePath] = useState(() => defaultTokenFilePaths[getDefaultSetupShell()]);
     const [clientGuide, setClientGuide] = useState<ClientGuide>('codex');
 
     const { data: status, isLoading } = useQuery({
@@ -151,12 +199,18 @@ const McpSetting = () => {
     const enabled = status?.enabled ?? false;
     const hasActiveToken = status?.hasActiveToken ?? false;
     const canToggle = !isLoading && !setEnabledMutation.isPending;
-    const normalizedTokenFilePath = tokenFilePath.trim() || defaultTokenFilePath;
+    const normalizedTokenFilePath = tokenFilePath.trim() || defaultTokenFilePaths[setupShell];
     const mcpCompatibilityLabel = getMcpCompatibilityLabel(status?.server.mcpVersionRequirement);
     const tokenStatusText = hasActiveToken ? '1 active token' : 'No active token';
     const outputLabel = clientGuide === 'json' ? 'Token file and MCP JSON' : `${clientGuideLabel[clientGuide]} setup`;
     const tokenValue = issuedToken || 'PASTE_TOKEN_HERE';
-    const connectionOutput = createConnectionOutput(clientGuide, serverUrl, normalizedTokenFilePath, tokenValue);
+    const connectionOutput = createConnectionOutput(
+        clientGuide,
+        setupShell,
+        serverUrl,
+        normalizedTokenFilePath,
+        tokenValue,
+    );
     const copyLabel = 'Copy setup';
 
     const sectionHeadingClassName = 'text-fg-tertiary';
@@ -310,6 +364,32 @@ const McpSetting = () => {
                             </summary>
                             <div className="space-y-3 border-t border-border-subtle px-3 py-3">
                                 <div className={fieldGroupClassName}>
+                                    <Label className={fieldLabelClassName}>Setup shell</Label>
+                                    <ToggleGroup
+                                        type="single"
+                                        variant="quiet"
+                                        size="sm"
+                                        value={setupShell}
+                                        onValueChange={(value) => {
+                                            if (value !== 'posix' && value !== 'powershell') {
+                                                return;
+                                            }
+
+                                            setTokenFilePath((currentPath) =>
+                                                currentPath === defaultTokenFilePaths[setupShell]
+                                                    ? defaultTokenFilePaths[value]
+                                                    : currentPath,
+                                            );
+                                            setSetupShell(value);
+                                        }}
+                                        aria-label="Setup shell"
+                                    >
+                                        <ToggleGroupItem value="posix">macOS / Linux</ToggleGroupItem>
+                                        <ToggleGroupItem value="powershell">Windows PowerShell</ToggleGroupItem>
+                                    </ToggleGroup>
+                                </div>
+
+                                <div className={fieldGroupClassName}>
                                     <Label htmlFor="mcp-server-url" className={fieldLabelClassName}>
                                         Ocean Brain URL
                                     </Label>
@@ -326,7 +406,7 @@ const McpSetting = () => {
                                     </Label>
                                     <Input
                                         id="mcp-token-file-path"
-                                        placeholder="/absolute/path/to/ocean-brain-mcp-token.txt"
+                                        placeholder="/absolute/path/to/ocean-brain/mcp-token"
                                         value={tokenFilePath}
                                         onChange={(event) => setTokenFilePath(event.target.value)}
                                     />


### PR DESCRIPTION
## :dart: Goal
- Make copied built-in MCP setup commands portable across macOS, Linux, and native Windows clients.
- Keep this optional compatibility work independent from the Fastify server migration.

## :hammer_and_wrench: Core Changes
- Add macOS/Linux and Windows PowerShell setup output to Settings > MCP.
- Wrap Windows npx launches with cmd.exe and generate compatible generic MCP JSON.
- Expand portable token-file prefixes such as ~, $HOME, and %USERPROFILE% inside the CLI.
- Document and test the generated setup paths without changing the built-in ocean-brain mcp contract.

## :brain: Key Decisions
- Keep MCP embedded in the ocean-brain package; this PR does not add a standalone package or plugin.
- Preserve existing global-install and absolute-path setups unchanged.
- Ship this as a separate patch so the server runtime migration can be reviewed independently.

## :test_tube: Verification Guide
### How to verify
1. Run `pnpm lint` and `pnpm type-check`.
2. Run `pnpm --filter @ocean-brain/client exec vitest run src/pages/setting/mcp.spec.tsx`.
3. Run `pnpm --filter ocean-brain test:ci`.
4. Run `pnpm build && pnpm --filter ocean-brain build`.

### Expected result
- Lint and type-check pass.
- MCP settings tests pass 5/5 and CLI tests pass 33/33.
- Client, server, and CLI production builds pass.
- Existing POSIX output remains available; Windows output uses cmd.exe for npx execution.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)
- [x] Documentation change follows `docs/process/DOCUMENTATION_CONVENTION.md` (if applicable)
