### PR TITLE
📝 Improve README development setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ For a stable session secret, persistent volumes, open mode, exact version tags, 
 
 ## Development
 
-Source development uses Node.js `22.13+`, pnpm `10.25.0`, and a `packages/*` workspace. See [DEV_CONVENTION.md](./docs/process/DEV_CONVENTION.md) and [GIT_CONVENTION.md](./docs/process/GIT_CONVENTION.md) before making changes.
+Source development uses Node.js `22.13+`, pnpm `10.25.0`, and a `packages/*` workspace. Run `pnpm install` to set up dependencies, then `pnpm dev` to start the development server. See [DEV_CONVENTION.md](./docs/process/DEV_CONVENTION.md) and [GIT_CONVENTION.md](./docs/process/GIT_CONVENTION.md) before making changes.
 
 ## License
 


### PR DESCRIPTION
## :dart: Goal

Make the README development setup actionable for contributors. This maintainer PR supersedes #325 after the requested convention updates were not made.

## :hammer_and_wrench: Core Changes

- Document the initial `pnpm install` step.
- Document `pnpm dev` as the standard local development command.

## :brain: Key Decisions

- Keep the existing Node.js, pnpm, workspace, and convention links unchanged.
- Add only the missing setup and startup commands to the existing Development section.

## :test_tube: Verification Guide

### How to verify

1. Read the `Development` section in `README.md`.
2. Run `pnpm check:encoding`.
3. Run `pnpm install`, then `pnpm dev` in a local checkout.

### Expected result

- The README clearly explains how to install dependencies and start local development.
- Encoding validation passes and the development server starts successfully.

## :white_check_mark: Checklist

- [ ] Lint completed (README-only change; not run locally)
- [ ] Type-check completed (README-only change; not run locally)
- [ ] Tests completed (README-only change; not run locally)
- [x] Documentation updated
- [x] Documentation change follows `docs/process/DOCUMENTATION_CONVENTION.md`