### PR TITLE
📝 Document development authentication setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,15 @@ For a stable session secret, persistent volumes, open mode, exact version tags, 
 
 ## Development
 
-Source development uses Node.js `22.13+`, pnpm `10.25.0`, and a `packages/*` workspace. Run `pnpm install` to set up dependencies, then `pnpm dev` to start the development server. See [DEV_CONVENTION.md](./docs/process/DEV_CONVENTION.md) and [GIT_CONVENTION.md](./docs/process/GIT_CONVENTION.md) before making changes.
+Source development uses Node.js `22.13+`, pnpm `10.25.0`, and a `packages/*` workspace. Run `pnpm install` to set up dependencies, then start the development server in local-only open mode:
+
+```bash
+OCEAN_BRAIN_ALLOW_INSECURE_NO_AUTH=true \
+HOST=127.0.0.1 \
+pnpm dev
+```
+
+Use password mode instead when the development server must be reachable beyond your own machine. See [DEV_CONVENTION.md](./docs/process/DEV_CONVENTION.md) and [GIT_CONVENTION.md](./docs/process/GIT_CONVENTION.md) before making changes.
 
 ## License
 

--- a/docs/process/DEV_CONVENTION.md
+++ b/docs/process/DEV_CONVENTION.md
@@ -1,6 +1,6 @@
 # Ocean Brain Dev Convention
 
-Updated: 2026-08-19
+Updated: 2026-08-22
 
 ## 1. Base Environment
 - Node.js: `22.13+`
@@ -15,6 +15,16 @@ Updated: 2026-08-19
 - Server start: `pnpm start`
 - Core user-flow integration: `pnpm test:integration`
 - Full browser E2E: `pnpm test:e2e`
+
+The server requires an explicit authentication mode. For local-only development, start it in open mode with the loopback bind:
+
+```bash
+OCEAN_BRAIN_ALLOW_INSECURE_NO_AUTH=true \
+HOST=127.0.0.1 \
+pnpm dev
+```
+
+Use `OCEAN_BRAIN_PASSWORD` together with `OCEAN_BRAIN_SESSION_SECRET` instead when the server must be reachable beyond the local machine.
 
 Both browser test commands build the production app before starting Playwright.
 Install the local browser once with `pnpm exec playwright install chromium` after Playwright is installed or updated.


### PR DESCRIPTION
## :dart: Goal
- Fix the development onboarding gap where `pnpm dev` was documented without its required authentication configuration.
- Make the safe local development command explicit.

## :hammer_and_wrench: Core Changes
- Document local-only open mode with `OCEAN_BRAIN_ALLOW_INSECURE_NO_AUTH=true` and `HOST=127.0.0.1` in `README.md`.
- Add the same authentication requirement and command to `docs/process/DEV_CONVENTION.md`.

## :brain: Key Decisions
- Recommend explicit open mode only for loopback development.
- Keep password mode as the guidance for servers reachable beyond the local machine.
- Update the process document date because its meaning changed.

## :test_tube: Verification Guide
### How to verify
1. Run `pnpm check:encoding`.
2. Run `OCEAN_BRAIN_ALLOW_INSECURE_NO_AUTH=true HOST=127.0.0.1 pnpm dev`.
3. Open `http://127.0.0.1:6683`.

### Expected result
- The development server starts without the auth-mode resolution error and is bound to the loopback interface.

## :white_check_mark: Checklist
- [ ] Lint completed
- [ ] Type-check completed
- [ ] Tests completed
- [x] Documentation updated
- [x] Documentation change follows `docs/process/DOCUMENTATION_CONVENTION.md`