### PR TITLE
🛠 Prevent false client bundle budget failures

### DIFF
--- a/packages/client/build/client-build-environment.spec.ts
+++ b/packages/client/build/client-build-environment.spec.ts
@@ -1,0 +1,38 @@
+// @vitest-environment node
+
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { resolveConfig } from 'vite';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const clientRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const originalNodeEnv = process.env.NODE_ENV;
+
+afterEach(() => {
+    if (originalNodeEnv === undefined) {
+        delete process.env.NODE_ENV;
+        return;
+    }
+
+    process.env.NODE_ENV = originalNodeEnv;
+});
+
+describe('client build environment', () => {
+    it('resolves a production build when NODE_ENV is inherited as development', async () => {
+        process.env.NODE_ENV = 'development';
+
+        const config = await resolveConfig(
+            {
+                configFile: path.resolve(clientRoot, 'vite.config.ts'),
+                logLevel: 'silent',
+                root: clientRoot,
+            },
+            'build',
+            'production',
+            'production',
+        );
+
+        expect(config.isProduction).toBe(true);
+        expect(process.env.NODE_ENV).toBe('production');
+    });
+});

--- a/packages/client/build/client-bundling.ts
+++ b/packages/client/build/client-bundling.ts
@@ -6,15 +6,17 @@ type RollupOptions = NonNullable<NonNullable<UserConfig['build']>['rollupOptions
 /**
  * Client bundle safety contract:
  *
- * 1. Keep route-preload as an independent entry. A normal module script in
+ * 1. Force production NODE_ENV during builds. Vite preserves inherited values,
+ *    which can otherwise select React's development runtime.
+ * 2. Keep route-preload as an independent entry. A normal module script in
  *    index.html is merged into the app entry and cannot start route downloads
  *    early enough for cold note URLs.
- * 2. Manually group only dependencies owned exclusively by the Note route.
+ * 3. Manually group only dependencies owned exclusively by the Note route.
  *    Object-form manualChunks pulls React and other transitive dependencies into
  *    note chunks, which makes the home entry load them again.
- * 3. Keep note-runtime together. Splitting its editor/markup/support packages
+ * 4. Keep note-runtime together. Splitting its editor/markup/support packages
  *    produced circular chunks and production-only initialization risk.
- * 4. Do not silence the remaining note-runtime size warning. It is route-only;
+ * 5. Do not silence the remaining note-runtime size warning. It is route-only;
  *    scripts/ci/check-client-bundle.mjs enforces the actual initial-load budget.
  *
  * Production behavior is guarded by the bundle check and
@@ -94,6 +96,15 @@ const createNoteOnlyManualChunks = () => {
         return owners.size === 1 && owner?.endsWith(NOTE_PAGE_MODULE_SUFFIX) ? getNoteChunkName(id) : undefined;
     };
 };
+
+export const createProductionBuildEnvironmentPlugin = (): Plugin => ({
+    name: 'ocean-brain-production-build-environment',
+    config(_config, { command }) {
+        if (command === 'build') {
+            process.env.NODE_ENV = 'production';
+        }
+    },
+});
 
 export const createRoutePreloadPlugin = (): Plugin => {
     let command: 'build' | 'serve' = 'serve';

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -3,7 +3,11 @@ import react from '@vitejs/plugin-react';
 import path from 'path';
 import { defineConfig } from 'vitest/config';
 
-import { createClientRollupOptions, createRoutePreloadPlugin } from './build/client-bundling';
+import {
+    createClientRollupOptions,
+    createProductionBuildEnvironmentPlugin,
+    createRoutePreloadPlugin,
+} from './build/client-bundling';
 import { createDevAuthGateMiddleware } from './src/dev-auth-gate';
 
 const backendOrigin = process.env.OCEAN_BRAIN_DEV_SERVER_URL || 'http://localhost:6683';
@@ -25,6 +29,7 @@ const searchAdminAdapterPath = isLocalOnlyDemoBuild
 // https://vitejs.dev/config/
 export default defineConfig({
     plugins: [
+        createProductionBuildEnvironmentPlugin(),
         createRoutePreloadPlugin(),
         react(),
         tailwindcss(),


### PR DESCRIPTION
## :dart: Goal
- Prevent inherited `NODE_ENV=development` values from making production client builds include the React development runtime.
- Stop valid changes from reporting false client bundle budget failures in shared development environments.

## :hammer_and_wrench: Core Changes
- Force `NODE_ENV=production` only while Vite resolves a client build.
- Keep development server and test environment behavior unchanged.
- Add a regression test for a build started with an inherited development environment.

## :brain: Key Decisions
- Apply the guard as the first Vite config plugin so production conditions are established before other build plugins run.
- Keep the fix dependency-free and scoped to the existing client bundle safety contract.
- Preserve the route-only large chunk warning; the initial-load budget check remains the build gate.

## :test_tube: Verification Guide
### How to verify
1. Run `NODE_ENV=development pnpm build`.
2. Run `pnpm --filter @ocean-brain/client test:ci`.
3. Run `pnpm --filter @ocean-brain/client lint`, `pnpm --filter @ocean-brain/client type-check`, and `pnpm check:encoding`.

### Expected result
- The full build exits successfully and reports an initial client bundle of 248.26 KiB gzip against the 300 KiB budget.
- All 101 client test files and 462 tests pass.
- Lint, type-check, and encoding checks pass.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (not needed; the build contract and regression test describe the behavior)
- [x] Documentation change follows `docs/process/DOCUMENTATION_CONVENTION.md` (not applicable)