### PR TITLE
🐛 Fix server build path aliases

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -7,7 +7,7 @@
     "scripts": {
         "dev": "prisma migrate deploy && prisma generate && tsx watch --clear-screen=false --exclude \"../client/node_modules/**\" dev/main.ts",
         "dev:server": "prisma migrate deploy && prisma generate && node --watch --import tsx src/main.ts",
-        "build": "prisma generate && tsup && tsc-alias",
+        "build": "prisma generate && tsup && tsc-alias -p tsconfig.alias.json && node ../../scripts/ci/check-server-build-imports.mjs",
         "start": "node dist/start.js",
         "lint": "biome check .",
         "format": "biome check --write .",

--- a/packages/server/tsconfig.alias.json
+++ b/packages/server/tsconfig.alias.json
@@ -1,0 +1,8 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "rootDir": "./src"
+    },
+    "include": ["src/**/*"],
+    "exclude": ["src/**/*.test.ts"]
+}

--- a/scripts/ci/check-server-build-imports.mjs
+++ b/scripts/ci/check-server-build-imports.mjs
@@ -1,0 +1,28 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const distDirectory = path.resolve(repositoryRoot, 'packages/server/dist');
+const unresolvedAliasPattern = /(?:\bfrom\s*|\bimport\s*(?:\(\s*)?|\brequire\s*\(\s*)['"]~\//;
+
+const findJavaScriptFiles = (directory) => fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = path.join(directory, entry.name);
+
+    if (entry.isDirectory()) {
+        return findJavaScriptFiles(entryPath);
+    }
+
+    return /\.[cm]?js$/.test(entry.name) ? [entryPath] : [];
+});
+
+const unresolvedFiles = findJavaScriptFiles(distDirectory)
+    .filter((filePath) => unresolvedAliasPattern.test(fs.readFileSync(filePath, 'utf8')))
+    .map((filePath) => path.relative(repositoryRoot, filePath))
+    .sort();
+
+if (unresolvedFiles.length > 0) {
+    throw new Error(`Server build contains unresolved path aliases:\n${unresolvedFiles.join('\n')}`);
+}
+
+console.log('Server build path alias check passed.');


### PR DESCRIPTION
## :dart: Goal
- Restore production server startup after the TypeScript 7 upgrade left `~/` imports unresolved in compiled server files.
- Unblock the paused 0.13.1 release with a verified runtime artifact.

## :hammer_and_wrench: Core Changes
- Use a dedicated tsc-alias configuration that maps server source aliases onto the flat tsup output layout.
- Fail the server build when compiled JavaScript still contains unresolved `~/` imports.

## :brain: Key Decisions
- Keep the TypeScript 7 type-check configuration unchanged and isolate the output-layout override to tsc-alias.
- Validate compiled imports during every server build so this failure cannot pass CI silently again.

## :test_tube: Verification Guide
### How to verify
1. Run `pnpm --parallel -r run --if-present lint` and `pnpm --parallel -r run --if-present type-check`.
2. Run `pnpm test:ci` and `pnpm build`.
3. Run `pnpm test:e2e`.

### Expected result
- All checks pass, the server build reports that its path alias check passed, and all eight E2E scenarios complete successfully.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)
- [x] Documentation change follows `docs/process/DOCUMENTATION_CONVENTION.md` (if applicable)