### PR TITLE
✅ Stabilize calendar navigation test

### DIFF
--- a/packages/client/src/components/view/ViewSectionCalendarRenderer.spec.tsx
+++ b/packages/client/src/components/view/ViewSectionCalendarRenderer.spec.tsx
@@ -43,6 +43,7 @@ const renderCalendar = (
     onNavigationStateChange = vi.fn(),
     section = createSection(),
     calendarDateProperty?: ComponentProps<typeof ViewSectionCalendarRenderer>['calendarDateProperty'],
+    navigationState: ViewSectionRouteState = { calendar: { year: 2026, month: 8 } },
 ) => {
     const { Wrapper } = createQueryClientWrapper();
 
@@ -50,7 +51,7 @@ const renderCalendar = (
         <ViewSectionCalendarRenderer
             section={section}
             calendarDateProperty={calendarDateProperty}
-            navigationState={{ calendar: { year: 2026, month: 8 } }}
+            navigationState={navigationState}
             onNavigationStateChange={onNavigationStateChange}
         />,
         { wrapper: Wrapper },
@@ -97,14 +98,19 @@ describe('<ViewSectionCalendarRenderer />', () => {
 
     it('stores month navigation in the owning section URL state', async () => {
         const user = userEvent.setup();
-        const { onNavigationStateChange } = renderCalendar();
+        const { onNavigationStateChange } = renderCalendar(vi.fn(), createSection(), undefined, {});
+        const nextMonth = new Date();
+        nextMonth.setDate(1);
+        nextMonth.setMonth(nextMonth.getMonth() + 1);
 
         await user.click(screen.getByRole('button', { name: 'Next month' }));
 
         const updater = onNavigationStateChange.mock.calls[0]?.[0] as (
             current: ViewSectionRouteState,
         ) => ViewSectionRouteState;
-        expect(updater({})).toEqual({ calendar: { year: 2026, month: 9 } });
+        expect(updater({})).toEqual({
+            calendar: { year: nextMonth.getFullYear(), month: nextMonth.getMonth() + 1 },
+        });
     });
 
     it('places date properties on their saved day without timezone shifting', async () => {


### PR DESCRIPTION
## :dart: Goal
- Keep calendar navigation tests deterministic across calendar months.
- Unblock repository validation for dependency maintenance PRs.

## :hammer_and_wrench: Core Changes
- Start the navigation assertion from the actual current month.
- Derive the expected next month dynamically, including year rollover.

## :brain: Key Decisions
- Preserve production behavior and change only the date-dependent test setup.
- Avoid freezing global timers so async query and user-event behavior remains realistic.

## :test_tube: Verification Guide
### How to verify
1. Run pnpm --filter @ocean-brain/client exec vitest run src/components/view/ViewSectionCalendarRenderer.spec.tsx
2. Run pnpm validate

### Expected result
- All calendar renderer tests and the full repository validation pass in any month.

## :white_check_mark: Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (not needed)
- [x] Documentation change follows docs/process/DOCUMENTATION_CONVENTION.md (not applicable)